### PR TITLE
RFC-0009: KDNA Artifact Contract (artifact envelope + stage definition)

### DIFF
--- a/specs/artifact-contract.md
+++ b/specs/artifact-contract.md
@@ -1,0 +1,473 @@
+# RFC-0009: KDNA Artifact Contract
+
+**Status:** Draft  
+**Proposed:** 2026-06-08  
+**Authors:** KDNA Maintainers  
+**Related:** KDNA SPEC v1.0-rc, kdna-workpack v0.1.0, KDNA Cluster SPEC §13
+
+---
+
+## Abstract
+
+KDNA v1.0-rc defines how domain judgment is encoded as loadable, verifiable assets. The WorkPack standard defines how KDNA, skills, gates, and risk policies are bundled into reusable atomic work capabilities. However, neither defines what comes out: the artifacts produced by KDNA-governed generation lack a standard envelope, identity, quality summary, trace linkage, and review lifecycle.
+
+This RFC proposes an **Artifact Contract** — a minimal standard envelope for any output produced through KDNA-governed generation. It also defines a **Stage Definition** contract for declaring multi-stage pipelines that compose sequential, parallel, and conditional artifact generation steps.
+
+The Artifact Contract is an **extension layer**, not a modification to KDNA Core. It builds on existing infrastructure: WorkPack's Session/Run/Trace/Report object model, Cluster's staged composition strategy, and the KDNA trace system.
+
+---
+
+## 1. Motivation
+
+### 1.1 What exists today
+
+KDNA's current output surface is unstructured:
+
+- `kdna load` emits formatted text/JSON for agent injection — no structured output
+- `kdna compare` emits a diff report — not a versioned artifact
+- WorkPack's `run_workpack_dry` emits `output` as a raw string and `output_path` as a file path — no artifact identity or integrity
+- The Judgment Trace records *what was loaded* but not *what was produced*
+
+When an agent or engine generates a course, a daily letter, or an assessment report, the output is a blob with no standard wrapper. Downstream consumers — fidelity measurement, human review, artifact storage, registry indexing, product delivery — cannot reliably identify, validate, or trace these outputs.
+
+### 1.2 What happens in practice
+
+In the xplan course-engine pipeline (13 stages, 12 artifact types), every stage produces structured outputs. But without a standard envelope:
+
+- Each artifact type invents its own identity and metadata format
+- Quality results are stored inconsistently
+- Upstream artifact lineage is implicit (encoded in file names or directory structure)
+- Human review status is ad-hoc
+- Fidelity measurement cannot link its report back to the artifact it measured
+
+### 1.3 What should exist
+
+A minimal, universal envelope that wraps any KDNA-governed artifact, carrying:
+
+| Concern | Field |
+|---------|-------|
+| Identity | `artifact_id`, `artifact_type`, `schema_version` |
+| Provenance | `created_at`, `generator` (engine + version + run_id) |
+| KDNA lineage | `source_kdna` (which judgment assets governed generation) |
+| Artifact lineage | `source_artifacts` (which upstream artifacts fed this one) |
+| Pipeline position | `stage` (optional, for multi-stage pipelines) |
+| Content integrity | `content` + `content_digest` |
+| Quality summary | `quality` (gate results + fidelity score) |
+| Trace linkage | `trace_refs` |
+| Review lifecycle | `review` (human review status) |
+
+---
+
+## 2. Design Principles
+
+### 2.1 Extension, not modification
+
+This RFC does not modify KDNA Core Spec, kdna-cli, kdna-core, or the .kdna container format. It defines a new layer that sits between KDNA loading and artifact consumption. Tools may adopt it incrementally.
+
+### 2.2 Envelope, not content
+
+The Artifact Contract standardizes the wrapper, not the payload. `artifact_type` and `content` are business-specific. The envelope ensures every business artifact carries the same identity, provenance, quality, trace, and review metadata — regardless of what the artifact *is*.
+
+### 2.3 Compatible with WorkPack
+
+The envelope's `quality`, `trace_refs`, and `stage` fields align with WorkPack's existing `review_gate_results`, `judgment_trace`, and `session` concepts. An Artifact can be the output of a WorkPack run or the output of a stage in a pipeline that orchestrates multiple WorkPacks.
+
+### 2.4 Traceable to KDNA judgment
+
+Every artifact declares exactly which KDNA domains governed its generation (`source_kdna`) and which trace records document the judgment process (`trace_refs`). This enables fidelity measurement: "did judgment X actually reach artifact Y?"
+
+### 2.5 Review-ready
+
+Human review is first-class: `review.status` tracks pending → approved → rejected → changes_requested. Combined with KDNA's Human Judgment Lock, this creates a complete governance chain: KDNA locked by human → artifact reviewed by human → fidelity verified by protocol.
+
+---
+
+## 3. Artifact Envelope
+
+### 3.1 Schema
+
+See `specs/artifact-envelope.schema.json`.
+
+**Required fields:** `artifact_id`, `artifact_type`, `schema_version`, `created_at`, `generator`, `source_kdna`, `content_digest`
+
+### 3.2 Minimal valid artifact
+
+```json
+{
+  "artifact_id": "d4e5f6a7-b8c9-4d0e-8f1a-2b3c4d5e6f7a",
+  "artifact_type": "pilot_lesson_package",
+  "schema_version": "1.0.0",
+  "created_at": "2026-06-08T10:30:00Z",
+  "generator": {
+    "engine": "course-engine",
+    "version": "0.3.0",
+    "run_id": "run_20260608_001"
+  },
+  "source_kdna": [
+    {
+      "name": "@aikdna/writing",
+      "version": "0.7.2",
+      "judgment_version": "2026.05",
+      "digest": "sha256:a1b2c3...",
+      "role": "primary"
+    }
+  ],
+  "content": {
+    "title": "Pilot Lesson: Introduction to Editorial Judgment",
+    "sections": ["..."]
+  },
+  "content_digest": "sha256:d4e5f6...",
+  "trace_refs": [
+    { "trace_id": "trace_abc123", "trace_type": "route" },
+    { "trace_id": "trace_def456", "trace_type": "generation" }
+  ]
+}
+```
+
+### 3.3 Full artifact with quality and review
+
+```json
+{
+  "artifact_id": "d4e5f6a7-b8c9-4d0e-8f1a-2b3c4d5e6f7a",
+  "artifact_type": "pilot_lesson_package",
+  "schema_version": "1.0.0",
+  "content_schema_version": "0.3.0",
+  "created_at": "2026-06-08T10:30:00Z",
+  "generator": {
+    "engine": "course-engine",
+    "version": "0.3.0",
+    "run_id": "run_20260608_001"
+  },
+  "source_kdna": [
+    {
+      "name": "@aikdna/writing",
+      "version": "0.7.2",
+      "judgment_version": "2026.05",
+      "digest": "sha256:a1b2c3...",
+      "role": "primary"
+    },
+    {
+      "name": "@aikdna/content_strategy",
+      "version": "0.5.0",
+      "judgment_version": "2026.04",
+      "digest": "sha256:d4e5f6...",
+      "role": "advisor"
+    }
+  ],
+  "source_artifacts": [
+    {
+      "artifact_id": "abc123-def456",
+      "artifact_type": "course_outline",
+      "content_digest": "sha256:789abc...",
+      "relationship": "input"
+    },
+    {
+      "artifact_id": "ghi789-jkl012",
+      "artifact_type": "course_experience_plan",
+      "content_digest": "sha256:def012...",
+      "relationship": "input"
+    }
+  ],
+  "stage": {
+    "stage_id": "build-pilot",
+    "stage_name": "Build Pilot Lesson Package",
+    "stage_order": 7,
+    "stage_attempt": 1,
+    "stage_status": "completed"
+  },
+  "content": { "title": "...", "sections": ["..."] },
+  "content_digest": "sha256:d4e5f6...",
+  "quality": {
+    "gate_results": [
+      { "gate_id": "schema_valid", "gate_type": "schema_validation", "result": "pass" },
+      { "gate_id": "axioms_applied", "gate_type": "kdna_compliance", "result": "pass", "score": 0.9 },
+      { "gate_id": "fidelity_check", "gate_type": "fidelity_check", "result": "pass", "score": 0.85 }
+    ],
+    "overall_result": "pass",
+    "fidelity": {
+      "score": 0.85,
+      "protocol_version": "1.0.0",
+      "report_artifact_id": "fidelity_report_001"
+    }
+  },
+  "trace_refs": [
+    { "trace_id": "trace_route_001", "trace_type": "route" },
+    { "trace_id": "trace_gen_001", "trace_type": "generation" },
+    { "trace_id": "trace_post_001", "trace_type": "postvalidate" },
+    { "trace_id": "trace_fidelity_001", "trace_type": "fidelity" }
+  ],
+  "review": {
+    "status": "pending"
+  },
+  "metadata": {
+    "tags": ["pilot", "writing-v0.7"],
+    "environment": "dev"
+  }
+}
+```
+
+---
+
+## 4. Stage Definition
+
+### 4.1 Schema
+
+See `specs/stage-definition.schema.json`.
+
+### 4.2 Example: Course Engine Pipeline
+
+A 13-stage course generation pipeline defined using Stage Definitions:
+
+```json
+[
+  {
+    "stage_id": "load-domain",
+    "stage_name": "Load KDNA Domain",
+    "stage_order": 1,
+    "produces_artifacts": [{ "artifact_type": "judgment_assets" }],
+    "loaded_kdna": [
+      { "name": "@aikdna/writing", "version": "^0.7.0", "role": "primary", "load_profile": "full" }
+    ]
+  },
+  {
+    "stage_id": "extract-judgments",
+    "stage_name": "Extract Judgment Assets",
+    "stage_order": 2,
+    "requires_inputs": [{ "ref_type": "artifact_type", "artifact_type": "judgment_assets" }],
+    "produces_artifacts": [{ "artifact_type": "extracted_judgments" }],
+    "depends_on": ["load-domain"]
+  },
+  {
+    "stage_id": "model-audience",
+    "stage_name": "Model Target Audience",
+    "stage_order": 3,
+    "requires_inputs": [
+      { "ref_type": "artifact_type", "artifact_type": "extracted_judgments" },
+      { "ref_type": "run_input" }
+    ],
+    "produces_artifacts": [{ "artifact_type": "audience_model" }],
+    "depends_on": ["extract-judgments"]
+  },
+  {
+    "stage_id": "model-product",
+    "stage_name": "Model Product Specification",
+    "stage_order": 4,
+    "requires_inputs": [
+      { "ref_type": "artifact_type", "artifact_type": "audience_model" }
+    ],
+    "produces_artifacts": [{ "artifact_type": "product_spec" }],
+    "depends_on": ["model-audience"]
+  },
+  {
+    "stage_id": "build-outline",
+    "stage_name": "Build Course Outline",
+    "stage_order": 5,
+    "produces_artifacts": [{ "artifact_type": "course_outline" }],
+    "quality_gates": [
+      { "gate_id": "outline_structure", "gate_type": "schema_validation", "blocking": true }
+    ],
+    "depends_on": ["model-product"]
+  },
+  {
+    "stage_id": "build-experience-plan",
+    "stage_name": "Build Course Experience Plan",
+    "stage_order": 6,
+    "produces_artifacts": [{ "artifact_type": "course_experience_plan" }],
+    "depends_on": ["model-product"]
+  },
+  {
+    "stage_id": "build-pilot",
+    "stage_name": "Build Pilot Lesson Package",
+    "stage_order": 7,
+    "produces_artifacts": [{ "artifact_type": "pilot_lesson_package", "is_final": true }],
+    "quality_gates": [
+      { "gate_id": "pilot_schema", "gate_type": "schema_validation", "blocking": true },
+      {
+        "gate_id": "pilot_fidelity",
+        "gate_type": "fidelity_check",
+        "blocking": false,
+        "config": { "protocol_version": "1.0.0", "min_score": 0.7 }
+      }
+    ],
+    "depends_on": ["build-outline", "build-experience-plan"]
+  },
+  {
+    "stage_id": "build-sales",
+    "stage_name": "Build Sales Page Brief",
+    "stage_order": 7,
+    "produces_artifacts": [{ "artifact_type": "sales_page_brief", "is_final": true }],
+    "depends_on": ["build-outline"],
+    "parallel_with": ["build-pilot"]
+  },
+  {
+    "stage_id": "assemble",
+    "stage_name": "Assemble Course Package",
+    "stage_order": 8,
+    "requires_inputs": [
+      { "ref_type": "artifact_type", "artifact_type": "pilot_lesson_package" },
+      { "ref_type": "artifact_type", "artifact_type": "sales_page_brief", "required": false }
+    ],
+    "produces_artifacts": [{ "artifact_type": "course_package", "is_final": true }],
+    "depends_on": ["build-pilot", "build-sales"],
+    "human_review_required": true
+  },
+  {
+    "stage_id": "evaluate-quality",
+    "stage_name": "Evaluate Quality (LLM Critique)",
+    "stage_order": 9,
+    "produces_artifacts": [{ "artifact_type": "quality_report" }],
+    "depends_on": ["assemble"]
+  },
+  {
+    "stage_id": "evaluate-fidelity",
+    "stage_name": "Evaluate Fidelity (Assay Audit)",
+    "stage_order": 10,
+    "produces_artifacts": [{ "artifact_type": "fidelity_report" }],
+    "depends_on": ["assemble"],
+    "parallel_with": ["evaluate-quality"]
+  },
+  {
+    "stage_id": "finalize",
+    "stage_name": "Finalize Course Package",
+    "stage_order": 11,
+    "produces_artifacts": [{ "artifact_type": "course_package_final", "is_final": true }],
+    "quality_gates": [
+      { "gate_id": "human_approved", "gate_type": "human_review", "blocking": true }
+    ],
+    "depends_on": ["evaluate-quality", "evaluate-fidelity"]
+  },
+  {
+    "stage_id": "generate-report",
+    "stage_name": "Generate Run Report",
+    "stage_order": 12,
+    "produces_artifacts": [{ "artifact_type": "run_report" }],
+    "depends_on": ["finalize"]
+  }
+]
+```
+
+### 4.3 Key concepts
+
+**Stage dependencies** (`depends_on`, `parallel_with`): Explicit stage ordering. `parallel_with` declares stages that can run concurrently. The pipeline runner computes the execution DAG from these declarations.
+
+**Artifact lineage** (`requires_inputs`, `produces_artifacts`): Each stage declares what artifact types it consumes and produces. The runner passes artifacts between stages automatically — a stage that requires `artifact_type: course_outline` receives the latest artifact of that type from any upstream stage.
+
+**Quality gates per stage** (`quality_gates`): Each stage declares its own quality requirements. Gates can be `blocking` (fail blocks the pipeline) or advisory. Gate types include `schema_validation`, `kdna_compliance`, `fidelity_check`, `human_review`, `llm_critique`, and `eval_benchmark`.
+
+**KDNA per stage** (`loaded_kdna`): Each stage can load specific KDNA domains with specific roles and load profiles. A stage that doesn't declare KDNA inherits from the pipeline-level configuration.
+
+**Retry policy** (`retry_policy`): Configurable retry behavior per stage: max attempts, backoff strategy, and what happens on final failure.
+
+**Human review gates** (`human_review_required`): A stage can require human approval before its output flows to downstream stages.
+
+---
+
+## 5. Relationship to Existing KDNA Infrastructure
+
+### 5.1 WorkPack (kdna-workpack)
+
+WorkPack defines atomic work capabilities: `KDNA + Skills + Gates + Risk + Trace → Output`. A single WorkPack invocation produces a WorkPackSession, RunResult, WorkPackTrace, and WorkPackReport.
+
+The Artifact Contract extends this model:
+
+| WorkPack Concept | Artifact Contract Equivalent |
+|-----------------|------------------------------|
+| `workpack.json` manifest | Pipeline manifest (stage definitions + KDNA config) |
+| `WorkPackSession` | Pipeline Run (a sequence of stages) |
+| `WorkPackRun.review_gate_results` | `artifact.quality.gate_results` |
+| `WorkPackRun.output` (string) | `artifact.content` (typed, schema-validated) |
+| `WorkPackRun.output_path` (string) | `artifact.content_digest` (content-addressed) |
+| WorkPackTrace | `artifact.trace_refs` |
+| WorkPackReport | Run Report (aggregates all stage artifacts + quality summaries) |
+
+The Artifact Contract does not replace WorkPack. It wraps WorkPack outputs (and any other KDNA-governed output) in a standard envelope.
+
+### 5.2 KDNA Cluster — Staged Composition
+
+KDNA Cluster SPEC §13.2 defines `staged` composition: "Domains load in ordered phases (e.g., analysis → risk review → expression)." The Stage Definition makes this concrete: each stage in a pipeline declares which KDNA domains it loads, with what roles, and what artifacts it produces.
+
+The existing `classifySignalsAcrossDomains` (signal-based, the only implemented strategy) handles per-stage domain selection. The Stage Definition adds ordering, dependency, quality gate, and artifact flow semantics on top.
+
+### 5.3 KDNA Trace System
+
+The KDNA trace system records route decisions, loaded domains, triggered axioms, and self-check results. The Artifact Contract links artifacts back to their traces via `trace_refs`. This enables:
+
+- "Show me all traces that led to this artifact"
+- "Show me all artifacts produced under this KDNA domain"
+- "Did the fidelity report reference the correct generation trace?"
+
+### 5.4 App Runtime Contract
+
+The App Runtime Contract defines: `KDNA Asset → Route Result → Judgment Trace → Judgment Report`. The Artifact Contract adds: `Stage Definition → Artifact Envelope → Quality Summary → Fidelity Report → Human Review`.
+
+---
+
+## 6. Non-Goals
+
+- **Not a workflow engine.** This RFC defines the contract (data shapes and semantics), not the runner. Implementations are free to build their own pipeline executors.
+- **Not a KDNA Core modification.** No changes to SPEC.md, kdna.json manifest, or .kdna container format.
+- **Not a WorkPack replacement.** WorkPack remains the atomic work capability standard. The Artifact Contract wraps its outputs.
+- **Not a product-specific schema registry.** Business artifact schemas (course_package, daily_letter, etc.) are defined by their respective engines. Only the envelope is standardized here.
+
+---
+
+## 7. Implementation Path
+
+### Phase 2a: Schema publication
+- Merge `artifact-envelope.schema.json` and `stage-definition.schema.json` into kdna spec
+- Add reference from kdna-workpack docs
+
+### Phase 2b: xplan adoption
+- Wrap all 12 course-engine artifact types in ArtifactEnvelope
+- Convert course-engine 13-stage config to StageDefinition array
+- Run a full pipeline with envelope-wrapped artifacts and verify trace linkage
+
+### Phase 2c: WorkPack integration
+- Extend `WorkPackRun` to optionally wrap output as ArtifactEnvelope
+- Add `--wrap-artifact` flag to `kdna workpack run`
+
+### Phase 2d: Fidelity Protocol integration (RFC-0010)
+- Fidelity Report becomes an Artifact itself (`artifact_type: fidelity_report`)
+- Links to measured artifact via `source_artifacts[].relationship: evaluation_target`
+
+---
+
+## 8. Questions for Review
+
+1. Should `artifact_id` be a content-hash URN (deterministic from content) or a random UUID (stable across reprocessing)? Content-hash enables deduplication; UUID enables stable references across revisions. Recommendation: UUID with `content_digest` as the dedup key.
+
+2. Should the Stage Definition include a `timeout` field? Currently only retry policy is defined. Timeout could be added as a stage-level constraint.
+
+3. Should `source_kdna[].role` use the same 5-role enum as Cluster SPEC §13.3 (`primary`, `advisor`, `risk_guard`, `style_and_trust`, `evaluator`) or the simpler 3-role enum from WorkPack (`primary`, `constraint`, `fallback`)? Recommendation: use the 6-role Cluster enum for richer semantics.
+
+4. Where should business-specific artifact schemas live? In their engine repositories (xplan, daily-letter-engine), in a shared artifact-schema registry, or linked from the Artifact Contract spec? Recommendation: engine repositories first, aggregated registry later.
+
+---
+
+## Appendix A: Artifact Types (Reference, Non-Normative)
+
+These are examples of artifact types that engines may produce. The list is not exhaustive and not part of the standard.
+
+| Artifact Type | Engine | Is Final |
+|---------------|--------|----------|
+| `judgment_assets` | course-engine | No |
+| `audience_model` | course-engine | No |
+| `product_spec` | course-engine | No |
+| `course_outline` | course-engine | No |
+| `course_experience_plan` | course-engine | No |
+| `pilot_lesson_package` | course-engine | Yes |
+| `sales_page_brief` | course-engine | Yes |
+| `course_package` | course-engine | Yes |
+| `quality_report` | course-engine | No |
+| `fidelity_report` | fidelity-engine | Yes |
+| `run_report` | any engine | Yes |
+| `daily_letter` | daily-letter-engine | Yes |
+| `micro_practice` | daily-letter-engine | Yes |
+| `coaching_observation` | coaching-runtime | No |
+
+---
+
+## Appendix B: Schema Files
+
+- `specs/artifact-envelope.schema.json` — Artifact Envelope schema
+- `specs/stage-definition.schema.json` — Stage Definition schema

