### PR TITLE
rfc: file RFC-0014 (Card v2) and RFC-0015 (Trace v2) Drafts

### DIFF
--- a/docs/audits/phase-2-rfc-0014-0015-filing.md
+++ b/docs/audits/phase-2-rfc-0014-0015-filing.md
@@ -1,0 +1,160 @@
+# Phase 2 Filing Note — RFC-0014 / RFC-0015 Drafts
+
+**RFC-0013 phase:** Phase 2 (companion RFC drafting)
+**Status:** Both RFC-0014 and RFC-0015 filed as Draft
+**Re-run (manual):**
+- `git show origin/main:specs/RFC-0014-kdna-card-v2.md | head -1`  → `# RFC-0014: KDNA Card Spec v2.0`
+- `git show origin/main:specs/RFC-0015-runtime-trace-v2.md | head -1` → `# RFC-0015: Runtime Trace Spec v2`
+- `git show origin/main:docs/rfc-status.md | grep -E "RFC-001[45]"`   → both rows present
+
+## Scope
+
+This PR files **two Draft RFCs** in the `aikdna/kdna` meta repo:
+
+- `specs/RFC-0014-kdna-card-v2.md` — KDNA Card Spec v2
+- `specs/RFC-015-runtime-trace-v2.md` — Runtime Trace Spec v2
+
+These companion RFCs were declared in RFC-0013 §7:
+
+> Two companion detail specs are required for implementation. They
+> are NOT this RFC and will be filed separately: RFC-0014 — KDNA
+> Card Spec v2.0, RFC-0015 — Runtime Trace Spec v2.
+
+This PR **only files the drafts**. It does not implement Card v2 or
+Trace v2 in code. Per work plan §4.3 Phase 2, RFC-0014 and
+RFC-0015 are scope-limited to **detail-schema only**.
+
+## Why these RFCs can be filed now
+
+The work plan §4.2 PR-4 boundary states:
+
+> PR-4 must verify the lifecycle. PR-4b must close §9 #7. RFC-0014
+> and RFC-0015 are filed separately and must wait for PR-1~4b
+> implementation feedback per the work plan §4.3.
+
+PR-1 through PR-4b are now merged:
+- **PR-1** (aikdna/kdna #86) — three authoring-time schemas
+- **PR-2** (aikdna/kdna-cli #10) — Anti-Monolithic CLI lint
+- **PR-2a** (aikdna/kdna #87) — SPEC §1.6.3 Anti-Monolithic
+  principle
+- **PR-3** (aikdna/kdna-studio-core #3) — SAG/TC compile gates
+- **PR-4** (aikdna/kdna-lab #3) — lifecycle smoke on a simple
+  official legacy domain
+- **PR-4b** (aikdna/kdna-lab #4) — default SAG/TC synthesis
+  migration smoke
+
+PR-4 and PR-4b together produced the implementation feedback
+that RFC-0014 and RFC-0015 build on:
+
+- **PR-4** produced 11 lifecycle trace events with
+  `sag_version` and `tc_status` on every event.
+- **PR-4b** produced 6 lifecycle trace events plus migration-
+  specific fields (`migration_mode`, `synthesis_status`,
+  `lock_status`, `runtime_payload_leaked`).
+- **PR-3** proved that the runtime payload does not leak
+  authoring-time objects. RFC-0014 / RFC-0015 codify this
+  boundary in the Card / Trace field shapes.
+
+## RFC-0013 §9 acceptance criteria coverage (after this PR)
+
+| # | Item | Status | Where |
+|---|------|--------|-------|
+| #1 | All three new schema files merged in `aikdna/kdna/schema/` | ✅ | PR-1 (#86) |
+| #2 | `kdna dev validate --anti-monolithic` exists | ✅ | PR-2 (#10) |
+| #3 | kdna-studio-core rejects (with clear error) on `strict-authority` violations | ✅ | PR-3 (#3) |
+| #4 | kdna-lab smoke test on a simple official legacy domain | ✅ | PR-4 (#3) |
+| #5 | SPEC §1.6 contains the Anti-Monolithic Domain Principle verbatim | ✅ | PR-2a (#87) |
+| #6 | RFC-0014 and RFC-0015 are filed as separate Draft RFCs | ✅ | **this PR** |
+| #7 | Migration run synthesizes default SAG/TC and produces valid `.kdna` | ✅ | PR-4b (#4) |
+
+After this PR, **§9 acceptance criteria are now covered**. The
+implementation series is technically complete.
+
+## What this PR does NOT do (intentional)
+
+Per work plan §4.3 Phase 2 boundary, this PR only files drafts:
+
+- ❌ **No implementation of Card v2.** RFC-0014 is a detail-schema
+  proposal; the kdna-studio-core release that emits the v2 fields
+  is a follow-up.
+- ❌ **No implementation of Trace v2.** RFC-0015 is a detail-schema
+  proposal; the kdna-studio-core and kdna-lab releases that emit
+  and consume the v2 lifecycle events are follow-ups.
+- ❌ **No runtime payload changes.**
+- ❌ **No schema changes** (the existing PR-1 schemas are unchanged).
+- ❌ **No changes to kdna-cli / kdna-studio-core / kdna-lab.**
+- ❌ **No atomspeak / book-derived domain smoke** (deferred to PR-5).
+- ❌ **No fix of kdna-studio-core's 11 pre-existing test failures**
+  (out of scope for the RFC-0013 series; see PR-3 audit note).
+- ❌ **No marketplace / enterprise / privacy / WorkPack work.**
+- ❌ **No changes to existing v1 trace command** (`docs/kdna-trace.md`)
+  or v1 judgment-trace schema (`specs/judgment-trace-schema.json`).
+  v2 is additive; v1 remains valid.
+
+## Files
+
+| File | Change | Lines |
+|------|--------|-------|
+| `specs/RFC-0014-kdna-card-v2.md` | new | ~270 |
+| `specs/RFC-0015-runtime-trace-v2.md` | new | ~250 |
+| `docs/rfc-status.md` | modified (added RFC-0014 / RFC-0015 rows; current-state progress bars; status note) | +12 / -2 |
+
+## Dependency evidence
+
+| PR | Repo | Commit | Role |
+|----|------|--------|------|
+| #86 | aikdna/kdna | `c00601c` | PR-1: SAG / TC / IMM schemas. RFC-0014 / RFC-0015 reference these schemas in their field shapes. |
+| #10 | aikdna/kdna-cli | `bb64821` | PR-2: Anti-Monolithic CLI lint. PR-2 debt (question-count heuristic) is referenced in RFC-0014 §6. |
+| #87 | aikdna/kdna | `f328ca0` | PR-2a: SPEC §1.6.3 Anti-Monolithic principle. RFC-0014 §6 references the principle. |
+| #3 | aikdna/kdna-studio-core | `e2dddf4` | PR-3: SAG/TC compile gates. RFC-0014 / RFC-0015 §2 boundary is derived from the PR-3 compile-time separation. |
+| #3 | aikdna/kdna-lab | `d8c466c` | PR-4: lifecycle smoke. RFC-0015 §1 motivation is derived from the 11 PR-4 events. |
+| #4 | aikdna/kdna-lab | `3849ae1` | PR-4b: default synthesis migration. RFC-0014 §6 + RFC-0015 §3.2 migration fields are derived from PR-4b's outputs. |
+
+## On the public RFC-0013 status
+
+The `docs/rfc-status.md` change includes a note:
+
+> RFC-0013 §9 acceptance criteria are now **technically covered** by
+> the implementation series (PR-1 / PR-2 / PR-2a / PR-3 / PR-4 /
+> PR-4b), plus the filing of RFC-0014 and RFC-0015 (this update).
+> However, RFC-0013 is **not** promoted to `Accepted` or
+> `Implemented` here. The public status remains `Draft` until
+> external review and approval ratifies the implementation.
+
+Per the user's instruction:
+
+> 即使 #6 完成，也建议对外口径保持保守：
+> "RFC-0013 implementation acceptance criteria are now covered;
+> external approval / final status update pending."
+
+The status note in `docs/rfc-status.md` matches this wording.
+
+## What happens next (NOT in this PR)
+
+A future Phase 3 (work plan §4.4) may file implementation RFCs for
+Card v2 and Trace v2 in kdna-studio-core, and may file a Phase 2/3
+RFC for the at-home / production-policy RFCs (k-dna registry trust,
+marketplace, etc.). PR-5 (atomspeak) is also a separate workstream.
+None of these are in this PR.
+
+## Governance
+
+- This PR follows the real PR flow (feature branch, push, PR,
+  admin merge). No direct push to `main`.
+- PR title and description clearly limit scope to "Phase 2: file
+  RFC-0014 / RFC-0015 Drafts".
+- The PR description will explicitly state:
+  - "no review submissions; admin merge only" (if no reviews).
+  - "no workflow runs; local validation only" (the aikdna/kdna meta
+    repo's CI does not run on Draft filings; local grep checks only).
+
+## References
+
+- RFC-0013 §7: declares RFC-0014 / RFC-0015 as companion Drafts
+- RFC-0013 §9: acceptance criteria, now all covered after this PR
+- PR-1 to PR-4b: implementation evidence (see §"Dependency evidence")
+- Work plan: `Kdna内部思考/KDNA 协议升级工作计划 2026-06-16.md` §4.3
+- aikdna/kdna-lab PR-4 audit note: `docs/audits/pr-4-acceptance.md`
+- aikdna/kdna-lab PR-4b audit note: `docs/audits/pr-4b-acceptance.md`
+- aikdna/kdna-studio-core PR-3 audit note: `docs/audits/pr-3-acceptance.md` (PR-2 debt)
+- aikdna/kdna PR-2a audit note: `docs/audits/pr-2-acceptance.md`

--- a/docs/rfc-status.md
+++ b/docs/rfc-status.md
@@ -18,7 +18,9 @@
 | RFC-0010 | Fidelity Protocol | **Implemented** | `specs/fidelity-result.schema.json`, `@aikdna/kdna-fidelity-core` |
 | RFC-0011 | Product Runtime | **Accepted** | `specs/product-runtime.schema.json`, `examples/product-runtime/` |
 | RFC-0012 | Artifact Envelope (output artifact) | **Draft** | `specs/RFC-0012-artifact-contract.md` (companion to RFC-0009; output-side envelope) |
-| RFC-0013 | Judgment Asset Lifecycle | **Draft** | `specs/RFC-0013-judgment-asset-lifecycle.md` (this RFC) |
+| RFC-0013 | Judgment Asset Lifecycle | **Draft** | `specs/RFC-0013-judgment-asset-lifecycle.md` (companion RFCs RFC-0014 / RFC-0015 now also filed) |
+| RFC-0014 | KDNA Card Spec v2 | **Draft** | `specs/RFC-0014-kdna-card-v2.md` (companion to RFC-0013; field-level extension, not implementation) |
+| RFC-0015 | Runtime Trace Spec v2 | **Draft** | `specs/RFC-0015-runtime-trace-v2.md` (companion to RFC-0013; field-level extension, not implementation) |
 
 ## Lifecycle Rules
 
@@ -35,5 +37,17 @@ RFC-0009 Artifact Contract     ████████████░░░░ 
 RFC-0010 Fidelity Protocol     ████████████░░░░  Implemented
 RFC-0011 Product Runtime       ████████░░░░░░░░  Accepted
 RFC-0012 Artifact Envelope     ██░░░░░░░░░░░░░░  Draft
-RFC-0013 Judgment Asset Life.  █░░░░░░░░░░░░░░░  Draft
+RFC-0013 Judgment Asset Life.  █░░░░░░░░░░░░░░░  Draft (companion RFCs filed; see note)
+RFC-0014 Card v2                █░░░░░░░░░░░░░░░  Draft
+RFC-0015 Trace v2              █░░░░░░░░░░░░░░░  Draft
 ```
+
+> **Note on RFC-0013 status (2026-06-16):** RFC-0013 §9 acceptance
+> criteria are now **technically covered** by the implementation
+> series (PR-1 / PR-2 / PR-2a / PR-3 / PR-4 / PR-4b), plus the
+> filing of RFC-0014 and RFC-0015 (this update). However, RFC-0013
+> is **not** promoted to `Accepted` or `Implemented` here. The
+> public status remains `Draft` until external review and approval
+> ratifies the implementation. The accurate external wording is:
+> *"RFC-0013 implementation acceptance criteria are now covered;
+> external approval / final status update pending."*

--- a/specs/RFC-0014-kdna-card-v2.md
+++ b/specs/RFC-0014-kdna-card-v2.md
@@ -1,0 +1,368 @@
+# RFC-0014: KDNA Card Spec v2.0
+
+**Status:** Draft
+**Proposed:** 2026-06-16
+**Authors:** KDNA Maintainers
+**Supersedes:** (none — extends `docs/KDNA_CARD_SPEC.md` v1)
+**Related:**
+- RFC-0013 (`specs/RFC-0013-judgment-asset-lifecycle.md`) — the lifecycle that introduces SAG, TC, IMM
+- `docs/KDNA_CARD_SPEC.md` — KDNA Card Spec v1 (shipped, **not replaced** by this RFC)
+- `specs/source_authority.schema.json` (PR-1, aikdna/kdna #86)
+- `specs/truth_charter.schema.json` (PR-1)
+- `specs/module_manifest.schema.json` (PR-1)
+- aikdna/kdna-lab PR #3 (PR-4 lifecycle smoke)
+- aikdna/kdna-lab PR #4 (PR-4b default synthesis migration)
+
+---
+
+## Abstract
+
+RFC-0013 introduced three authoring-time object types — Source
+Authority Graph (SAG), Truth Charter (TC), and Internal Module
+Manifest (IMM) — and explicitly forbade them from leaking into the
+runtime `.kdna` payload (RFC-0013 §3 + SPEC §3.3.2). The KDNA
+Card v1 (`docs/KDNA_CARD_SPEC.md`) was designed before the
+lifecycle existed and therefore exposes a fixed metadata shape
+without any field that records which SAG/TC/IMM version a domain
+was governed by.
+
+RFC-0014 extends the Card with a v2 layout that surfaces **summary
+fields** derived from SAG/TC/IMM but does **not** carry the
+authoring-time objects themselves. The boundary is: a Card v2 can
+tell a consumer "this domain is locked, sag v1.2.3, tc v1.2.3, last
+synthesized 2026-06-14, source disclosure level = summary" — it cannot
+tell the consumer the full SAG structure, the full TC content, or
+the full IMM module list.
+
+This RFC is **detail-schema only**. It does not re-litigate the
+lifecycle architecture, the WorkPack boundary, or the
+anti-monolithic principle.
+
+---
+
+## 1. Motivation
+
+The lifecycle implementation series (PR-1 → PR-4b) made the
+following real-world trade-offs visible to the authoring-time vs
+runtime boundary:
+
+- **PR-1** introduced the three schemas (`source_authority.json`,
+  `truth_charter.json`, `module_manifest.json`) and documented them
+  as authoring-time only. v1 Card has no field that records which
+  of those schemas the domain was governed by.
+- **PR-3** (kdna-studio-core compile gates) introduced strict
+  vs default mode. A consumer who receives a `.kdna` has no way to
+  know whether the domain was compiled under strict-authority or
+  default mode.
+- **PR-4b** (default synthesis migration) introduced a new
+  `tc_status: "synthesized"` value. A consumer cannot distinguish a
+  domain whose TC was authored-and-locked by a human from one whose
+  TC was auto-synthesized and promoted by a real human lock step.
+  Both have `tc_status: "locked"`; only the migration_status
+  field on the Card can carry the provenance.
+
+These three observations drive the v2 fields below. They are
+**summary** fields, not the full SAG/TC/IMM objects.
+
+---
+
+## 2. Boundary: what Card v2 MUST NOT carry
+
+The following authoring-time objects are **never** embedded in
+Card v2, in any form:
+
+- The full `source_authority.json` (SAG) object, including its
+  `sources[]` array, `precedence_order`, `conflict_policies`,
+  `sensitivity`, and any author-locked or synthesized source
+  details.
+- The full `truth_charter.json` (TC) object, including its
+  `highest_question`, `core_insight`, `in_scope` / `out_of_scope`,
+  `highest_axiom_protected`, `forbidden_simplifications`,
+  `renamed_terms`, `anti_drift_rules`, and `judgment_authority_holder`.
+- The full `module_manifest.json` (IMM) object, including its
+  `modules[]` array, per-module `module_id` / `module_type` /
+  `maps_to` / `loadable_via` / `decomposition_rationale`.
+
+These objects **may** appear in the provenance report (the
+`reports/provenance-report.json` already produced by the compile
+pipeline) and in audit sidecar logs, but NOT on the Card.
+
+**Test for the boundary:** if removing a field from Card v2 would
+force the consumer to lose the ability to audit the domain, the
+field belongs in the provenance report, not on the Card.
+
+---
+
+## 3. Card v2 field layout (additive over v1)
+
+The v1 Card fields (`name`, `version`, `risk_level`,
+`intended_use`, `out_of_scope`, `known_limitations`,
+`author_responsibility`, `risk_warnings`, `human_lock_summary`,
+`quality_badge`, `review_status`, `provenance`, `license`)
+**remain unchanged**. RFC-0014 only adds new fields; it does not
+deprecate, rename, or move any v1 field.
+
+```json
+{
+  "name": "@aikdna/code_review",
+  "version": "0.8.0-draft.1",
+  "risk_level": "R1",
+  "intended_use": [...],
+  "out_of_scope": [...],
+  "human_lock_summary": { ... },
+  "quality_badge": "validated",
+  "review_status": "verified",
+  "provenance": { ... },
+  "license": "CC-BY-4.0",
+
+  // ── v2 additions (this RFC) ──────────────────────────────────
+  "sag_summary": { ... },
+  "tc_summary": { ... },
+  "module_summary": { ... },
+  "authority_status": "locked",
+  "truth_charter_status": "locked",
+  "migration_status": "human_locked",
+  "source_disclosure_level": "summary"
+}
+```
+
+### 3.1 `sag_summary` (object, **required** if a SAG exists, else **absent**)
+
+```json
+"sag_summary": {
+  "sag_id": "sag_<domain>_<yyyy_mm_dd>",
+  "version_intent": "0.8.0-draft.1",
+  "source_count": 3,
+  "current_highest_count": 2,
+  "has_conflict_policies": true,
+  "sensitivity": {
+    "pii": false,
+    "author_consent_on_file": true
+  }
+}
+```
+
+The summary carries the SAG identity and counts, never the
+individual source entries. `current_highest_count > 0` is the
+gating property: if it is 0, the domain cannot have been compiled
+under PR-3 strict-authority (and the Card MUST surface that the
+compile was not strict-authority via `authority_status`).
+
+### 3.2 `tc_summary` (object, **required** if a TC exists, else **absent**)
+
+```json
+"tc_summary": {
+  "tc_id": "tc_<domain>_<version>_<yyyy_mm_dd>",
+  "highest_question": "Code review judgment: diagnose the layer of a PR before responding.",
+  "in_scope_count": 4,
+  "out_of_scope_count": 4,
+  "renamed_terms_count": 2,
+  "highest_axiom_protected_chars": 92
+}
+```
+
+The summary carries TC identity plus a few non-sensitive aggregates.
+It does **not** carry the full `forbidden_simplifications` /
+`anti_drift_rules` lists (those can contain author-only
+directives). It does **not** carry the full `core_insight` (which
+is often longer than 30 characters and contains the most
+discriminating author-only language).
+
+### 3.3 `module_summary` (object, **required** if an IMM exists, else **absent**)
+
+```json
+"module_summary": {
+  "module_count": 4,
+  "internal_module_count": 3,
+  "sub_domain_count": 0,
+  "reference_count": 1,
+  "decomposition_rationale_present": true
+}
+```
+
+The summary carries counts only, never the per-module `maps_to`
+paths (those are author-only and would let a consumer reconstruct
+internal naming).
+
+### 3.4 `authority_status` (enum, **required**)
+
+A flat string that summarises the compile authority:
+
+| Value | Meaning |
+|-------|---------|
+| `"none"` | No SAG was supplied; compile used default mode. |
+| `"declared_only"` | SAG was supplied but had no `current_highest` source; compile did not run under strict-authority. |
+| `"human_locked"` | SAG had a `current_highest` source of `type: "human_locked_charter"`. |
+| `"synthesized_then_human_locked"` | PR-4b migration path: the SAG was synthesized by the default helper, then a real human lock was recorded. The Card distinguishes this from `"human_locked"` because the SAG content was not originally authored. |
+| `"author_confirmation_only"` | SAG's only `current_highest` source is `type: "author_confirmation"`. Domain is not formally locked in the human-locked sense. |
+
+### 3.5 `truth_charter_status` (enum, **required** if a TC exists, else **absent**)
+
+A flat string mirroring TC's `tc_status` but redacted for the
+runtime surface:
+
+| Value | Meaning |
+|-------|---------|
+| `"draft"` | TC exists and has `tc_status: "draft"`. Not safe to ship. |
+| `"synthesized"` | TC exists and has `tc_status: "synthesized"`. PR-3 strict compile would reject this. |
+| `"locked"` | TC exists and has `tc_status: "locked"`. Default: safe. |
+| `"deprecated"` | TC exists and has `tc_status: "deprecated"`. |
+
+This field carries the **status value** but not the locked_by /
+locked_at fields. Those are audit-only; surfacing them on the
+Card would leak the identity of the human who locked the domain.
+
+### 3.6 `migration_status` (enum, **required**)
+
+A flat string describing how the SAG/TC came into existence:
+
+| Value | Meaning |
+|-------|---------|
+| `"human_authored"` | All three objects (SAG/TC/IMM, or any subset) were authored by a human lock. |
+| `"synthesized"` | At least one of SAG/TC/IMM was produced by `kdna_lab.rfc0013_migration.default_synthesize` and has NOT yet been promoted to a real human lock. |
+| `"synthesized_then_human_locked"` | The synthesis helper produced the objects, then a real human lock was recorded (PR-4b's full pipeline). |
+| `"mixed"` | A hybrid: some fields are human-locked, others are still in `synthesized` state. |
+
+`"synthesized"` MUST be a hard warning on the Card: a consumer
+should know that the domain's TC may not reflect authorial intent.
+`"synthesized_then_human_locked"` is the legitimate migration
+path documented in PR-4b and is safe to ship.
+
+### 3.7 `source_disclosure_level` (enum, **required**)
+
+A flat string declaring how much authoring-time detail the Card
+reveals:
+
+| Value | Meaning |
+|-------|---------|
+| `"summary"` | The Card carries only `*_summary` aggregates. The full SAG/TC/IMM are not present anywhere on the Card. This is the only acceptable default for `public` registries. |
+| `"audit_only"` | The full SAG/TC/IMM are available in a sidecar `audit.json` next to the `.kdna`, intended for enterprise-audit consumers. The Card itself still carries only `*_summary` fields. |
+| `"none"` | No SAG/TC/IMM were supplied; the Card carries only v1 fields plus the v2 status fields. |
+
+The default MUST be `"summary"`. A consumer that wants the
+authoring-time objects MUST follow the `audit_only` sidecar path
+described in the Migration section, not the Card.
+
+---
+
+## 4. Required vs optional vs future fields
+
+| Field | When present | Required? |
+|-------|--------------|-----------|
+| `sag_summary` | Only if a SAG was supplied during compile. | **Required if a SAG exists**, else the field is **absent** (not present at all). |
+| `tc_summary` | Only if a TC was supplied during compile. | **Required if a TC exists**, else **absent**. |
+| `module_summary` | Only if an IMM was supplied during compile. | **Required if an IMM exists**, else **absent**. |
+| `authority_status` | Always emitted (it is the most basic compile-time signal). | **Required**. |
+| `truth_charter_status` | Always emitted if a TC exists, else the field is **absent**. | **Required if a TC exists**, else **absent**. |
+| `migration_status` | Always emitted. | **Required**. |
+| `source_disclosure_level` | Always emitted; defaults to `"summary"`. | **Required**. |
+
+**Future (not in this RFC):**
+
+- `sag_history` — an array of past SAG ids for domains that have
+  evolved. Deferred because v1 of the lifecycle has no
+  established migration path between SAGs.
+- `author_team` — list of contributor handles. Deferred because the
+  KDNA Core does not yet model multi-author collaboration.
+
+---
+
+## 5. Migration: how existing v1 Cards become v2
+
+The migration is **additive only**. v1 Cards are still valid; the
+v2 fields are filled in at compile time when a SAG/TC/IMM exists.
+
+- A domain compiled with no SAG/TC/IMM (pre-RFC-0013 domains): the
+  Card carries only the v1 fields plus `authority_status: "none"`,
+  `truth_charter_status` **absent**, `migration_status:
+  "human_authored"` (the original v1 Card's `human_lock_summary` is
+  the migration_status source), and `source_disclosure_level:
+  "none"`.
+- A domain compiled with a SAG but no TC: the Card carries
+  `sag_summary`, `authority_status`, `migration_status`, and
+  `source_disclosure_level`. The `tc_summary` and
+  `truth_charter_status` fields are **absent**.
+- A domain compiled via the PR-4b migration path:
+  `migration_status: "synthesized_then_human_locked"`. The
+  `truth_charter_status` is `"locked"` (because the lock step
+  produces a `tc_status: "locked"` TC).
+
+The migration is **not** a JSON-Schema version bump. The Card
+schema's `additionalProperties` setting from v1 carries forward.
+The new fields are added under the same `required` / `optional`
+contract as v1: nothing in v1 becomes required in v2; the v2
+fields are required when their authoring-time objects exist.
+
+---
+
+## 6. Relationship to PR-4b
+
+PR-4b (`docs/audits/pr-4b-acceptance.md`) is the closing piece of
+RFC-0013 §9 #7. RFC-0014 builds on PR-4b's findings:
+
+- The `migration_status: "synthesized_then_human_locked"` value is
+  the result of running `kdna_lab.rfc0013_migration.default_synthesize`
+  followed by `lock_tc_with_rationale`. PR-4b proves that this
+  pipeline produces a TC that passes PR-3 strict compile; RFC-0014
+  defines the Card field that surfaces this fact.
+- The `sag_summary` and `tc_summary` field shapes are derived from
+  the PR-1 schemas and the PR-4b helper's output. They contain
+  counts and ids, never the underlying objects.
+
+A domain that comes out of the PR-4b migration pipeline MUST have
+its Card v2 stamped with `migration_status:
+"synthesized_then_human_locked"`, not `"human_authored"`. The
+synthesized / human-locked distinction is a key part of the v2
+Card's audit value.
+
+---
+
+## 7. Non-Goals (Restated for Clarity)
+
+This RFC explicitly does **not**:
+
+- ❌ Define new marketplace display fields. The marketplace is
+  Application track; its Card layout is a separate concern.
+- ❌ Define enterprise owner-scope fields. Enterprise governance
+  is Governance track; v2 only adds flat status fields.
+- ❌ Define WorkPack-specific fields. WorkPack is Application
+  track.
+- ❌ Define atomspeak-specific fields. Atomspeak PR-5 is a
+  follow-up; v2 should not be atomspeak-specific.
+- ❌ Define a new schema version of the Card. v2 is additive; v1
+  Cards remain valid.
+- ❌ Embed full SAG/TC/IMM in the Card. See §2. The full objects
+  belong in the provenance report, never on the Card.
+- ❌ Implement Card v2 in code. This RFC is a detail-schema
+  proposal; implementation is a follow-up RFC or a kdna-studio-core
+  release.
+
+---
+
+## 8. Acceptance Criteria
+
+This RFC is considered **Accepted → Implemented** when:
+
+1. A kdna-studio-core release emits the v2 fields on the Card.
+2. The v2 fields are documented in `docs/KDNA_CARD_SPEC.md` (or its
+   successor).
+3. The `migration_status: "synthesized_then_human_locked"` value
+   is exercised by a kdna-lab smoke (PR-4b already produces it).
+4. The Card schema validates against a JSON Schema Draft 2020-12
+   document.
+5. A consumer reading only the v2 fields can answer the questions
+   "is this domain locked?" and "was this domain's TC synthesized
+   or human-authored?" without consulting the full SAG/TC/IMM.
+
+---
+
+## 9. References
+
+- RFC-0013: `https://github.com/aikdna/kdna/blob/main/specs/RFC-0013-judgment-asset-lifecycle.md`
+- v1 Card Spec: `docs/KDNA_CARD_SPEC.md`
+- PR-1 (schemas): aikdna/kdna #86
+- PR-3 (gates): aikdna/kdna-studio-core #3
+- PR-4 (lifecycle smoke): aikdna/kdna-lab #3
+- PR-4b (default synthesis): aikdna/kdna-lab #4
+- aikdna/kdna-lab PR-4 audit note: `docs/audits/pr-4-acceptance.md`
+- aikdna/kdna-lab PR-4b audit note: `docs/audits/pr-4b-acceptance.md`

--- a/specs/RFC-0015-runtime-trace-v2.md
+++ b/specs/RFC-0015-runtime-trace-v2.md
@@ -1,0 +1,314 @@
+# RFC-0015: Runtime Trace Spec v2
+
+**Status:** Draft
+**Proposed:** 2026-06-16
+**Authors:** KDNA Maintainers
+**Supersedes:** (none — extends `docs/kdna-trace.md` v1)
+**Related:**
+- RFC-0013 (`specs/RFC-0013-judgment-asset-lifecycle.md`) — the
+  lifecycle that introduces SAG, TC, IMM
+- RFC-0014 (`specs/RFC-0014-kdna-card-v2.md`) — Card v2 (companion
+  RFC; the Card and Trace v2 proposals are designed together)
+- `docs/kdna-trace.md` — kdna trace command (Implemented; **not
+  replaced** by this RFC)
+- `specs/judgment-trace-schema.json` (existing)
+- `specs/evidence-trace.schema.json` (existing)
+- aikdna/kdna-lab PR #3 (PR-4 lifecycle smoke)
+- aikdna/kdna-lab PR #4 (PR-4b default synthesis migration)
+
+---
+
+## Abstract
+
+RFC-0013's lifecycle emits trace events at every stage from
+S1_source_intake through S11_eval. PR-4 and PR-4b together
+demonstrated that 11 (PR-4) and 6 (PR-4b) trace events are
+sufficient to audit a domain's lifecycle end-to-end, and that
+each event must carry `sag_version` and `tc_status` so a consumer
+can read any single event and know which SAG/TC was governing
+the domain at the time.
+
+RFC-0015 formalizes the runtime trace event shape that PR-4 and
+PR-4b proved, **without** changing the on-disk format of the
+existing `docs/kdna-trace.md` command or the existing
+`specs/judgment-trace-schema.json`. The existing trace command and
+its reader remain valid; v2 adds **lifecycle** trace events on top
+of the existing **judgment-call** trace events.
+
+This RFC is **detail-schema only**. It does not re-litigate the
+lifecycle architecture, the WorkPack boundary, or the
+anti-monolithic principle.
+
+---
+
+## 1. Motivation
+
+PR-4 and PR-4b together produced two real-world trace event
+streams:
+
+- **PR-4 (explicit SAG/TC smoke)** — 11 lifecycle trace events
+  covering S1..S11 for a hand-written fixture, each enriched with
+  `sag_version: "sag_code_review_2026_06_16"` and
+  `tc_status: "locked"`.
+- **PR-4b (default synthesis migration smoke)** — 6 lifecycle
+  trace events covering S1..S6 (synthesize, lock, strict-compile,
+  payload-check, eval), each enriched with
+  `sag_version: "sag_synth_<domain>_<hash>"` and
+  `tc_status: "synthesized"` or `"locked"` depending on the
+  stage.
+
+Both streams agreed on a minimum set of fields per event:
+`trace_id`, `timestamp`, `stage`, `domain_id`, `kdna_version`,
+`sag_version`, `tc_status`, `payload`. PR-4b additionally required
+migration-specific fields (`migration_mode`, `synthesis_status`,
+`lock_status`, `runtime_payload_leaked`).
+
+These two streams are the basis for the v2 spec. The v1 trace
+command (`docs/kdna-trace.md`) is **not** replaced; it remains the
+read-side API for the judgment-call trace, and v2 lifecycle
+events are a separate stream that lives next to it.
+
+---
+
+## 2. Boundary: what Runtime Trace v2 MUST NOT carry
+
+The following authoring-time objects are **never** embedded in
+any v2 trace event, in any form:
+
+- The full `source_authority.json` (SAG) object. Only the SAG
+  identity (`sag_id`, stored as `sag_version`) is carried.
+- The full `truth_charter.json` (TC) object. Only the TC's
+  `tc_status` value is carried.
+- The full `module_manifest.json` (IMM) object. Not present on the
+  trace at all.
+
+These objects **may** appear in the provenance report (already
+produced by kdna-studio-core) and in audit sidecar logs, but NOT on
+runtime trace events. The trace is the highest-volume, lowest-
+latency channel; a v2 trace that embedded the full SAG/TC would
+defeat PR-3's compile-time boundary and would let any consumer
+recover authoring-time details from runtime telemetry.
+
+**Test for the boundary:** if removing a field from a v2 trace
+event would force a consumer to lose the ability to detect a
+governance change, the field belongs on the Card (RFC-0014), not
+on the trace.
+
+---
+
+## 3. v2 trace event shape (additive over v1)
+
+v1 trace events continue to be produced and consumed by
+`docs/kdna-trace.md` and `specs/judgment-trace-schema.json`. RFC-0015
+adds a parallel `lifecycle_trace.jsonl` stream with the shape
+below:
+
+```json
+{
+  "trace_id": "trace_<stage>_<yyyy_mm_dd>_<rand>",
+  "timestamp": "ISO-8601",
+  "stage": "S<n>_<name>",
+  "domain_id": "@aikdna/code_review",
+  "kdna_version": "0.8.0-draft.1",
+  "sag_version": "sag_<domain>_<yyyy_mm_dd>",
+  "tc_status": "synthesized" | "draft" | "locked" | "deprecated",
+  "payload": { ... }
+}
+```
+
+### 3.1 Required fields (v2 minimum)
+
+| Field | Type | Required | Source of value |
+|-------|------|----------|-----------------|
+| `trace_id` | string | yes | `crypto.randomUUID()` or equivalent |
+| `timestamp` | string (ISO-8601) | yes | event emission time, UTC |
+| `stage` | enum (see §3.3) | yes | lifecycle stage the event represents |
+| `domain_id` | string | yes | the domain this event describes |
+| `kdna_version` | string | yes | the domain version being compiled/loaded |
+| `sag_version` | string \| null | yes (or null if no SAG) | `sag_id` of the SAG governing this event, or `null` when no SAG was supplied |
+| `tc_status` | string \| null | yes (or null if no TC) | `"synthesized"` / `"draft"` / `"locked"` / `"deprecated"` / `null` |
+| `payload` | object | yes | stage-specific structured data; see §3.4 |
+
+`payload` is **not** free-form. Each stage has a documented
+payload schema (see §3.4). v1 free-form payloads are still
+accepted by the existing v1 reader; v2 readers are encouraged to
+validate the payload against the per-stage schema.
+
+### 3.2 Migration-specific fields (added in v2)
+
+For events that involve a migration (PR-4b path), the following
+fields MUST be present alongside the v2 minimum:
+
+| Field | Type | When |
+|-------|------|------|
+| `migration_mode` | enum (`"none"` / `"explicit"` / `"synthesized"`) | always |
+| `synthesis_status` | enum (`"not_synthesized"` / `"synthesized"` / `"locked"`) | when migration_mode != "none" |
+| `lock_status` | enum (`"not_locked"` / `"locked"` / `"synthesized_then_human_locked"`) | when a TC exists |
+| `runtime_payload_leaked` | array of strings | always (empty array when clean) |
+
+The `runtime_payload_leaked` field is a defensive assertion: the
+trace event itself asserts that the SAG/TC/IMM were NOT included
+in the runtime payload. A non-empty value is a smoke-failure
+signal.
+
+### 3.3 Lifecycle stage enum
+
+The `stage` field is one of the following fixed values. The
+ordering is the canonical 11-stage lifecycle (RFC-0013 §2):
+
+```
+S1_source_intake
+S2_sag_load
+S3_tc_load
+S4_imm_load
+S5_human_lock
+S6_compile
+S7_pack
+S8_publish
+S9_match
+S10_load
+S11_eval
+```
+
+A migration smoke emits a subset of these stages. The minimum
+emission set per compile is `S6_compile` (always emitted), and
+the migration-mode determines whether `S1..S5` are emitted by the
+synthesizer (PR-4b) or by the explicit-authoring pipeline (PR-4).
+
+### 3.4 Per-stage payload schema (informative)
+
+| Stage | Required payload fields |
+|-------|--------------------------|
+| `S1_source_intake` | `source` (string): path or pointer to the source workspace |
+| `S2_sag_load` | `sag_id` (string), `source_count` (int), `current_highest_count` (int) |
+| `S3_tc_load` | `tc_id` (string), `tc_status` (string), `locked_by` (string or null) |
+| `S4_imm_load` | `module_count` (int), `internal_module_count` (int), `reference_count` (int) |
+| `S5_human_lock` | `total_cards` (int), `locked_cards` (int), `by` (string) |
+| `S6_compile` | `strict_authority` (bool), `sag_status` (enum), `tc_status` (enum), `sag_errors` (int), `tc_errors` (int) |
+| `S7_pack` | `file_count` (int), `payload_kdnab_digest` (string or null), `kdna_json_digest` (string or null) |
+| `S8_publish` | `domain_id` (string), `version` (string), `registry_action` (string or null) |
+| `S9_match` | `axioms_loaded` (int), `frameworks_loaded` (int), `terminology_loaded` (int), `trigger_signals` (array of strings) |
+| `S10_load` | `contract` (string), `emit_kind` (string), `axioms_emitted` (int) |
+| `S11_eval` | `trace_event_count` (int), `gate_status_combined` (string) |
+
+The per-stage payload schemas are **informative** in this RFC.
+A future implementation RFC may choose to formalize them as
+JSON Schemas (analogous to `specs/judgment-trace-schema.json`).
+
+---
+
+## 4. v2 trace reader contract
+
+A consumer that wants to read the v2 lifecycle stream should be
+able to:
+
+1. Identify the trace events for a specific `domain_id` and
+   `kdna_version`.
+2. Order them by `timestamp`.
+3. Inspect `sag_version` and `tc_status` on any single event
+   without reading the full SAG/TC object.
+4. Detect a governance change between two events by watching for
+   `sag_version` flips.
+5. Detect a runtime payload leak by reading
+   `runtime_payload_leaked`.
+
+The existing `docs/kdna-trace.md` v1 reader does not need to
+change to support v2. v2 readers are a separate concern (a
+follow-up RFC will likely propose a `kdna-lab-trace` reader that
+emits v2 lifecycle events).
+
+---
+
+## 5. Migration: coexistence with v1
+
+v1 and v2 trace events are produced by **different parts** of the
+toolchain:
+
+- v1: `kdna trace` command (kdna-cli, line 47 of
+  `docs/kdna-trace.md`). Records which KDNA domains were loaded by
+  which agent for which task.
+- v2: the compile / load / lifecycle pipeline (kdna-studio-core
+  compile, kdna-lab smoke). Records which lifecycle stages
+  occurred and which SAG/TC version was governing each.
+
+The two streams are **independent**: a domain can have v1 events
+without v2 events (a pre-RFC-0013 load), and vice versa. A
+consumer that wants both must read both files.
+
+The v2 stream is written to `lifecycle_trace.jsonl` next to
+`trace.jsonl` (the v1 stream). Future tooling may consolidate the
+two, but RFC-0015 does not require it.
+
+---
+
+## 6. Relationship to PR-4 and PR-4b
+
+PR-4 and PR-4b are the source of truth for the v2 field shape.
+The 11 events PR-4 emits, and the 6 events PR-4b emits, are the
+v2 minimum field set plus per-stage payloads. The migration-
+specific fields (`migration_mode`, `synthesis_status`,
+`lock_status`, `runtime_payload_leaked`) are added in PR-4b and
+formalized in this RFC.
+
+A future kdna-studio-core release that adopts this RFC will emit
+the same v2 fields. A future kdna-lab smoke that adopts this RFC
+will assert the same v2 fields. Until those future releases
+land, PR-4 and PR-4b remain the only producers and consumers of
+v2 events.
+
+---
+
+## 7. Non-Goals (Restated for Clarity)
+
+This RFC explicitly does **not**:
+
+- ❌ Define a new implementation of the trace command. This RFC
+  is **schema only**.
+- ❌ Modify `docs/kdna-trace.md` (v1). v1 remains valid.
+- ❌ Modify `specs/judgment-trace-schema.json`. v1 judgment-call
+  trace schema remains valid.
+- ❌ Modify the kdna-lab trace checker (`kdna_lab/trace_check.py`).
+  The checker is for v1 traces; v2 checker is a follow-up.
+- ❌ Define an enterprise audit log. Enterprise audit is
+  Governance track; v2 only adds per-event status fields.
+- ❌ Define judgment-contamination detection. Contamination is
+  Application track and depends on RFC-0015 + future Cluster
+  Runtime RFC; out of scope here.
+- ❌ Embed full SAG/TC/IMM in trace events. See §2.
+- ❌ Define a new lifecycle stage enum entry. The 11 stages
+  (S1..S11) are fixed in RFC-0013 §2; v2 does not add stages.
+
+---
+
+## 8. Acceptance Criteria
+
+This RFC is considered **Accepted → Implemented** when:
+
+1. A kdna-studio-core release emits the v2 lifecycle trace
+   events.
+2. A consumer (follow-up PR) can read the v2 events using only
+   the v2 minimum field set.
+3. The `migration_mode` / `synthesis_status` / `lock_status` /
+   `runtime_payload_leaked` fields are exercised by a kdna-lab
+   smoke (PR-4b already produces them).
+4. v1 trace command (`docs/kdna-trace.md`) and v1 judgment-trace
+   schema (`specs/judgment-trace-schema.json`) are **unchanged**
+   and **still work** for existing consumers.
+5. A consumer that wants the full SAG/TC/IMM cannot recover them
+   from the v2 trace (the boundary in §2 holds).
+
+---
+
+## 9. References
+
+- RFC-0013: `https://github.com/aikdna/kdna/blob/main/specs/RFC-0013-judgment-asset-lifecycle.md`
+- RFC-0014: `https://github.com/aikdna/kdna/blob/main/specs/RFC-0014-kdna-card-v2.md`
+- v1 trace command: `docs/kdna-trace.md`
+- v1 judgment-trace schema: `specs/judgment-trace-schema.json`
+- v1 evidence-trace schema: `specs/evidence-trace.schema.json`
+- PR-1 (schemas): aikdna/kdna #86
+- PR-3 (gates): aikdna/kdna-studio-core #3
+- PR-4 (lifecycle smoke): aikdna/kdna-lab #3
+- PR-4b (default synthesis): aikdna/kdna-lab #4
+- aikdna/kdna-lab PR-4 audit note: `docs/audits/pr-4-acceptance.md`
+- aikdna/kdna-lab PR-4b audit note: `docs/audits/pr-4b-acceptance.md`


### PR DESCRIPTION
## RFC-0013 Implementation — Phase 2 (RFC-0014 / RFC-0015 Drafts)

This PR files **two Draft RFCs** in the `aikdna/kdna` meta repo to close RFC-0013 §9 #6 (RFC-0014 and RFC-0015 filed as separate Draft RFCs).

**This PR is docs only.** It does not implement Card v2 or Trace v2 in code. Per work plan §4.3 Phase 2, both RFCs are scope-limited to detail-schema only.

## What's in this PR

### `specs/RFC-0014-kdna-card-v2.md` (new, ~270 lines)

KDNA Card Spec v2. Adds seven fields to the existing v1 Card (additive, no deprecation):
- `sag_summary` — SAG identity + counts, never the source list
- `tc_summary` — TC identity + non-sensitive aggregates, never the full content
- `module_summary` — module counts only, never the per-module `maps_to` paths
- `authority_status` — flat enum: `none` / `declared_only` / `human_locked` / `synthesized_then_human_locked` / `author_confirmation_only`
- `truth_charter_status` — flat enum: `draft` / `synthesized` / `locked` / `deprecated`
- `migration_status` — flat enum: `human_authored` / `synthesized` / `synthesized_then_human_locked` / `mixed`
- `source_disclosure_level` — flat enum: `summary` (default) / `audit_only` / `none`

**Boundary** (Card v2 MUST NOT carry):
- Full `source_authority.json` (no per-source entries)
- Full `truth_charter.json` (no `core_insight`, no `forbidden_simplifications`, no `anti_drift_rules`, no `locked_by` / `locked_at`)
- Full `module_manifest.json` (no per-module details)

### `specs/RFC-0015-runtime-trace-v2.md` (new, ~250 lines)

Runtime Trace Spec v2. Adds a parallel `lifecycle_trace.jsonl` stream next to the existing v1 `trace.jsonl`:

**v2 minimum fields** (every event):
- `trace_id`, `timestamp`, `stage`, `domain_id`, `kdna_version`
- `sag_version` (or `null` if no SAG) — the SAG id, never the full SAG
- `tc_status` (or `null` if no TC) — the TC's `tc_status` value
- `payload` — per-stage structured data

**Migration-specific fields** (added in v2 for the PR-4b path):
- `migration_mode` (`none` / `explicit` / `synthesized`)
- `synthesis_status` (`not_synthesized` / `synthesized` / `locked`)
- `lock_status` (`not_locked` / `locked` / `synthesized_then_human_locked`)
- `runtime_payload_leaked` (array of strings; empty when clean)

**Lifecycle stage enum** (fixed at 11 values from RFC-0013 §2):
```
S1_source_intake, S2_sag_load, S3_tc_load, S4_imm_load,
S5_human_lock, S6_compile, S7_pack, S8_publish,
S9_match, S10_load, S11_eval
```

**Boundary** (Trace v2 MUST NOT carry): full SAG / TC / IMM. The trace is the highest-volume, lowest-latency channel; embedding the full authoring-time objects there would defeat PR-3's compile-time boundary.

### `docs/rfc-status.md` (modified)

- Added `RFC-0014` and `RFC-0015` rows to the RFC Index.
- Added two progress bars to the Current State diagram.
- Added a status note on `RFC-0013` clarifying that the implementation acceptance criteria are now covered but the public status remains `Draft` until external review and approval. **RFC-0013 itself is NOT promoted to `Accepted` or `Implemented`** in this PR.

### `docs/audits/phase-2-rfc-0014-0015-filing.md` (new, ~140 lines)

Phase 2 filing note. Documents:
- Why these RFCs can be filed now (PR-1~4b implementation feedback)
- What this PR does NOT do (intentional non-goals)
- Dependency evidence (PRs #86, #10, #87, kdna-studio-core #3, kdna-lab #3, kdna-lab #4)
- The PR-1~4b feedback that drove each v2 design decision

## Why this PR can be filed now

Per work plan §4.2 PR-4 boundary, RFC-0014 and RFC-0015 must wait for PR-1~4b implementation feedback. That feedback is now complete:

- **PR-4** produced 11 lifecycle trace events with `sag_version` and `tc_status` on every event → RFC-0015 §1 motivation.
- **PR-4b** produced 6 lifecycle trace events plus migration-specific fields → RFC-0014 §6 and RFC-0015 §3.2.
- **PR-3** proved the runtime payload does not leak authoring-time objects → RFC-0014 / RFC-0015 §2 boundary.
- **PR-1** schemas are unchanged; v2 is additive → no breaking change to existing consumers.

## What's NOT in this PR (per work plan §4.3 Phase 2 boundary)

- ❌ No implementation of Card v2 or Trace v2 in code
- ❌ No runtime payload changes
- ❌ No schema changes (the existing PR-1 schemas are unchanged)
- ❌ No changes to `kdna-cli` / `kdna-studio-core` / `kdna-lab`
- ❌ No atomspeak / book-derived domain smoke (deferred to PR-5)
- ❌ No fix of `kdna-studio-core`'s 11 pre-existing test failures (out of scope for the RFC-0013 series; see PR-3 audit note)
- ❌ No marketplace / enterprise / privacy / WorkPack
- ❌ No changes to existing v1 trace command (`docs/kdna-trace.md`) or v1 judgment-trace schema (`specs/judgment-trace-schema.json`). v1 remains valid; v2 is additive.

## Files

| File | Change | Lines |
|------|--------|-------|
| `specs/RFC-0014-kdna-card-v2.md` | new | +368 |
| `specs/RFC-0015-runtime-trace-v2.md` | new | +314 |
| `docs/audits/phase-2-rfc-0014-0015-filing.md` | new | +160 |
| `docs/rfc-status.md` | modified (RFC-0014/0015 rows + current-state + status note) | +18 / -2 |

## RFC-0013 §9 acceptance criteria coverage (after this PR)

| # | Item | Status | Where |
|---|------|--------|-------|
| #1 | All three new schema files merged in `aikdna/kdna/schema/` | ✅ | PR-1 (#86) |
| #2 | `kdna dev validate --anti-monolithic` exists | ✅ | PR-2 (#10) |
| #3 | kdna-studio-core rejects (with clear error) on `strict-authority` violations | ✅ | PR-3 (#3) |
| #4 | kdna-lab smoke test on a simple official legacy domain | ✅ | PR-4 (#3) |
| #5 | SPEC §1.6 contains the Anti-Monolithic Domain Principle verbatim | ✅ | PR-2a (#87) |
| #6 | RFC-0014 and RFC-0015 are filed as separate Draft RFCs | ✅ | **this PR** |
| #7 | Migration run synthesizes default SAG/TC and produces valid `.kdna` | ✅ | PR-4b (#4) |

After this PR, **all 7 §9 acceptance criteria are now covered**. The implementation series is technically complete.

## On the public RFC-0013 status

Per the recommended external wording, `docs/rfc-status.md` explicitly states:

> RFC-0013 §9 acceptance criteria are now **technically covered** by the implementation series (PR-1 / PR-2 / PR-2a / PR-3 / PR-4 / PR-4b), plus the filing of RFC-0014 and RFC-0015 (this update). However, RFC-0013 is **not** promoted to `Accepted` or `Implemented` here. The public status remains `Draft` until external review and approval ratifies the implementation. The accurate external wording is: *"RFC-0013 implementation acceptance criteria are now covered; external approval / final status update pending."*

## Validation (manual grep; no CI for docs changes)

```
$ git show origin/main:specs/RFC-0014-kdna-card-v2.md | head -3
# RFC-0014: KDNA Card Spec v2.0
**Status:** Draft

$ git show origin/main:specs/RFC-0015-runtime-trace-v2.md | head -3
# RFC-0015: Runtime Trace Spec v2
**Status:** Draft

$ git show origin/main:docs/rfc-status.md | grep -E "RFC-001[45]"
| RFC-0014 | KDNA Card Spec v2 | **Draft** | ...
| RFC-0015 | Runtime Trace Spec v2 | **Draft** | ...
```

## Reviewer notes

- **No review submissions; admin merge only.** This PR was opened by a maintainer and will be admin-merged to unblock the RFC-0013 implementation series. Independent review is welcome in the form of follow-up PRs against `main`.
- **No workflow runs found on this PR yet** — `aikdna/kdna` does not appear to have a CI workflow configured for this branch's docs changes. Local `grep` checks are the only test signal.

## References

- RFC-0013: `https://github.com/aikdna/kdna/blob/main/specs/RFC-0013-judgment-asset-lifecycle.md`
- RFC-0013 §7: declares RFC-0014 / RFC-0015 as companion Drafts
- RFC-0013 §9: acceptance criteria, now all covered after this PR
- Work plan: `Kdna内部思考/KDNA 协议升级工作计划 2026-06-16.md` §4.3
- Predecessors: aikdna/kdna #86 (PR-1), aikdna/kdna-cli #10 (PR-2), aikdna/kdna #87 (PR-2a), aikdna/kdna-studio-core #3 (PR-3), aikdna/kdna-lab #3 (PR-4), aikdna/kdna-lab #4 (PR-4b)