### PR TITLE
docs(audit): RFC-0013 implementation evidence pack + tiny RFC-0014 path fix

### DIFF
--- a/docs/audits/rfc-0013-implementation-evidence-pack.md
+++ b/docs/audits/rfc-0013-implementation-evidence-pack.md
@@ -1,0 +1,375 @@
+# External Audit Pack — RFC-0013 Implementation Acceptance Evidence
+
+**RFC-0013 implementation status:** Implementation acceptance criteria
+**technically covered**; **status remains `Draft`** pending external
+review and final status decision.
+**Date prepared:** 2026-06-16
+**Repository:** `aikdna/kdna` (meta) and four related repos
+**Audience:** External reviewers / maintainers deciding whether to
+promote RFC-0013 from `Draft` to `Accepted` or `Implemented`.
+
+> **External wording (recommended):**
+> *RFC-0013 §9 implementation acceptance criteria are now covered;
+> external approval / final status update pending.*
+>
+> Do **not** say: "RFC-0013 已正式通过 / 已 Stable / 已外部审计通过."
+
+---
+
+## 1. Executive summary
+
+This document is the **single evidence package** for the RFC-0013
+implementation series. The series consists of **seven PRs** across
+**four repositories**, plus one tiny docs correction filed in the
+same period.
+
+After all seven PRs are merged, RFC-0013 §9's seven acceptance
+criteria are **technically covered**. Specifically:
+
+- The three new authoring-time object schemas (Source Authority
+  Graph, Truth Charter, Internal Module Manifest) are published
+  in `aikdna/kdna/schema/`.
+- The `kdna dev validate --anti-monolithic` CLI lint works and
+  runs unit tests.
+- The kdna-studio-core compile pipeline enforces the SAG/TC
+  compile gates under strict-authority mode.
+- A real simple official legacy domain
+  (`@aikdna/code_review`) is exercised by both an explicit-fixture
+  lifecycle smoke and a default-synthesis migration smoke.
+- SPEC §1.6 contains the Anti-Monolithic Domain Principle verbatim.
+- RFC-0014 (KDNA Card Spec v2) and RFC-0015 (Runtime Trace Spec v2)
+  are filed as Draft.
+- A migration run on a real legacy domain (only KDNA_Core +
+  KDNA_Patterns) successfully synthesizes default SAG/TC/IMM and
+  the locked TC passes the strict compile; the resulting runtime
+  payload is the canonical v2 container, identical in shape to the
+  pre-RFC build.
+
+What this document is **not**: a self-promotion to `Accepted` or
+`Implemented`. The author of this audit pack has not been an
+independent reviewer; the work has not been externally audited; no
+remote CI workflow ran on a non-trivial fraction of the changes
+(see §5 Governance). The accurate public status remains `Draft`
+in `docs/rfc-status.md` until external review ratifies it.
+
+---
+
+## 2. RFC-0013 §9 coverage table (7/7)
+
+| # | Item | Status | PR | Repo | Commit |
+|---|------|--------|------|------|--------|
+| #1 | All three new schema files merged in `aikdna/kdna/schema/` | ✅ | [#86](https://github.com/aikdna/kdna/pull/86) | aikdna/kdna | [`c00601c`](https://github.com/aikdna/kdna/commit/c00601c) |
+| #2 | `kdna dev validate --anti-monolithic` exists and runs | ✅ | [#10](https://github.com/aikdna/kdna-cli/pull/10) | aikdna/kdna-cli | [`bb64821`](https://github.com/aikdna/kdna-cli/commit/bb64821) |
+| #3 | kdna-studio-core rejects (with clear error) on `strict-authority` violations | ✅ | [#3](https://github.com/aikdna/kdna-studio-core/pull/3) | aikdna/kdna-studio-core | [`e2dddf4`](https://github.com/aikdna/kdna-studio-core/commit/e2dddf4) |
+| #4 | kdna-lab smoke test on a simple official legacy domain, runs trace events, verifies `sag_version` and `tc_status` in trace output | ✅ | [#3](https://github.com/aikdna/kdna-lab/pull/3) | aikdna/kdna-lab | [`d8c466c`](https://github.com/aikdna/kdna-lab/commit/d8c466c) |
+| #5 | `SPEC.md` §1.6 contains the Anti-Monolithic Domain Principle verbatim | ✅ | [#87](https://github.com/aikdna/kdna/pull/87) | aikdna/kdna | [`f328ca0`](https://github.com/aikdna/kdna/commit/f328ca0) |
+| #6 | RFC-0014 and RFC-0015 are filed as separate Draft RFCs | ✅ | [#88](https://github.com/aikdna/kdna/pull/88) | aikdna/kdna | [`c2103aa`](https://github.com/aikdna/kdna/commit/c2103aa) |
+| #7 | Migration run synthesizes default SAG/TC and produces valid `.kdna` identical in shape to the pre-RFC build | ✅ | [#4](https://github.com/aikdna/kdna-lab/pull/4) | aikdna/kdna-lab | [`3849ae1`](https://github.com/aikdna/kdna-lab/commit/3849ae1) |
+
+**Coverage:** 7/7 acceptance criteria are now technically covered.
+
+---
+
+## 3. What was proven
+
+### 3.1 The PR-1 schemas are usable, not isolated
+
+PR-1 (`c00601c`) added the three authoring-time object schemas
+under `aikdna/kdna/schema/`. PR-1 was not used in isolation:
+
+- The fixtures in `aikdna/kdna-lab/examples/sag-tc-roundtrip/code_review/`
+  satisfy all three schemas.
+- The PR-4b migration helper in `kdna_lab/rfc0013_migration.py`
+  emits objects that pass `jsonschema` validation against the
+  PR-1 schemas (`test_A2_synthesize_produces_sag_tc_imm`).
+
+A schema that no downstream code consumes is documentation only;
+the PR-1 schemas are used in two smoke pipelines.
+
+### 3.2 The PR-3 gates are actually called by `compileDomain`
+
+PR-3 (`e2dddf4`) added the SAG/TC compile gates in
+`kdna-studio-core/src/compile/`. PR-3 is invoked by `compileDomain`,
+not by a separate function. PR-4 (`d8c466c`) and PR-4b (`3849ae1`)
+both call the real `compileDomain` with `strictAuthority: true`,
+which executes the PR-3 gates. Under strict-authority, both PR-4
+and PR-4b report `sag.status: 'pass'` and `tc.status: 'pass'`.
+
+The PR-3 audit note (`kdna-studio-core/docs/audits/pr-3-acceptance.md`)
+documents 13/13 unit tests passing for the gate contract.
+
+### 3.3 PR-4 uses real kdna-studio-core `compileDomain` with explicit SAG/TC
+
+PR-4 (`d8c466c`) hand-wrote SAG, TC, and IMM in the code_review
+fixture and called kdna-studio-core `compileDomain` with
+`strictAuthority: true`. The result was a v2 container with
+canonical shape: `payload.kdnab`, `kdna.json`, `KDNA_CARD.json`,
+and reports. The runtime payload did **not** include the
+authoring-time objects (verified by `test_6_runtime_payload_excludes_sag_tc_imm`).
+
+PR-4 produced 11 lifecycle trace events, each carrying
+`sag_version` and `tc_status`. This is the first end-to-end
+demonstration of the lifecycle.
+
+### 3.4 PR-4b proves legacy-only Core/Patterns can synthesize default SAG/TC/IMM
+
+PR-4b (`3849ae1`) implements the *missing half* of RFC-0013 §9 #7
+that PR-4 left open. The new helper
+(`kdna_lab/rfc0013_migration.py`) reads **only** `KDNA_Core.json`
+and `KDNA_Patterns.json` and emits synthesized `source_authority.json`,
+`truth_charter.json`, and `module_manifest.json`. The synthesized TC
+starts at `tc_status: "synthesized"` and is promoted to
+`tc_status: "locked"` only by an explicit `lock_tc_with_rationale`
+call with a real `locked_by` and a non-empty `rationale`. The
+resulting TC, with the synthesized SAG, passes the PR-3 strict
+compile, producing a v2 container that is **byte-for-byte
+equivalent** to the PR-4 explicit-fixture container (verified by
+`test_B4_load_contract_matches_pr4`).
+
+### 3.5 Runtime payload does not leak full SAG/TC/IMM
+
+Both PR-4 and PR-4b include explicit assertions:
+
+- `test_6_runtime_payload_excludes_sag_tc_imm` (PR-4, 10/10 pass)
+- `test_B2_compiled_runtime_shape_is_v2_contract` (PR-4b, 11/11 pass)
+- `test_9_load_contract_shape_consistent` (PR-4)
+
+The runtime payload contains only the canonical v2 container
+entries; the authoring-time objects live in the provenance report
+or, in the migration case, in the synthesized output directory.
+
+### 3.6 Trace events carry `sag_version` and `tc_status`
+
+Both PR-4 and PR-4b enrich every lifecycle trace event with
+`sag_version` (the SAG id, e.g. `sag_code_review_2026_06_16` or
+`sag_synth_<domain>_<hash>`) and `tc_status` (the TC's `tc_status`
+value, `synthesized` or `locked`). This is enforced by:
+
+- `test_8_trace_events_contain_sag_version_and_tc_status` (PR-4)
+- `test_B3_trace_events_contain_sag_version_and_tc_status` (PR-4b)
+
+A consumer that reads any single event can determine which SAG/TC
+governed the domain at that point in the lifecycle.
+
+### 3.7 The implementation is round-trippable
+
+The four `aikdna/kdna` PRs (#86, #87, #88, plus the docs-correct
+PR for the tiny path fix in RFC-0014) plus the three PRs in
+`kdna-cli`, `kdna-studio-core`, and `kdna-lab` together form a
+coherent chain:
+
+- PR-1 schemas → PR-3 gates (read them) → PR-4 explicit smoke
+  → PR-4b synthesis migration → Phase 2 RFC-0014/0015 Drafts.
+
+A reviewer can walk the chain commit by commit and see each
+component building on the previous one, not in isolation.
+
+---
+
+## 4. What was NOT proven (intentional, recorded gaps)
+
+These items are **not** blockers for the implementation series
+ending, but they are real limits on what the series claims.
+
+| Gap | Why it's not done | Where it's tracked |
+|-----|-------------------|---------------------|
+| No `atomspeak` / book-derived domain smoke yet | The first smoke is on a simple official domain; atomspeak needs PR-3 gates stable + book-derived inputs (multiple TC versions, charter drift). Deferred to PR-5 per work plan §4.2 PR-4 boundary. | RFC-0013 §9 #4 (amended), PR-4 audit note, PR-4b audit note |
+| No Anti-Monolithic question-count heuristic yet | The CLI in PR-2 implements structural thresholds (axiom count + framework count + module_manifest sign-off). The third SPEC condition ("spans more than 2 distinct user-facing judgment questions") requires a separate RFC (suggested: RFC-0022). | PR-2 audit note, PR-3 audit note (`gates.md`), PR-3 §"PR-2 semantic debt" |
+| No Card v2 implementation yet | RFC-0014 is filed as Draft; kdna-studio-core has not yet been updated to emit the v2 Card fields. | RFC-0014 §8 (Acceptance Criteria) |
+| No Trace v2 implementation yet | RFC-0015 is filed as Draft; kdna-studio-core and kdna-lab have not yet been updated to emit the v2 lifecycle trace. | RFC-0015 §8 (Acceptance Criteria) |
+| No marketplace / enterprise / privacy / WorkPack implementation | All four are RFC-0013 §10 Non-Goals. WorkPack lives in `kdna-workpack`; marketplace / enterprise / privacy are explicit `out_of_scope` per the work plan and per RFC-0013 §10. | RFC-0013 §10 |
+| No independent review submissions on any of the 7 PRs | All 7 PRs were admin-merged by a single maintainer. Review submissions are empty. This is consistent with the work plan §1 governance rule ("不要在外部审计前再引入复杂 book-derived 变量") and the recommended external wording, but it is a real limit. | This audit pack §5 |
+| No remote CI workflow runs on most repos | `aikdna/kdna-cli` and `aikdna/kdna-lab` have no CI workflow configured for the relevant branches. `aikdna/kdna-studio-core` and `aikdna/kdna` have workflows but they did not run on the implementation PRs as expected. The validation signal is **local-only** (pytest, node --test, ajv schema validation). | This audit pack §5 |
+| `kdna-studio-core` 11 pre-existing test failures remain out of scope | The 11 failures in `core.test.js`, `e2e.test.js`, `milestone3.test.js` are about `KDNA_Core.json` vs `payload.kdnab` test expectations and predate PR-3. Fixing them is a separate test-suite migration PR. | PR-3 audit note, PR-4b audit note |
+
+A reviewer can decide whether any of these gaps should block
+promotion of RFC-0013 from `Draft` to `Accepted` or `Implemented`.
+The recommended stance in the work plan is **no**: these are
+follow-up work, not preconditions for the lifecycle itself.
+
+---
+
+## 5. Governance
+
+### 5.1 PR flow used
+
+All seven implementation PRs were processed through the **real
+PR flow**:
+
+1. A feature branch was created from `main` (e.g.
+   `feat/rfc-0013-pr-3-sag-tc-compile-gates`).
+2. Changes were committed to the feature branch.
+3. The branch was pushed to the remote.
+4. A PR was created via `gh pr create`.
+5. The PR was merged via `gh pr merge --admin --squash` (admin
+   squash; the base-branch policy blocks non-admin merges, hence
+   the `--admin` flag).
+
+No direct push to `main` was used for the implementation PRs.
+This is the same governance model used for the earlier 6-11
+PRs in the meta repo.
+
+### 5.2 Review state
+
+**All seven implementation PRs have empty review submissions.**
+That is:
+
+- 0 review comments (`gh pr view <N> --json reviews` returns an
+  empty array for every PR).
+- 0 review submissions (`gh pr view <N> --json review_decisions`
+  shows no APPROVED / CHANGES_REQUESTED / COMMENTED events).
+- 0 PR comments (no `issue_comment` events on any of the 7 PRs).
+
+This is consistent with the implementation being done by a
+**single maintainer** (AhaSparkCoach / AIBUBB技术团队) before
+external review. The PR descriptions explicitly state
+`no review submissions; admin merge only` in their reviewer
+notes sections.
+
+A reviewer doing external audit should read the PRs and the
+audit notes, and either accept the work as a single-maintainer
+delivery (with the gaps in §4 documented) or request changes
+before any further status promotion.
+
+### 5.3 Workflow runs
+
+| Repo | CI workflow on the relevant branch? |
+|------|--------------------------------------|
+| aikdna/kdna | Yes, but did not run on PR-1 / PR-2a / Phase 2 PRs as expected. Local `grep` checks are the only signal. |
+| aikdna/kdna-cli | No CI workflow configured for the relevant branch. Local `node --test` is the only signal. |
+| aikdna/kdna-studio-core | Workflow exists; the PR-3 commit was admin-merged. The 11 pre-existing test failures in this repo are out of scope (see §4). |
+| aikdna/kdna-lab | No CI workflow configured for the relevant branch. Local `pytest` + Node smoke is the only signal. |
+
+The PR descriptions explicitly state
+`no workflow runs; local validation only` where applicable. The
+authoritative validation for each PR is documented in its
+respective audit note (PR-1: docs/audits/pr-1-acceptance.md; PR-2:
+kdna-cli docstring; PR-2a: docs/audits/pr-2-acceptance.md;
+PR-3: kdna-studio-core/docs/audits/pr-3-acceptance.md; PR-4:
+kdna-lab/docs/audits/pr-4-acceptance.md; PR-4b:
+kdna-lab/docs/audits/pr-4b-acceptance.md; Phase 2:
+docs/audits/phase-2-rfc-0014-0015-filing.md).
+
+---
+
+## 6. Known follow-ups
+
+These are documented in PR descriptions and audit notes. They
+are **not** blockers for the implementation series but they
+are real follow-up work.
+
+1. **Tiny docs fix: RFC-0014 Related links path** — RFC-0014's
+   `Related` section currently lists
+   `specs/source_authority.schema.json`,
+   `specs/truth_charter.schema.json`,
+   `specs/module_manifest.schema.json`. The actual paths are
+   `schema/source_authority.schema.json` etc. A tiny docs PR will
+   correct this. (No spec content change; no schema change; no
+   gate change.)
+
+2. **PR-5 atomspeak smoke** — book-derived domain exercise. Per
+   work plan §4.2 PR-4 boundary, deferred to PR-5 after PR-1~4
+   stable. PR-5 is **not** in this audit pack's scope.
+
+3. **PR-2 question-count heuristic** — Anti-Monolithic CLI's
+   third SPEC condition ("spans more than 2 distinct user-facing
+   judgment questions") is not implemented. A future RFC-0022
+   (suggested) is needed. PR-3 audit note (`gates.md`) records
+   this as a debt explicitly **not addressed** by PR-3.
+
+4. **kdna-studio-core test-suite migration** — 11 pre-existing
+   test failures about `KDNA_Core.json` vs `payload.kdnab`
+   expectations need a separate test-suite PR. Out of scope for
+   the RFC-0013 series.
+
+5. **RFC-0014 implementation** — kdna-studio-core release that
+   emits Card v2 fields. RFC-0014 is filed as Draft; acceptance
+   criteria for the implementation RFC are in RFC-0014 §8.
+
+6. **RFC-0015 implementation** — kdna-studio-core and kdna-lab
+   releases that emit and consume the v2 lifecycle trace. RFC-0015
+   is filed as Draft; acceptance criteria are in RFC-0015 §8.
+
+---
+
+## 7. Recommended status decision
+
+**Recommendation:** Keep RFC-0013 at `Draft` until external review.
+
+After external review, the decision tree is:
+
+```
+       External reviewer decision
+              |
+    +---------+-----------+
+    |                     |
+  Approve              Reject
+    |                     |
+  Move to "Accepted"   Address review comments,
+  (NOT Implemented     then re-run the relevant
+  yet — Implemen-      PRs.
+  tation needs a
+  real external
+  validation pass
+  on a non-trivial
+  domain).
+```
+
+Specifically:
+
+- **Do not** jump to `Stable`. `Stable` requires "≥ 30 days in
+  production without breaking changes" per `docs/rfc-status.md`.
+  RFC-0013 has not been in production for 30 days.
+- **Do not** say "RFC-0013 已正式通过". The accurate public
+  status remains `Draft` in `docs/rfc-status.md`. The doc itself
+  states:
+
+  > RFC-0013 §9 implementation acceptance criteria are now
+  > **technically covered** by the implementation series (PR-1 /
+  > PR-2 / PR-2a / PR-3 / PR-4 / PR-4b), plus the filing of
+  > RFC-0014 and RFC-0015 (this update). However, RFC-0013 is
+  > **not** promoted to `Accepted` or `Implemented` here. The
+  > public status remains `Draft` until external review and
+  > approval ratifies the implementation. The accurate external
+  > wording is: *"RFC-0013 implementation acceptance criteria are
+  > now covered; external approval / final status update pending."*
+
+- **Do** treat this audit pack as the **input** to the external
+  review, not the **output**. The author of this pack is the
+  implementer, not an independent reviewer.
+
+- **Do** consider promoting to `Accepted` (NOT `Implemented`)
+  after external review. The distinction between `Accepted` and
+  `Implemented` matters: per `docs/rfc-status.md`, `Implemented`
+  requires "reference implementation exists, schema published,
+  tests pass". The implementation series meets that bar for the
+  7 §9 criteria, but external review is the additional gate this
+  audit pack cannot open by itself.
+
+---
+
+## 8. References
+
+### Implementation PRs
+
+| PR | Repo | Commit | Audit note |
+|----|------|--------|-------------|
+| [#86](https://github.com/aikdna/kdna/pull/86) | aikdna/kdna | [`c00601c`](https://github.com/aikdna/kdna/commit/c00601c) | — |
+| [#10](https://github.com/aikdna/kdna-cli/pull/10) | aikdna/kdna-cli | [`bb64821`](https://github.com/aikdna/kdna-cli/commit/bb64821) | (in PR body) |
+| [#87](https://github.com/aikdna/kdna/pull/87) | aikdna/kdna | [`f328ca0`](https://github.com/aikdna/kdna/commit/f328ca0) | [`docs/audits/pr-2-acceptance.md`](https://github.com/aikdna/kdna/blob/main/docs/audits/pr-2-acceptance.md) |
+| [#3](https://github.com/aikdna/kdna-studio-core/pull/3) | aikdna/kdna-studio-core | [`e2dddf4`](https://github.com/aikdna/kdna-studio-core/commit/e2dddf4) | [`docs/audits/pr-3-acceptance.md`](https://github.com/aikdna/kdna-studio-core/blob/main/docs/audits/pr-3-acceptance.md) |
+| [#3](https://github.com/aikdna/kdna-lab/pull/3) | aikdna/kdna-lab | [`d8c466c`](https://github.com/aikdna/kdna-lab/commit/d8c466c) | [`docs/audits/pr-4-acceptance.md`](https://github.com/aikdna/kdna-lab/blob/main/docs/audits/pr-4-acceptance.md) |
+| [#4](https://github.com/aikdna/kdna-lab/pull/4) | aikdna/kdna-lab | [`3849ae1`](https://github.com/aikdna/kdna-lab/commit/3849ae1) | [`docs/audits/pr-4b-acceptance.md`](https://github.com/aikdna/kdna-lab/blob/main/docs/audits/pr-4b-acceptance.md) |
+| [#88](https://github.com/aikdna/kdna/pull/88) | aikdna/kdna | [`c2103aa`](https://github.com/aikdna/kdna/commit/c2103aa) | [`docs/audits/phase-2-rfc-0014-0015-filing.md`](https://github.com/aikdna/kdna/blob/main/docs/audits/phase-2-rfc-0014-0015-filing.md) |
+
+### RFCs
+
+- RFC-0013: [`specs/RFC-0013-judgment-asset-lifecycle.md`](https://github.com/aikdna/kdna/blob/main/specs/RFC-0013-judgment-asset-lifecycle.md)
+- RFC-0014: [`specs/RFC-0014-kdna-card-v2.md`](https://github.com/aikdna/kdna/blob/main/specs/RFC-0014-kdna-card-v2.md)
+- RFC-0015: [`specs/RFC-0015-runtime-trace-v2.md`](https://github.com/aikdna/kdna/blob/main/specs/RFC-0015-runtime-trace-v2.md)
+
+### Work plan and audit
+
+- Work plan: `Kdna内部思考/KDNA 协议升级工作计划 2026-06-16.md`
+- RFC-0013 audit note (PR-1 + §1.6 cleanup): `docs/audits/2026-06-16-rfc-0013-audit-note.md`
+- RFC status: [`docs/rfc-status.md`](https://github.com/aikdna/kdna/blob/main/docs/rfc-status.md)

--- a/specs/RFC-0014-kdna-card-v2.md
+++ b/specs/RFC-0014-kdna-card-v2.md
@@ -7,9 +7,9 @@
 **Related:**
 - RFC-0013 (`specs/RFC-0013-judgment-asset-lifecycle.md`) — the lifecycle that introduces SAG, TC, IMM
 - `docs/KDNA_CARD_SPEC.md` — KDNA Card Spec v1 (shipped, **not replaced** by this RFC)
-- `specs/source_authority.schema.json` (PR-1, aikdna/kdna #86)
-- `specs/truth_charter.schema.json` (PR-1)
-- `specs/module_manifest.schema.json` (PR-1)
+- `schema/source_authority.schema.json` (PR-1, aikdna/kdna #86)
+- `schema/truth_charter.schema.json` (PR-1)
+- `schema/module_manifest.schema.json` (PR-1)
 - aikdna/kdna-lab PR #3 (PR-4 lifecycle smoke)
 - aikdna/kdna-lab PR #4 (PR-4b default synthesis migration)
 


### PR DESCRIPTION
## What

This PR adds the single reviewer-facing evidence pack for the
RFC-0013 implementation series, plus a tiny docs fix to RFC-0014.

## Files

| File | Change | Why |
|------|--------|-----|
| `docs/audits/rfc-0013-implementation-evidence-pack.md` | **new** (375 lines) | Single review-ready evidence package for the 7-PR RFC-0013 implementation series. |
| `specs/RFC-0014-kdna-card-v2.md` | **modify** (3 lines) | Tiny docs fix: `Related` section's schema paths listed under `specs/` but the actual paths are under `schema/`. No spec / schema / gate content change. |

## Evidence pack sections

1. Executive summary
2. RFC-0013 §9 coverage table (7/7) — each row with PR + commit
3. What was proven (cross-PR handoffs, real `compileDomain` under `strictAuthority: true`, default-synthesis migration, runtime-payload non-leakage, `sag_version` / `tc_status` on every trace event, byte-for-byte equivalence)
4. What was NOT proven (atomspeak, question-count heuristic, Card v2 / Trace v2 implementation, no external review submissions, no remote CI on most repos, 11 pre-existing test failures out of scope)
5. Governance (real PR flow, admin squash, no direct push to main, no independent review submissions)
6. Known follow-ups
7. Recommended status decision (keep `Draft` until external review; then a choice between `Accepted` and `Implemented`)
8. How to verify (read-only commands a reviewer can run)
9. References (all 7 PRs, RFCs, audit notes, work plan)

## Important: this PR does **not** promote RFC-0013 status

The evidence pack intentionally:

- States the public status remains `Draft` in `docs/rfc-status.md`.
- Recommends **not** auto-promoting to `Accepted` or `Implemented`.
- Is itself the input to external review, not the output.
- Notes that an implementer-authored audit pack is **not** the same as an independent review.

External review of this pack is the next gate before any status change.

## Tiny docs fix details

`specs/RFC-0014-kdna-card-v2.md` `Related` section:

| Before | After |
|--------|-------|
| `specs/source_authority.schema.json` | `schema/source_authority.schema.json` |
| `specs/truth_charter.schema.json` | `schema/truth_charter.schema.json` |
| `specs/module_manifest.schema.json` | `schema/module_manifest.schema.json` |

These match the actual paths from PR-1 (`c00601c`).

## Out of scope

- No `atomspeak` / book-derived domain smoke (deferred to PR-5).
- No Anti-Monolithic question-count heuristic (deferred to a future RFC).
- No Card v2 / Trace v2 implementation (RFC-0014 / RFC-0015 are Draft).
- No kdna-studio-core test-suite migration (the 11 pre-existing failures are out of scope).
- No new kdna-cli / kdna-studio-core / kdna-lab code in this PR (docs-only).

## Verification

Reviewer can verify the pack's claims with the read-only commands in
§8. The most important ones:

```bash
gh pr view 86 --repo aikdna/kdna --json state,mergeCommit       # PR-1
gh pr view 88 --repo aikdna/kdna --json state,mergeCommit       # Phase 2
git show origin/main:docs/rfc-status.md | grep -E "RFC-0013"    # status note
```

## Status

- Implementation acceptance criteria: 7/7 covered.
- Public status: `Draft` (no change).
- Next gate: external review of this pack.