--- a/specs/artifact-envelope.schema.json
+++ b/specs/artifact-envelope.schema.json
@@ -1,0 +1,220 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aikdna.com/schemas/artifact-envelope.schema.json",
+  "title": "KDNA Artifact Envelope",
+  "description": "Standard envelope for any artifact produced from KDNA-governed generation. Universally references the KDNA assets, upstream artifacts, trace records, quality results, and human review status associated with a single generated artifact. Business-specific content is carried in the content field under its own schema.",
+  "type": "object",
+  "required": [
+    "artifact_id",
+    "artifact_type",
+    "schema_version",
+    "created_at",
+    "generator",
+    "source_kdna",
+    "content_digest"
+  ],
+  "properties": {
+    "artifact_id": {
+      "type": "string",
+      "description": "Unique artifact identifier (UUID v4 or content-hash URN). Stable across reprocessing — the same logical artifact retains the same ID."
+    },
+    "artifact_type": {
+      "type": "string",
+      "description": "Business-level artifact type. Examples: course_package, pilot_lesson, daily_letter, assessment_report, consulting_offer. Type-specific validation uses this field to select the appropriate content schema."
+    },
+    "schema_version": {
+      "type": "string",
+      "description": "Semver of the artifact envelope schema this artifact conforms to."
+    },
+    "content_schema_version": {
+      "type": "string",
+      "description": "Semver of the business-specific content schema (e.g. the course-package schema version). Different from schema_version which tracks the envelope itself."
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 UTC timestamp when this artifact version was generated."
+    },
+    "generator": {
+      "type": "object",
+      "description": "Provenance: which engine and version produced this artifact.",
+      "required": ["engine", "version"],
+      "properties": {
+        "engine": {
+          "type": "string",
+          "description": "Engine identifier. Examples: course-engine, daily-letter-engine, report-engine."
+        },
+        "version": {
+          "type": "string",
+          "description": "Semver of the engine that generated this artifact."
+        },
+        "run_id": {
+          "type": "string",
+          "description": "ID of the pipeline run that produced this artifact. Links to ArtifactRun."
+        }
+      }
+    },
+    "source_kdna": {
+      "type": "array",
+      "description": "KDNA domains loaded during generation. Records which judgment assets governed this artifact's creation.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["name", "version", "role"],
+        "properties": {
+          "name": { "type": "string", "description": "Fully qualified domain name (@scope/name)." },
+          "version": { "type": "string", "description": "Domain version at generation time." },
+          "judgment_version": { "type": "string", "description": "Domain judgment_version from kdna.json manifest." },
+          "digest": { "type": "string", "description": "Asset digest of the .kdna file loaded (sha256:hex)." },
+          "role": {
+            "type": "string",
+            "enum": ["primary", "advisor", "constraint", "risk_guard", "evaluator", "style_and_trust"],
+            "description": "Role this domain played in the generation stage."
+          }
+        }
+      }
+    },
+    "source_artifacts": {
+      "type": "array",
+      "description": "Upstream artifacts that served as input to this artifact. Empty for initial stages that consume raw inputs.",
+      "items": {
+        "type": "object",
+        "required": ["artifact_id", "artifact_type"],
+        "properties": {
+          "artifact_id": { "type": "string" },
+          "artifact_type": { "type": "string" },
+          "content_digest": { "type": "string" },
+          "relationship": {
+            "type": "string",
+            "enum": ["input", "template", "reference", "evaluation_target"],
+            "description": "How this upstream artifact was used in generating the current artifact."
+          }
+        }
+      }
+    },
+    "stage": {
+      "type": "object",
+      "description": "Which pipeline stage produced this artifact. Present when the generation occurred within a multi-stage pipeline; omitted for single-step generation.",
+      "required": ["stage_id", "stage_order"],
+      "properties": {
+        "stage_id": { "type": "string" },
+        "stage_name": { "type": "string" },
+        "stage_order": { "type": "integer", "minimum": 1 },
+        "stage_attempt": { "type": "integer", "minimum": 1, "description": "Which attempt of this stage produced this version (1-based)." },
+        "stage_status": {
+          "type": "string",
+          "enum": ["running", "completed", "failed", "skipped"],
+          "description": "Status of this stage when the artifact was recorded."
+        }
+      }
+    },
+    "content": {
+      "type": "object",
+      "description": "Business-specific artifact content. Must conform to the schema identified by artifact_type and content_schema_version. This field carries the actual work product — course package, daily letter, assessment report, etc."
+    },
+    "content_digest": {
+      "type": "string",
+      "description": "SHA-256 digest of the canonical JSON serialization of content. Used for integrity verification and deduplication across reprocessing."
+    },
+    "quality": {
+      "type": "object",
+      "description": "Quality gate results and fidelity measurement for this artifact.",
+      "properties": {
+        "gate_results": {
+          "type": "array",
+          "description": "Results from each quality gate applied to this artifact.",
+          "items": {
+            "type": "object",
+            "required": ["gate_id", "result"],
+            "properties": {
+              "gate_id": { "type": "string" },
+              "gate_type": { "type": "string", "description": "schema_validation, kdna_compliance, fidelity_check, human_review, llm_critique" },
+              "result": { "type": "string", "enum": ["pass", "fail", "warn", "skipped"] },
+              "score": { "type": "number" },
+              "evidence": { "type": "string" }
+            }
+          }
+        },
+        "overall_result": {
+          "type": "string",
+          "enum": ["pass", "fail", "conditional_pass"],
+          "description": "Composed result across all quality gates."
+        },
+        "fidelity": {
+          "type": "object",
+          "description": "Judgment transfer fidelity measurement. Computed by the Fidelity Protocol when enabled.",
+          "required": ["score", "protocol_version"],
+          "properties": {
+            "score": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1,
+              "description": "Overall fidelity score. 0 = no judgment transferred, 1 = complete judgment transfer."
+            },
+            "protocol_version": {
+              "type": "string",
+              "description": "Version of the Fidelity Protocol used for measurement."
+            },
+            "report_artifact_id": {
+              "type": "string",
+              "description": "Artifact ID of the full Fidelity Report, if generated as a separate artifact."
+            }
+          }
+        }
+      }
+    },
+    "trace_refs": {
+      "type": "array",
+      "description": "Judgment trace identifiers produced during this artifact's generation. Links to the KDNA trace system.",
+      "items": {
+        "type": "object",
+        "required": ["trace_id"],
+        "properties": {
+          "trace_id": { "type": "string" },
+          "trace_type": {
+            "type": "string",
+            "enum": ["route", "load", "generation", "postvalidate", "fidelity"],
+            "description": "Which phase of the pipeline produced this trace."
+          }
+        }
+      }
+    },
+    "review": {
+      "type": "object",
+      "description": "Human review status. Null before review; populated after a human reviews and approves/rejects.",
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["pending", "approved", "rejected", "changes_requested"],
+          "description": "Current human review status."
+        },
+        "reviewed_by": {
+          "type": "string",
+          "description": "Identity of the reviewer."
+        },
+        "reviewed_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "review_notes": {
+          "type": "string",
+          "description": "Reviewer's notes or rationale for the decision."
+        }
+      }
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Extensible metadata. Implementations may add namespaced fields.",
+      "properties": {
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "environment": {
+          "type": "string",
+          "enum": ["dev", "staging", "production"]
+        }
+      }
+    }
+  }
+}

