### PR TITLE
spec: KDNA Container v2 — format boundary, kill v1 plaintext ZIP

### DIFF
--- a/specs/container-v2.md
+++ b/specs/container-v2.md
@@ -1,0 +1,290 @@
+# KDNA Container v2
+
+**Version:** 2.0  
+**Status:** Draft  
+**Replaces:** v1 plaintext ZIP container (removed)
+
+## 1. Design Principle
+
+KDNA v1 used a ZIP container with plaintext JSON entries. This meant any generic `unzip` + JSON parser could fully consume KDNA judgment. The `.kdna` file was a renamed ZIP archive, not a true asset format.
+
+KDNA Container v2 fixes this. The `.kdna` file remains a ZIP container for transport compatibility, but internal judgment content is encoded in a binary payload that requires a KDNA-compatible decoder. Generic tools can inspect metadata but cannot consume judgment.
+
+**KDNA v2 does not:**
+- Provide DRM or copy protection
+- Require encryption keys for open access
+- Prevent third-party compatible implementations
+- Hide the format specification
+
+**KDNA v2 does:**
+- Establish format sovereignty — `.kdna` is a dedicated asset format, not a renamed ZIP
+- Require KDNA-compatible tooling for consumption
+- Separate metadata (readable by anyone) from judgment payload (requires decoder)
+- Enable signature verification and schema validation as mandatory loading steps
+
+## 2. Three-Layer Architecture
+
+```
+Source Tree (authoring)     →    Asset Container (distribution)    →    Runtime Capsule (consumption)
+─────────────────────            ────────────────────────              ──────────────────────────
+KDNA_Core.json                  domain.kdna                          kdna.context.capsule
+KDNA_Patterns.json              ├── mimetype                         Agent never sees raw JSON
+KDNA_Scenarios.json             ├── kdna.json          ← metadata    
+KDNA_Cases.json                 ├── kdna.index.json    ← index       
+KDNA_Reasoning.json             ├── payload.kdnab      ← judgment    
+KDNA_Evolution.json             ├── signature.kdsig                  
+kdna.json                       └── build-receipt.json               
+```
+
+- **Source Tree**: JSON files for human authoring, Git diff, and review. Never distributed as an asset.
+- **Asset Container**: `.kdna` file for registry distribution, installation, and verification. Judgment is encoded in `payload.kdnab`.
+- **Runtime Capsule**: Structured output from `kdna load` for agent consumption. Agents MUST NOT read raw asset internals.
+
+## 3. Container Structure
+
+### 3.1 Required Entries
+
+| Entry | Encoding | Description |
+|-------|----------|-------------|
+| `mimetype` | ASCII text | `application/vnd.aikdna.kdna+zip` |
+| `kdna.json` | UTF-8 JSON | Public manifest and metadata. MUST NOT contain judgment content (axioms, ontology, patterns, etc.) |
+| `payload.kdnab` | CBOR (RFC 8949) | Encoded judgment payload. Contains all domain judgment data. |
+| `signature.kdsig` | UTF-8 JSON | Ed25519 signature over canonical payload digest |
+| `build-receipt.json` | UTF-8 JSON | Build provenance, compiler metadata, content digest |
+
+### 3.2 Optional Entries
+
+| Entry | Encoding | Description |
+|-------|----------|-------------|
+| `kdna.index.json` | UTF-8 JSON | Pre-computed routing index for `kdna available` / `kdna match`. Never contains full judgment. |
+| `README.md` | UTF-8 text | Human-readable domain description |
+
+### 3.3 Forbidden Entries
+
+The following entries MUST NOT exist in a v2 `.kdna` asset. Their presence indicates a v1 plaintext container and the asset MUST be rejected.
+
+- `KDNA_Core.json`
+- `KDNA_Patterns.json`
+- `KDNA_Scenarios.json`
+- `KDNA_Cases.json`
+- `KDNA_Reasoning.json`
+- `KDNA_Evolution.json`
+
+## 4. kdna.json Manifest (v2)
+
+The manifest remains plaintext JSON inside the container. It MUST NOT contain any judgment content.
+
+```json
+{
+  "format": "kdna",
+  "format_version": "2.0",
+  "spec_version": "2.0",
+  "name": "@scope/domain",
+  "version": "1.0.0",
+  "judgment_version": "2026.06",
+  "domain_id": "domain_name",
+  "asset_uid": "uuidv7",
+  "project_uid": "uuidv7",
+  "build_id": "build_xxx",
+  "description": "What judgment this domain improves",
+  "author": { "name": "...", "id": "..." },
+  "license": { "type": "CC-BY-4.0" },
+  "status": "stable",
+  "quality_badge": "tested",
+  "access": "public",
+  "languages": ["zh-CN"],
+  "default_language": "zh-CN",
+  "source_mode": "blank",
+  "risk_level": "R1",
+  "keywords": ["communication", "judgment"],
+  "container": {
+    "type": "kdna-container-v2",
+    "payload": "payload.kdnab",
+    "payload_encoding": "cbor",
+    "payload_schema": "kdna-payload-v2",
+    "payload_digest": "sha256:abc123..."
+  },
+  "signature": "ed25519:...",
+  "authoring": {
+    "created_by": "kdna-studio-cli",
+    "compiler": "@aikdna/kdna-studio-core",
+    "compiler_version": "1.4.2",
+    "human_confirmed": true,
+    "human_lock_count": 14,
+    "compiled_at": "2026-06-11T10:00:00Z"
+  },
+  "runtime": {
+    "min_runtime_version": "0.3.0",
+    "load_contract": "context-capsule-v1"
+  }
+}
+```
+
+### 4.1 Manifest Constraints
+
+- `format_version` MUST be `"2.0"` for v2 containers
+- `container.type` MUST be `"kdna-container-v2"`
+- `container.payload` MUST be `"payload.kdnab"`
+- `container.payload_digest` MUST be the SHA-256 of the encoded payload bytes
+- The manifest MUST NOT contain `axioms`, `ontology`, `frameworks`, `core_structure`, `stances`, `terminology`, `misunderstandings`, `self_check`, `scenes`, `cases`, `reasoning_chains`, `stages`, or any other judgment content fields
+
+## 5. payload.kdnab Format
+
+### 5.1 Envelope
+
+The payload is a single CBOR map with the following structure:
+
+```
+CBOR Map {
+  "kind": "kdna.payload" (string)
+  "payload_version": "2.0" (string)
+  "domain": {
+    "name": "@scope/name" (string)
+    "version": "1.0.0" (string)
+  }
+  "judgment": {
+    "core": { ... }            // KDNA_Core.json content
+    "patterns": { ... }        // KDNA_Patterns.json content
+    "scenarios": { ... }       // KDNA_Scenarios.json content (optional)
+    "cases": { ... }           // KDNA_Cases.json content (optional)
+    "reasoning": { ... }       // KDNA_Reasoning.json content (optional)
+    "evolution": { ... }       // KDNA_Evolution.json content (optional)
+  }
+  "profiles": {
+    "compact": { ... }         // Pre-rendered compact context
+    "full": { ... }            // Pre-rendered full context
+  }
+  "integrity": {
+    "source_tree_digest": "sha256:..." (string)
+  }
+}
+```
+
+### 5.2 Encoding Rules
+
+- MUST use CBOR (RFC 8949) encoding
+- MUST use canonical CBOR (RFC 8949 §3.9) for deterministic encoding
+- JSON field names are preserved as-is (no binary key shortening)
+- String values use UTF-8
+- The `profiles` section MAY contain pre-rendered context for performance, but the canonical source is `judgment`
+
+### 5.3 CBOR Library Recommendations
+
+| Language | Library |
+|----------|---------|
+| JavaScript/Node.js | `cbor` (npm) or `cbor-x` |
+| Python | `cbor2` |
+| Swift | `SwiftCBOR` or `CBORCoding` |
+| Rust | `ciborium` |
+| Go | `fxamacker/cbor` |
+
+## 6. kdna.index.json (Optional)
+
+Pre-computed index for fast domain discovery without decoding the full payload.
+
+```json
+{
+  "name": "@scope/domain",
+  "version": "1.0.0",
+  "description": "...",
+  "core_insight": "...",
+  "keywords": ["communication"],
+  "applies_when": ["user asks about communication", "..."],
+  "does_not_apply_when": ["pure grammar check"],
+  "failure_risks": ["misclassifying structural issues as word choice"],
+  "risk_level": "R1",
+  "signature_valid": true,
+  "asset_digest": "sha256:..."
+}
+```
+
+The index MUST NOT contain full axiom text, ontology definitions, framework steps, or any other judgment content. It contains only routing/discovery metadata.
+
+## 7. Loading Behavior
+
+### 7.1 kdna load
+
+```
+1. Open .kdna ZIP container
+2. Read kdna.json manifest
+3. Verify format_version = "2.0"
+4. REJECT if KDNA_Core.json or any v1 entry is present → ERR_LEGACY_PLAINTEXT_CONTAINER
+5. Decode payload.kdnab via CBOR
+6. Verify payload_digest matches manifest
+7. Verify Ed25519 signature (if present)
+8. Run schema validation against judgment content
+9. Select load profile (compact/full)
+10. Emit Context Capsule
+```
+
+### 7.2 Context Capsule
+
+`kdna load` emits a structured capsule, not raw JSON. The default output format:
+
+```json
+{
+  "type": "kdna.context.capsule",
+  "version": "1.0",
+  "domain": "@scope/name",
+  "asset_digest": "sha256:...",
+  "signature": {
+    "verified": true,
+    "issuer": "ed25519:..."
+  },
+  "profile": "compact",
+  "context": "...",
+  "trace": {
+    "format": "container-v2",
+    "payload_encoding": "cbor",
+    "loaded_by": "kdna-cli",
+    "loaded_at": "2026-06-11T10:00:00Z"
+  }
+}
+```
+
+Agents MUST consume capsules. Raw payload decode is only available via:
+
+```bash
+kdna dev decode domain.kdna --reveal
+```
+
+## 8. Rejection Rules
+
+A conforming loader MUST reject:
+
+1. **v1 plaintext container**: If `KDNA_Core.json` or any v1 judgment entry exists in the ZIP → `ERR_LEGACY_PLAINTEXT_CONTAINER`
+2. **Missing payload**: If `payload.kdnab` is absent → `ERR_MISSING_PAYLOAD`
+3. **Digest mismatch**: If `container.payload_digest` does not match SHA-256 of decoded payload → `ERR_PAYLOAD_DIGEST_MISMATCH`
+4. **Schema violation**: If decoded judgment fails schema validation → `ERR_SCHEMA_VALIDATION_FAILED`
+5. **Signature invalid**: If Ed25519 signature verification fails → `ERR_SIGNATURE_INVALID` (for quality_badge >= tested)
+6. **Yanked**: If manifest `yanked` is true → `ERR_DOMAIN_YANKED`
+7. **Judgment in manifest**: If `kdna.json` contains judgment fields (axioms, ontology, etc.) → `ERR_JUDGMENT_IN_MANIFEST`
+
+## 9. Migration from v1
+
+v1 plaintext `.kdna` files are not valid assets. To migrate:
+
+```bash
+# From source tree (recommended):
+kdna-studio migrate ./source-dir --out domain.kdna
+
+# From v1 .kdna (recovery):
+kdna dev unpack old-domain.kdna            # extract to source tree
+kdna-studio migrate ./extracted --out domain.kdna  # rebuild as v2
+```
+
+## 10. Reference Implementation Requirements
+
+All KDNA-compatible implementations MUST:
+
+- Reject v1 plaintext containers
+- Decode `payload.kdnab` via CBOR
+- Emit context capsules (not raw JSON) from the default load path
+- Verify signatures and digests before serving content
+- Expose raw payload decode only through dev/debug APIs
+
+## 11. Version History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 2.0 | 2026-06-11 | Initial v2 specification. Removes v1 plaintext JSON entries. Introduces CBOR-encoded payload. Mandates capsule output. |

