### PR TITLE
fix: add human-lock inline format doc, sunset policy, dev source gap transparency

### DIFF
--- a/docs/DEV_SOURCE_VS_STUDIO.md
+++ b/docs/DEV_SOURCE_VS_STUDIO.md
@@ -1,0 +1,45 @@
+# Dev Source vs Studio Project: Current State
+
+> **Status:** v1.0-rc transparency note  
+> **Updated:** 2026-06-11
+
+## The Gap
+
+KDNA defines two authoring formats:
+
+| Format | SPEC Status | Actual Usage | Trust Level |
+|--------|------------|-------------|-------------|
+| **Dev Source Directory** | Non-canonical (SPEC §1 line 19) | **12+ open-source domain repos** use this as their sole format | Dev-only, non-trusted |
+| **Studio Project** (`studio.project.json`) | Canonical authoring workspace (SPEC §15) | **0 instances** in the open-source ecosystem | Required for trusted assets |
+
+## Why This Gap Exists
+
+The Studio project format was introduced in v1.0-rc as the canonical authoring workspace. At the time of writing:
+
+1. **`kdna-studio-cli` (v0.2.0)** is the only tool that creates Studio projects
+2. **All 12+ open-source domain repos** were authored before Studio existed and use dev source directories
+3. **No migration tool** exists to convert dev source → Studio project while preserving all content (only axioms are currently imported via `--from-folder`)
+
+## What This Means for Contributors
+
+### Contributing to existing domains
+The primary authoring format for open-source domains is still the dev source directory. Contributors should:
+- Edit `KDNA_Core.json`, `KDNA_Patterns.json`, etc. directly
+- Validate with `kdna dev validate .`
+- The maintainer handles Studio compilation for trusted releases
+
+### Creating new domains
+- **Prototype/experiment**: `kdna dev scaffold <name>` → edit JSON files
+- **Trusted release**: `kdna-studio create <name>` → card add → lock → compile → export
+
+## Roadmap
+
+1. **Short-term**: Fix `kdna-studio create --from-folder` to fully import all content (not just axioms)
+2. **Medium-term**: Provide a `kdna-studio migrate <dev-source-dir>` command for seamless conversion
+3. **Long-term**: Transition all domain repos to Studio project format as primary source
+
+## Honesty Note
+
+We acknowledge that the canonical authoring path (Studio) currently has zero adoption in the open-source domain ecosystem. This document exists to prevent the confusion that arises when users read the SPEC saying "use Studio" but find no Studio projects anywhere in the ecosystem.
+
+The dev source directory format remains the practical authoring format for open-source domain contributors until the Studio migration path is seamless.

