### PR TITLE
fix: remove all deferred language, stale versions, dead links — final sweep

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -918,7 +918,7 @@ Persistent extraction MUST NOT be required for loading. A runtime MAY create int
 | `kdna load @aikdna/writing` | Load the installed `.kdna` asset directly into agent context |
 | `kdna load writing.kdna` | Load a local `.kdna` asset directly into agent context |
 | `kdna compare writing.kdna --input "..."` | Compare with/without a local `.kdna` asset |
-| `kdna dev pack ./writing-source` | [DEPRECATED] Build a dev-only, non-trusted diagnostic bundle from a non-canonical source directory. Use `kdna-studio compile/export` for trusted assets. |
+| `kdna dev pack ./writing-source` | Build a dev-only non-trusted diagnostic bundle from a non-canonical source directory. For trusted assets, use `kdna-studio migrate`. |
 | `kdna dev unpack writing.kdna` | Unpack into a dev source directory for inspection or editing |
 
 ### 14.9 Platform Recognition
@@ -1090,5 +1090,5 @@ A conforming validator MUST verify:
 - [Semantic Versioning](https://semver.org/) — Version numbering
 - [SPDX License List](https://spdx.org/licenses/) — License identifiers
 - JSON Schema files: `schema/KDNA_*.schema.json`
-- CLI tools: `kdna dev validate`, `kdna dev pack` (deprecated, use `kdna-studio`), `kdna compare`
+- CLI tools: `kdna dev validate`, `kdna dev pack`, `kdna compare`, `kdna-studio migrate`
 - Registry: `registry/domains.json`

--- a/docs/DEV_SOURCE_VS_STUDIO.md
+++ b/docs/DEV_SOURCE_VS_STUDIO.md
@@ -51,4 +51,4 @@ No separate create/approve/lock/compile/export steps needed.
 
 We acknowledge that the canonical authoring path (Studio) currently has zero adoption in the open-source domain ecosystem. This document exists to prevent the confusion that arises when users read the SPEC saying "use Studio" but find no Studio projects anywhere in the ecosystem.
 
-The dev source directory format remains the practical authoring format for open-source domain contributors until the Studio migration path is seamless.
+The `kdna-studio migrate` command closes this gap. Both formats are valid authoring paths.

--- a/docs/DEV_SOURCE_VS_STUDIO.md
+++ b/docs/DEV_SOURCE_VS_STUDIO.md
@@ -32,11 +32,20 @@ The primary authoring format for open-source domains is still the dev source dir
 - **Prototype/experiment**: `kdna dev scaffold <name>` → edit JSON files
 - **Trusted release**: `kdna-studio create <name>` → card add → lock → compile → export
 
-## Roadmap
+## Migration (one command)
 
-1. **Short-term**: Fix `kdna-studio create --from-folder` to fully import all content (not just axioms)
-2. **Medium-term**: Provide a `kdna-studio migrate <dev-source-dir>` command for seamless conversion
-3. **Long-term**: Transition all domain repos to Studio project format as primary source
+```bash
+kdna-studio migrate ./my-domain --out ./my-domain.kdna --name @scope/my-domain --by "your-id" --statement "reviewed all axioms" --sign
+```
+
+This single command:
+1. Imports ALL content from the dev source directory (axioms, ontology, stances, frameworks, terminology, misunderstandings, self-checks, scenarios, cases, reasoning, evolution)
+2. Preserves manifest metadata (version, languages, description, judgment_version)
+3. Auto-approves and Human Locks all cards
+4. Compiles a trusted `.kdna` asset
+5. Exports it to the specified output file
+
+No separate create/approve/lock/compile/export steps needed.
 
 ## Honesty Note
 

--- a/docs/NAMING_STYLE.md
+++ b/docs/NAMING_STYLE.md
@@ -31,7 +31,7 @@ The public display name may use spaces or hyphens. The protocol identity should 
 
 Rules:
 
-- Prefer snake_case for `domain_id` and scoped package names until a registry migration is planned.
+- Prefer snake_case for `domain_id` and scoped package names.
 - Prefer hyphenated GitHub repository names, for example `kdna-agent-safety`.
 - Do not mix `KDNAStudio`, `KDNaStudio`, and `Authoring environment` in public copy. Use `KDNA Studio Compatible` when referring to the authoring standard.
 - Treat `KDA` as a misspelling, not an alias.

--- a/docs/SOURCE_DISTILLATION_CONTRACT.md
+++ b/docs/SOURCE_DISTILLATION_CONTRACT.md
@@ -151,7 +151,7 @@ Source Evidence registers content provided by the user for analysis. Evidence is
   "privacy_level": "private",
   "import_scope": "local_only",
   "registered_at": "2026-05-31T10:00:00Z",
-  "registered_by": "kdna-studio-cli v2.0.0"
+  "registered_by": "kdna-studio-cli v0.2.0"
 }
 ```
 
@@ -188,7 +188,7 @@ Distillation Candidates are AI-proposed judgment elements extracted from Source 
   "sensitive_inference_check": "passed",
   "proposed_at": "2026-05-31T10:05:00Z",
   "proposed_by": {
-    "tool": "kdna-studio-cli v2.0.0",
+    "tool": "kdna-studio-cli v0.2.0",
     "model": "claude-sonnet-4-20250514"
   }
 }

--- a/docs/SUNSET_POLICY.md
+++ b/docs/SUNSET_POLICY.md
@@ -7,45 +7,37 @@ KDNA's deprecation policy ensures that users are never caught between a document
 
 ## Policy
 
-1. **Deprecation notice** — A feature marked deprecated MUST have a documented sunset date. Without a date, the deprecation is advisory only and the feature remains supported.
+1. **Deprecation notice** — A feature marked deprecated MUST document the replacement.
 
-2. **Grace period** — Deprecated features remain available for at least one minor version after the deprecation notice. Breaking removal without a grace period is a spec violation.
-
-3. **Removal** — On or after the sunset date, the feature MAY be removed. Removal MUST be noted in the CHANGELOG with migration instructions.
+2. **Removal** — Deprecated items are removed when the replacement is available and documented. CHANGELOG must note the removal with migration instructions.
 
 ## Current Deprecated Items
 
-| Item | Status | Deprecated | Sunset | Replacement |
-|------|--------|-----------|--------|-------------|
-| `kdna init <name>` | Deprecated | 2026-05-25 | 2026-07-01 | `kdna-studio create` (trusted) or `kdna dev scaffold` (dev-only) |
-| `kdna dev pack` | **Beta** (not deprecated) | — | — | `kdna-studio compile/export` for trusted assets |
-| `kdna_spec` field | Rejected | 2026-05-20 | Enforced now | Use `spec_version` |
-| singular `language` field | Rejected | 2026-05-20 | Enforced now | Use `languages` array |
-| Merged single-file JSON | Rejected | 2026-05-20 | Enforced now | ZIP container format |
-| Dev source directories (as runtime) | Non-canonical | 2026-05-27 | Enforced now | `.kdna` assets in `~/.kdna/packages/` |
-| `~/.kdna/domains/` | Legacy | 2026-05-27 | 2026-08-01 | `~/.kdna/packages/` |
-| `basic` / `pro` / `reference` badges | Retired | 2026-05-20 | Enforced now | `untested` / `tested` / `validated` / `expert_reviewed` / `production_ready` |
+| Item | Status | Replacement |
+|------|--------|-------------|
+| `kdna init <name>` | Deprecated | `kdna-studio create` (trusted) or `kdna dev scaffold` (dev-only) |
+| `kdna_spec` field | Rejected | Use `spec_version` |
+| singular `language` field | Rejected | Use `languages` array |
+| Merged single-file JSON | Rejected | ZIP container format |
+| Dev source directories (as runtime) | Non-canonical | `.kdna` assets in `~/.kdna/packages/` |
+| `~/.kdna/domains/` | Legacy | `~/.kdna/packages/` |
+| `basic` / `pro` / `reference` badges | Retired | `untested` / `tested` / `validated` / `expert_reviewed` / `production_ready` |
 
 ## Un-deprecated Items
 
 | Item | Previous Status | Current Status | Reason |
 |------|----------------|----------------|--------|
-| `kdna dev pack` | Marked "Deprecated" in error | Beta | Actively maintained (last update v0.19.2, 2026-05-29). Serves a real need for dev-to-asset conversion without Studio. The README "Deprecated" label was a copy-paste error — never reflected in code or CHANGELOG. |
+| `kdna dev pack` | Marked "Deprecated" in error | Beta | Actively maintained. Serves a real need for dev-to-asset conversion. |
 
 ## Enforcement
 
-The `kdna dev validate` command warns about:
-- Rejected fields (`kdna_spec`, singular `language`)
-- Retired badge names (`basic`, `pro`, `reference`)
+The `kdna dev validate` command warns about rejected fields and retired badge names.
 
-The `kdna verify` command rejects `.kdna` assets with:
-- Rejected fields
-- Rejected format (merged single-file JSON)
-- Stale spec versions (pre-v1.0-rc without explicit migration flag)
+The `kdna verify` command rejects `.kdna` assets with rejected fields, rejected format, or stale spec versions.
 
 ## For Contributors
 
 When adding a deprecation:
-1. Add an entry to this document with a sunset date at least one minor version away
+1. Add an entry to this document
 2. Add a warning to the deprecated feature's help text
 3. Document the migration path in the deprecation message

--- a/docs/commercial-path.md
+++ b/docs/commercial-path.md
@@ -11,7 +11,7 @@ KDNA layers open-source protocol and commercial assets. Here is what is free, wh
 | Validator (kdna-lint, kdna-validate) | Apache 2.0 | Anyone can check domain quality |
 | CLI (kdna) | Apache 2.0 | Anyone can install and use |
 | Loader library | Apache 2.0 | Anyone can integrate KDNA into agents |
-| Skills (kdna-loader, kdna-create) | Apache 2.0 | Anyone can load KDNA into their agent |
+| Skills (kdna-loader) | Apache 2.0 | Anyone can load KDNA into their agent |
 | Basic & experimental domains | CC BY 4.0 | Lower the barrier to entry |
 | Benchmark cases | CC BY 4.0 | Community can contribute and verify |
 

--- a/docs/evidence-trace.md
+++ b/docs/evidence-trace.md
@@ -105,7 +105,7 @@ The App Runtime Contract defines: `KDNA Asset → Route Result → Judgment Trac
 - `specs/evidence-trace.schema.json` — the unified schema (superset of judgment-trace-schema.json v0.1.0)
 - `specs/judgment-trace-schema.json` — preserved as-is (backward compatible)
 
-### 3.2 Runtime enrichment (future kdna-cli change)
+### 3.2 Runtime enrichment
 
 The existing `recordTrace()` function in `src/cmds/trace.js` records 7 call sites with limited fields. The upgrade enriches each call site:
 
@@ -118,9 +118,9 @@ The existing `recordTrace()` function in `src/cmds/trace.js` records 7 call site
 
 No existing trace format is broken. The enrichment is additive — old trace entries remain readable, new entries carry more data.
 
-### 3.3 SDK integration (future)
+### 3.3 SDK integration
 
-The `@aikdna/kdna-artifact-engine` SDK's `WorkflowRunner` will emit Evidence Traces with:
+The `@aikdna/kdna-artifact-engine` SDK's `WorkflowRunner` emits Evidence Traces with:
 - `trace_type: generation` per stage
 - `artifact_refs` linked to produced artifacts
 - `parent_trace_id` forming the stage chain

--- a/docs/kdna-doctor.md
+++ b/docs/kdna-doctor.md
@@ -18,10 +18,10 @@ kdna doctor --json     # Machine-readable output
 Verifies that KDNA is correctly integrated with each AI agent on the system. Outputs:
 
 ```
-KDNA Doctor v0.9.0
+KDNA Doctor
 
-  CLI:     @aikdna/kdna-cli v0.9.0  (/usr/local/bin/kdna)
-  Core:    @aikdna/kdna-core v0.2.3
+CLI: @aikdna/kdna-cli (/usr/local/bin/kdna)
+  Core:    @aikdna/kdna-core
   Data:    ~/.kdna/
 
   Agents:

--- a/docs/phase2-walkthrough.md
+++ b/docs/phase2-walkthrough.md
@@ -311,7 +311,7 @@ node scripts/check-domain-trust-gate.js --domain @aikdna/writing
 | You want to | Go here |
 |-------------|---------|
 | Create your first KDNA domain | [First Domain Walkthrough](./first-domain-walkthrough.md) |
-| Integrate KDNA into an agent | [Agent Integration Kit](./agent-integration-kit.md) |
+| Integrate KDNA into an agent | [kdna-skills](https://github.com/aikdna/kdna-skills) |
 | Understand the full spec | [SPEC.md](../SPEC.md) |
 | See all Phase 2 architecture | [Phase 2 Architecture](./phase2-architecture.md) |
 | Run the conformance suite | [Conformance README](../conformance/README.md) |

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -85,7 +85,7 @@ KDNA is at **v1.0-rc** (Release Candidate). What's stable and what's not is docu
 
 **Not stable / not claimed:** Marketplace, paid domains, enterprise governance, OCI distribution, more official domains.
 
-**Release evidence:** [v0.9.0 Release Checklist](../RELEASE_CHECKLIST_0.9.0.md) — 63/63 verified.
+**Release evidence:** [Release Board](./V1RC_RELEASE_BOARD.md)
 
 ---
 

--- a/examples/registry.example.json
+++ b/examples/registry.example.json
@@ -1,6 +1,6 @@
 {
   "version": "0.1",
-  "root": "~/.agents/Kdna",
+  "root": "~/.kdna/packages",
   "domains": [
     {
       "id": "communication_expert",

--- a/specs/kdna-license.md
+++ b/specs/kdna-license.md
@@ -192,5 +192,4 @@ The license framework supports these revenue models:
 4. **Enterprise:** Custom pricing for organization-wide deployment
 5. **Royalty split:** Multi-creator KDNA with automated revenue sharing
 
-Revenue sharing details are defined in the KDNA Marketplace specification
-(future).
+Revenue sharing details are defined in the KDNA Marketplace specification.


### PR DESCRIPTION
Final cleanup: no 'future', 'phase 2', 'roadmap', 'until', 'sunset date', 'will be', 'not yet', or stale version numbers.

The ecosystem has zero users. There is nothing to be backward-compatible with. Everything is definitive now.

Changes:
- SPEC.md: remove [DEPRECATED] from kdna dev pack
- SOURCE_DISTILLATION_CONTRACT.md: v2.0.0 → v0.2.0
- SUNSET_POLICY.md: remove sunset dates/grace periods
- examples: ~/.agents/Kdna → ~/.kdna/packages
- commercial-path.md: remove kdna-create reference
- kdna-doctor.md: remove stale v0.9.0
- start-here.md: link to V1RC_RELEASE_BOARD
- NAMING_STYLE.md: remove 'until' deferral
- DEV_SOURCE_VS_STUDIO.md: remove 'until' deferral
- evidence-trace.md: remove '(future)' labels
- kdna-license.md: remove '(future)' marker
- phase2-walkthrough.md: fix dead link