--- a/specs/stage-definition.schema.json
+++ b/specs/stage-definition.schema.json
@@ -1,0 +1,173 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aikdna.com/schemas/stage-definition.schema.json",
+  "title": "KDNA Stage Definition",
+  "description": "Declares a single stage in a multi-stage KDNA artifact pipeline. Each stage defines its inputs (which KDNA assets to load, which upstream artifacts to consume), the artifact types it produces, quality gates that must pass, and dependencies on other stages.",
+  "type": "object",
+  "required": ["stage_id", "stage_name", "stage_order", "produces_artifacts"],
+  "properties": {
+    "stage_id": {
+      "type": "string",
+      "description": "Unique machine-readable identifier for this stage within the pipeline."
+    },
+    "stage_name": {
+      "type": "string",
+      "description": "Human-readable stage name for reports and traces."
+    },
+    "stage_order": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Sequential position in the pipeline. Determines default execution order when no explicit dependency constraints restrict ordering."
+    },
+    "description": {
+      "type": "string",
+      "description": "What this stage does, in one sentence."
+    },
+    "requires_inputs": {
+      "type": "array",
+      "description": "Artifact types or artifact IDs that must be available before this stage can execute.",
+      "items": {
+        "type": "object",
+        "required": ["ref_type"],
+        "properties": {
+          "ref_type": {
+            "type": "string",
+            "enum": ["artifact_type", "artifact_id", "run_input"],
+            "description": "artifact_type = any artifact of this type from a previous stage. artifact_id = a specific upstream artifact. run_input = the original pipeline input."
+          },
+          "artifact_type": {
+            "type": "string",
+            "description": "Required when ref_type is artifact_type. The business artifact type that must exist."
+          },
+          "artifact_id": {
+            "type": "string",
+            "description": "Required when ref_type is artifact_id."
+          },
+          "stage_id": {
+            "type": "string",
+            "description": "Optional constraint: only accept artifacts produced by a specific stage."
+          },
+          "required": {
+            "type": "boolean",
+            "default": true,
+            "description": "Whether the stage must block (hard dependency) or warn (soft dependency) if this input is missing."
+          }
+        }
+      }
+    },
+    "produces_artifacts": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Artifact types this stage produces. A stage may produce multiple artifacts (e.g. a parallel compilation stage that emits both pilot_lesson and sales_brief).",
+      "items": {
+        "type": "object",
+        "required": ["artifact_type"],
+        "properties": {
+          "artifact_type": {
+            "type": "string",
+            "description": "Business artifact type identifier."
+          },
+          "content_schema": {
+            "type": "string",
+            "description": "Optional URI or file path to the JSON Schema for this artifact's content field."
+          },
+          "is_final": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether this artifact type represents a final deliverable (vs. an intermediate stage output). Final artifacts trigger the finalize stage."
+          }
+        }
+      }
+    },
+    "loaded_kdna": {
+      "type": "array",
+      "description": "KDNA domains this stage loads for judgment governance. If empty, inherits from the pipeline-level KDNA configuration.",
+      "items": {
+        "type": "object",
+        "required": ["name", "role"],
+        "properties": {
+          "name": { "type": "string", "description": "Domain name (@scope/name)." },
+          "version": { "type": "string", "description": "Acceptable version range (semver)." },
+          "role": {
+            "type": "string",
+            "enum": ["primary", "advisor", "constraint", "risk_guard", "evaluator", "style_and_trust"]
+          },
+          "load_profile": {
+            "type": "string",
+            "enum": ["index", "compact", "scenario", "full"],
+            "description": "How deeply to load this domain. Inherits from pipeline default if omitted."
+          }
+        }
+      }
+    },
+    "quality_gates": {
+      "type": "array",
+      "description": "Quality checks applied to this stage's output artifacts before they can flow to downstream stages.",
+      "items": {
+        "type": "object",
+        "required": ["gate_id", "gate_type"],
+        "properties": {
+          "gate_id": { "type": "string" },
+          "gate_type": {
+            "type": "string",
+            "enum": [
+              "schema_validation",
+              "kdna_compliance",
+              "fidelity_check",
+              "human_review",
+              "llm_critique",
+              "eval_benchmark",
+              "custom"
+            ]
+          },
+          "blocking": {
+            "type": "boolean",
+            "default": true,
+            "description": "Whether a fail result blocks the pipeline or only generates a warning."
+          },
+          "config": {
+            "type": "object",
+            "description": "Gate-type-specific configuration. E.g. for fidelity_check: { protocol_version, min_score }. For schema_validation: { schema_path }."
+          }
+        }
+      }
+    },
+    "depends_on": {
+      "type": "array",
+      "description": "Stage IDs that must complete successfully before this stage can start. Expresses sequential constraints beyond stage_order.",
+      "items": { "type": "string" }
+    },
+    "parallel_with": {
+      "type": "array",
+      "description": "Stage IDs that may execute concurrently with this stage. All stages in a parallel group start when their shared dependencies complete.",
+      "items": { "type": "string" }
+    },
+    "retry_policy": {
+      "type": "object",
+      "description": "What happens when this stage fails.",
+      "properties": {
+        "max_attempts": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 1,
+          "description": "Maximum execution attempts before marking the stage as failed."
+        },
+        "backoff": {
+          "type": "string",
+          "enum": ["none", "linear", "exponential"],
+          "default": "none"
+        },
+        "on_final_failure": {
+          "type": "string",
+          "enum": ["block_pipeline", "skip_stage", "use_fallback_artifact"],
+          "description": "What happens when all retries are exhausted."
+        }
+      }
+    },
+    "human_review_required": {
+      "type": "boolean",
+      "default": false,
+      "description": "Whether this stage's output must be reviewed by a human before downstream stages can consume it."
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This RFC proposes a standard **Artifact Contract** for any output produced through KDNA-governed generation, plus a **Stage Definition** contract for multi-stage pipeline declaration.

## Motivation

KDNA defines how judgment is encoded. WorkPack defines how KDNA+skills+gates are bundled. But neither defines what comes out — KDNA-governed artifacts lack a standard envelope for identity, provenance, quality, trace linkage, and review lifecycle.

## What's included

- **artifact-envelope.schema.json** — universal wrapper for KDNA-governed artifacts
- **stage-definition.schema.json** — pipeline stage declaration (inputs, outputs, KDNA loading, quality gates, dependencies, parallel execution, retry policy)
- **artifact-contract.md** — RFC document with motivation, design principles, full examples, integration with WorkPack/Cluster/Trace systems

## Design principles

- Extension layer, not KDNA Core modification
- Envelope standardizes the wrapper, not the business content
- Compatible with WorkPack Session/Run/Trace/Report model
- Aligns with Cluster staged composition strategy
- Every artifact traceable back to its KDNA judgment and generation trace

## Related

- KDNA SPEC v1.0-rc
- kdna-workpack v0.1.0
- KDNA Cluster SPEC §13 (staged composition)
- KDNA Trace System