--- a/docs/KDNA_CARD_SPEC.md
+++ b/docs/KDNA_CARD_SPEC.md
@@ -45,8 +45,8 @@ The KDNA Card serves the same role as a model card in machine learning: it helps
   "review_status": "community",
   "requires_expert_review": false,
   "provenance": {
-    "studio_core": "aikdna/kdna-studio",
-    "studio_core_version": "0.6.0",
+    "studio_core": "aikdna/kdna-studio-core",
+    "studio_core_version": "1.4.2",
     "build_id": "build_xxx",
     "content_fingerprint": "sha256:xxx",
     "built_at": "2026-05-23T10:00:00Z"

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability in KDNA tooling (kdna-cli, kdna-core, kdna-studio, kdna-registry, kdna-website, or kdna-vscode), please report it privately.
+If you discover a security vulnerability in KDNA tooling (kdna-cli, kdna-core, kdna-studio-cli, kdna-studio-core, kdna-registry, kdna-website, or kdna-vscode), please report it privately.
 
 **Do not open a public issue.**
 

--- a/docs/SUNSET_POLICY.md
+++ b/docs/SUNSET_POLICY.md
@@ -1,0 +1,51 @@
+# Deprecation & Sunset Policy
+
+> **Status:** v1.0-rc  
+> **Effective:** 2026-06-11
+
+KDNA's deprecation policy ensures that users are never caught between a documented feature and its removal.
+
+## Policy
+
+1. **Deprecation notice** — A feature marked deprecated MUST have a documented sunset date. Without a date, the deprecation is advisory only and the feature remains supported.
+
+2. **Grace period** — Deprecated features remain available for at least one minor version after the deprecation notice. Breaking removal without a grace period is a spec violation.
+
+3. **Removal** — On or after the sunset date, the feature MAY be removed. Removal MUST be noted in the CHANGELOG with migration instructions.
+
+## Current Deprecated Items
+
+| Item | Status | Deprecated | Sunset | Replacement |
+|------|--------|-----------|--------|-------------|
+| `kdna init <name>` | Deprecated | 2026-05-25 | 2026-07-01 | `kdna-studio create` (trusted) or `kdna dev scaffold` (dev-only) |
+| `kdna dev pack` | **Beta** (not deprecated) | — | — | `kdna-studio compile/export` for trusted assets |
+| `kdna_spec` field | Rejected | 2026-05-20 | Enforced now | Use `spec_version` |
+| singular `language` field | Rejected | 2026-05-20 | Enforced now | Use `languages` array |
+| Merged single-file JSON | Rejected | 2026-05-20 | Enforced now | ZIP container format |
+| Dev source directories (as runtime) | Non-canonical | 2026-05-27 | Enforced now | `.kdna` assets in `~/.kdna/packages/` |
+| `~/.kdna/domains/` | Legacy | 2026-05-27 | 2026-08-01 | `~/.kdna/packages/` |
+| `basic` / `pro` / `reference` badges | Retired | 2026-05-20 | Enforced now | `untested` / `tested` / `validated` / `expert_reviewed` / `production_ready` |
+
+## Un-deprecated Items
+
+| Item | Previous Status | Current Status | Reason |
+|------|----------------|----------------|--------|
+| `kdna dev pack` | Marked "Deprecated" in error | Beta | Actively maintained (last update v0.19.2, 2026-05-29). Serves a real need for dev-to-asset conversion without Studio. The README "Deprecated" label was a copy-paste error — never reflected in code or CHANGELOG. |
+
+## Enforcement
+
+The `kdna dev validate` command warns about:
+- Rejected fields (`kdna_spec`, singular `language`)
+- Retired badge names (`basic`, `pro`, `reference`)
+
+The `kdna verify` command rejects `.kdna` assets with:
+- Rejected fields
+- Rejected format (merged single-file JSON)
+- Stale spec versions (pre-v1.0-rc without explicit migration flag)
+
+## For Contributors
+
+When adding a deprecation:
+1. Add an entry to this document with a sunset date at least one minor version away
+2. Add a warning to the deprecated feature's help text
+3. Document the migration path in the deprecation message

--- a/specs/human-lock.md
+++ b/specs/human-lock.md
@@ -80,6 +80,10 @@ The following should be recorded automatically but treated as evidence, not appr
 
 ## Human Judgment Lock Record Format
 
+There are two lock formats in use. The protocol-level format records locks in `KDNA_Evolution.json`. The inline format is used in `kdna.json` for dev-pack and compile-time validation.
+
+### Protocol Format (KDNA_Evolution.json)
+
 A Human Judgment Lock is recorded in `KDNA_Evolution.json` under the `human_locks` array:
 
 ```json
@@ -108,6 +112,36 @@ A Human Judgment Lock is recorded in `KDNA_Evolution.json` under the `human_lock
 | `lock_type` | Yes | `accept`, `reject`, or `defer`. |
 | `reason` | Yes | Human-readable rationale. Must be non-empty. |
 | `affected_files` | No | Array of KDNA files affected by the locked change. |
+
+### Inline Format (kdna.json, dev-pack compatible)
+
+The `kdna dev pack` CLI and Studio-compatible compilers use a simpler inline format embedded in `kdna.json` under the `human_lock` key (singular, not plural). This is the format users encounter when hand-editing domain metadata:
+
+```json
+{
+  "human_lock": {
+    "status": "locked",
+    "by": "human-identifier",
+    "statement": "Human-readable confirmation of what was reviewed and approved.",
+    "checked": {
+      "applies_when": true,
+      "does_not_apply_when": true,
+      "failure_risk": true
+    }
+  }
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `status` | Yes | Must be `"locked"`. |
+| `by` | Yes | Identity of the human who applied the lock. |
+| `statement` | Yes | Human-readable confirmation of what was reviewed. |
+| `checked.applies_when` | Yes | Boolean — confirmed all `applies_when` conditions correct. |
+| `checked.does_not_apply_when` | Yes | Boolean — confirmed all `does_not_apply_when` conditions correct. |
+| `checked.failure_risk` | Yes | Boolean — confirmed all `failure_risk` entries correct. |
+
+This inline format is what the `kdna dev pack` command checks for before accepting a domain. The protocol-level format in `KDNA_Evolution.json` is the long-term record; the inline format is the build-time gate.
 
 ---
 


### PR DESCRIPTION
## Summary

Documents that were missing from the protocol spec, causing users and agents to encounter undocumented behavior.

### specs/human-lock.md: Add inline format
The protocol format (KDNA_Evolution.json human_locks array) was documented, but the inline format used by kdna dev pack and Studio compilers (kdna.json human_lock object) was not. Users hit format mismatches and had to reverse-engineer from source code.

Added:
- Inline format schema (status, by, statement, checked.{applies_when,does_not_apply_when,failure_risk})
- Field-by-field documentation
- Clear distinction between protocol format (long-term record) and inline format (build-time gate)

### docs/SUNSET_POLICY.md (new)
- Formal deprecation lifecycle: notice → grace period → removal
- Complete table of all deprecated items with sunset dates
- kdna dev pack un-deprecation documented (was mislabeled)
- Enforcement rules for validators

### docs/DEV_SOURCE_VS_STUDIO.md (new)
- Transparency: Studio project has zero adoption in open-source ecosystem
- Dev source remains practical authoring format for domain contributors
- Gap closure roadmap

Related: aikdna/kdna-studio-cli#4, aikdna/kdna-cli#3