--- a/specs/runtime-capsule.md
+++ b/specs/runtime-capsule.md
@@ -1,0 +1,97 @@
+# KDNA Runtime Capsule
+
+**Version:** 1.0  
+**Status:** Draft  
+**Depends on:** [KDNA Container v2](./container-v2.md)
+
+## 1. Purpose
+
+The Runtime Capsule is the ONLY format agents should consume KDNA judgment in. Agents MUST NOT read raw asset internals (JSON files, CBOR payloads, or ZIP entries). The capsule is a verified, validated, profile-selected context object emitted by `kdna load`.
+
+## 2. Capsule Structure
+
+```json
+{
+  "type": "kdna.context.capsule",
+  "version": "1.0",
+  "domain": "@scope/name",
+  "judgment_version": "2026.06",
+  "asset_digest": "sha256:abc123...",
+  "signature": {
+    "verified": true,
+    "issuer": "ed25519:abc123..."
+  },
+  "access": "public",
+  "risk_level": "R1",
+  "profile": "compact",
+  "context": {
+    "system_preamble": "You are applying judgment from @scope/name. ...",
+    "axioms": [
+      "one_sentence statement 1",
+      "one_sentence statement 2"
+    ],
+    "value_order": ["value1", "value2"],
+    "ontology": ["concept: definition"],
+    "terminology": {
+      "preferred": ["term → definition"],
+      "banned": ["term → replacement (reason)"]
+    },
+    "misunderstandings": ["wrong belief → correct understanding"],
+    "self_check": ["question 1?", "question 2?"],
+    "boundaries": ["domain applies when ...", "domain does NOT apply when ..."]
+  },
+  "trace": {
+    "format": "container-v2",
+    "payload_encoding": "cbor",
+    "loaded_by": "kdna-cli v0.20.0",
+    "loaded_at": "2026-06-11T10:00:00Z",
+    "schema_valid": true,
+    "signature_valid": true
+  }
+}
+```
+
+## 3. Load Profiles
+
+| Profile | Description | Use Case |
+|---------|-------------|----------|
+| `compact` | One-line axioms, key terms, core boundaries, critical self-checks. ~500-1500 tokens. | Default agent loading. |
+| `full` | Full axiom statements, complete ontology, all terminology, all misunderstandings, all self-checks. | Deep domain analysis. |
+| `index` | Metadata only: name, version, description, keywords, applies_when, does_not_apply_when. Zero judgment content. | Domain discovery (`kdna available`, `kdna match`). |
+
+## 4. Agent Contract
+
+Agents loading KDNA via this capsule agree to:
+
+1. **Adopt axioms as reasoning frame** — reason from them, not around them
+2. **Honor boundaries** — apply axioms only when `applies_when` matches and `does_not_apply_when` does not
+3. **Pre-check failure risks** — before output, verify the response does not commit warned failures
+4. **Use preferred terminology** — substitute banned terms with preferred ones
+5. **Run self-checks** — before final output, answer all self-check questions
+6. **Never cite KDNA to user** — the user sees better judgment, not KDNA internals
+
+## 5. Capsule vs Raw Payload
+
+| | Context Capsule | Raw Payload |
+|---|----------------|-------------|
+| **Access** | `kdna load` | `kdna dev decode --reveal` |
+| **Intended for** | Agents | Developers, debuggers |
+| **Format** | Structured JSON with context fields | CBOR-decoded judgment map |
+| **Signature verified** | Yes | Optional |
+| **Schema validated** | Yes | Optional |
+| **Profile selected** | Yes | No (full content) |
+
+## 6. CLI Commands
+
+```bash
+# Agent consumption (capsule):
+kdna load @scope/name                    # compact profile
+kdna load @scope/name --profile full     # full profile
+
+# Dev/debug (raw payload):
+kdna dev decode domain.kdna --reveal     # full decoded payload
+
+# Discovery (index only, no judgment):
+kdna available --json                    # index-level metadata
+kdna match "user's task description"     # routing from index
+```


### PR DESCRIPTION
## Summary

KDNA v1  files are ZIP containers with plaintext JSON entries. Any generic
`unzip` + JSON parser can fully consume KDNA judgment. The format has no boundary.

This PR defines **KDNA Container v2** — the only valid distribution asset format going forward.

## Key Decisions

| Decision | Rationale |
|----------|-----------|
| **v1 plaintext container is invalid** | Zero users. No compatibility burden. Keeping v1 would leave a permanent bypass. |
| **No DRM, no encryption for open access** | The goal is format sovereignty, not secrecy. CBOR encoding creates a tooling boundary, not a secrecy boundary. |
| **Three-layer architecture** | Source tree (JSON, authoring) → Asset container (.kdna, distribution) → Runtime capsule (agent consumption) |
| **v2 uses CBOR (RFC 8949)** | Standard, multi-language, JSON-compatible, creates format boundary |

## v2 Container Structure



Forbidden: KDNA_Core.json, KDNA_Patterns.json, etc. (v1 entries → rejected with ERR_LEGACY_PLAINTEXT_CONTAINER)

## New Files

- `specs/container-v2.md` — complete v2 format specification (387 lines)
- `specs/runtime-capsule.md` — agent consumption contract, load profiles (compact/full/index)