### PR TITLE
docs(audit): fix drift in RFC-0013 audit documents

### DIFF
--- a/docs/audits/2026-06-16-rfc-0013-audit-note.md
+++ b/docs/audits/2026-06-16-rfc-0013-audit-note.md
@@ -4,6 +4,49 @@ This document records facts about the RFC-0013 submission so that external
 auditors can verify what was done without re-deriving the chain of
 reasoning from commit history.
 
+## Subsequent Status Update — RFC-0013 Implementation Series (2026-06-16 evening)
+
+After the three commits in this note were pushed, the maintainer
+shipped the **RFC-0013 implementation series**: seven PRs across
+four repositories that turn RFC-0013 §9 from a design contract
+into a working pipeline. The full evidence is in
+`docs/audits/rfc-0013-implementation-evidence-pack.md`. Summary:
+
+- **PR-1** `c00601c` (aikdna/kdna #86) — three authoring-time
+  schemas (`source_authority` / `truth_charter` /
+  `module_manifest`) under `schema/`.
+- **PR-2** `bb64821` (aikdna/kdna-cli #10) — Anti-Monolithic CLI
+  lint (`src/cmds/anti-monolithic.js`) + 6 unit tests.
+- **PR-2a** `f328ca0` (aikdna/kdna #87) — `SPEC.md` §1.6.3
+  Anti-Monolithic Domain Principle.
+- **PR-3** `e2dddf4` (aikdna/kdna-studio-core #3) — SAG/TC
+  compile gates under `src/compile/`.
+- **PR-4** `d8c466c` (aikdna/kdna-lab #3) — RFC-0013 lifecycle
+  smoke on `@aikdna/code_review` (11 trace events, all carrying
+  `sag_version` + `tc_status`).
+- **PR-4b** `3849ae1` (aikdna/kdna-lab #4) — default SAG/TC
+  synthesis migration smoke (6 trace events, default → locked TC
+  flow). 11/11 pytest pass.
+- **Phase 2** `c2103aa` (aikdna/kdna #88) — files RFC-0014
+  (Card v2) and RFC-0015 (Trace v2) as Drafts.
+- **Evidence pack** `3509fd7` (aikdna/kdna #89) — this evidence
+  pack itself, plus the tiny RFC-0014 path fix (the only drift
+  fix that landed in the same PR).
+
+**All seven implementation PRs were processed through the real PR
+flow** (feature branch, push, `gh pr create`, `gh pr merge
+--admin --squash`). There was **no second direct-push bypass**;
+the one documented in this note's "Governance" section remains
+a single one-time event.
+
+**RFC-0013 public status remains `Draft`** in
+`docs/rfc-status.md`. The status note explicitly says
+*"RFC-0013 implementation acceptance criteria are now covered;
+external approval / final status update pending."*
+
+This note predates the implementation series; the authoritative
+post-series status is in the evidence pack linked above.
+
 ## External Audit Outcome (as of 2026-06-16)
 
 **Status:** PARTIALLY VERIFIED / NOT YET APPROVED
@@ -146,8 +189,15 @@ bash scripts/scan-repo-compliance.sh /Users/AI/K/OPEN
 
 ## References
 
-- Original spec upgrade proposal: `Kdna内部思考/kdna 升级 614建议/KDNA生态协议全方位审计与升级建议_v0.1.md` (1778 lines, 2026-06-14)
-- Original reverse-audit: `Kdna内部思考/kdna 升级 614建议/KDNA协议反审计_从极简沟通书稿到KDNA实践_v0.1.md` (500 lines, 2026-06-14)
+- Original spec upgrade proposal: internal work plan, 2026-06-14
+  (lives in the maintainer's personal internal-thinking space;
+  not in repo; originally titled
+  `KDNA生态协议全方位审计与升级建议_v0.1.md`, 1778 lines)
+- Original reverse-audit: internal work plan, 2026-06-14
+  (originally titled
+  `KDNA协议反审计_从极简沟通书稿到KDNA实践_v0.1.md`, 500 lines)
 - 6-12 doc upgrade (related but distinct): commit `bbc34e8` (local, NOT pushed)
 - PR #85 (foundation for `9b08997`): commit `4090180` on remote
 - Backup tag (3 stale local commits): `backup-before-reset`
+- Subsequent RFC-0013 implementation series: see
+  `docs/audits/rfc-0013-implementation-evidence-pack.md`

--- a/docs/audits/phase-2-rfc-0014-0015-filing.md
+++ b/docs/audits/phase-2-rfc-0014-0015-filing.md
@@ -12,7 +12,7 @@
 This PR files **two Draft RFCs** in the `aikdna/kdna` meta repo:
 
 - `specs/RFC-0014-kdna-card-v2.md` — KDNA Card Spec v2
-- `specs/RFC-015-runtime-trace-v2.md` — Runtime Trace Spec v2
+- `specs/RFC-0015-runtime-trace-v2.md` — Runtime Trace Spec v2
 
 These companion RFCs were declared in RFC-0013 §7:
 
@@ -153,7 +153,7 @@ None of these are in this PR.
 - RFC-0013 §7: declares RFC-0014 / RFC-0015 as companion Drafts
 - RFC-0013 §9: acceptance criteria, now all covered after this PR
 - PR-1 to PR-4b: implementation evidence (see §"Dependency evidence")
-- Work plan: `Kdna内部思考/KDNA 协议升级工作计划 2026-06-16.md` §4.3
+- Work plan: internal work plan, 2026-06-16 (not in repo; lives in the maintainer's personal internal-thinking space) §4.3
 - aikdna/kdna-lab PR-4 audit note: `docs/audits/pr-4-acceptance.md`
 - aikdna/kdna-lab PR-4b audit note: `docs/audits/pr-4b-acceptance.md`
 - aikdna/kdna-studio-core PR-3 audit note: `docs/audits/pr-3-acceptance.md` (PR-2 debt)

--- a/docs/audits/pr-1-acceptance.md
+++ b/docs/audits/pr-1-acceptance.md
@@ -129,6 +129,6 @@ this as the maintainer sign-off for keeping a domain monolithic.
 - RFC-0013 (design contract): `specs/RFC-0013-judgment-asset-lifecycle.md`
 - RFC-0013 §9 acceptance criteria (amended): now requires simple official
   domain for first smoke test, atomspeak deferred to PR-5
-- Work plan: `Kdna内部思考/KDNA 协议升级工作计划 2026-06-16.md` §4.2 PR-1
+- Work plan: internal work plan, 2026-06-16 (not in repo; lives in the maintainer's personal internal-thinking space) §4.2 PR-1
 - RFC-0013 audit note: `docs/audits/2026-06-16-rfc-0013-audit-note.md`
 - Existing schema validation pattern: `scripts/validate-app-schemas.js`

--- a/docs/audits/pr-2-acceptance.md
+++ b/docs/audits/pr-2-acceptance.md
@@ -154,7 +154,7 @@ $ echo $?
 - RFC-0013: `specs/RFC-0013-judgment-asset-lifecycle.md`
 - RFC-0013 §4: same file, "New Top-Level Principle: Anti-Monolithic Domain"
 - RFC-0013 §9 #2 and #5: same file, "Acceptance Criteria"
-- Work plan: `Kdna内部思考/KDNA 协议升级工作计划 2026-06-16.md` §4.2 PR-2
+- Work plan: internal work plan, 2026-06-16 (not in repo; lives in the maintainer's personal internal-thinking space) §4.2 PR-2
 - kdna-cli PR-2: https://github.com/aikdna/kdna-cli/pull/10
 - kdna-cli commit: `bb64821` (squash of cherry-picked `b87b53f`)
 - kdna PR-1 (PR-1 schema baseline): https://github.com/aikdna/kdna/pull/86

--- a/docs/audits/rfc-0013-implementation-evidence-pack.md
+++ b/docs/audits/rfc-0013-implementation-evidence-pack.md
@@ -121,10 +121,16 @@ and `KDNA_Patterns.json` and emits synthesized `source_authority.json`,
 starts at `tc_status: "synthesized"` and is promoted to
 `tc_status: "locked"` only by an explicit `lock_tc_with_rationale`
 call with a real `locked_by` and a non-empty `rationale`. The
-resulting TC, with the synthesized SAG, passes the PR-3 strict
-compile, producing a v2 container that is **byte-for-byte
-equivalent** to the PR-4 explicit-fixture container (verified by
-`test_B4_load_contract_matches_pr4`).
+rationale is **not** carried in the locked TC JSON file itself
+(because the PR-1 TC schema has `additionalProperties: false`); it
+is returned by the helper separately and lives in the caller's
+context. The resulting TC, with the synthesized SAG, passes the
+PR-3 strict compile, producing a v2 container whose compiled file
+set is **identical** to the PR-4 explicit-fixture container
+(set equality of compiled file names; byte-equal content is **not**
+asserted). This is verified by
+`test_B4_load_contract_matches_pr4` in
+`kdna-lab/tests/test_rfc0013_migration_synthesis.py`.
 
 ### 3.5 Runtime payload does not leak full SAG/TC/IMM
 
@@ -153,10 +159,10 @@ governed the domain at that point in the lifecycle.
 
 ### 3.7 The implementation is round-trippable
 
-The four `aikdna/kdna` PRs (#86, #87, #88, plus the docs-correct
-PR for the tiny path fix in RFC-0014) plus the three PRs in
-`kdna-cli`, `kdna-studio-core`, and `kdna-lab` together form a
-coherent chain:
+The four `aikdna/kdna` PRs (#86 PR-1, #87 PR-2a, #88 Phase 2,
+#89 evidence pack + tiny RFC-0014 path fix) plus the three PRs in
+`kdna-cli` (#10), `kdna-studio-core` (#3), and `kdna-lab` (#3 + #4)
+together form a coherent chain:
 
 - PR-1 schemas → PR-3 gates (read them) → PR-4 explicit smoke
   → PR-4b synthesis migration → Phase 2 RFC-0014/0015 Drafts.
@@ -259,13 +265,14 @@ are **not** blockers for the implementation series but they
 are real follow-up work.
 
 1. **Tiny docs fix: RFC-0014 Related links path** — RFC-0014's
-   `Related` section currently lists
+   `Related` section originally listed
    `specs/source_authority.schema.json`,
    `specs/truth_charter.schema.json`,
    `specs/module_manifest.schema.json`. The actual paths are
-   `schema/source_authority.schema.json` etc. A tiny docs PR will
-   correct this. (No spec content change; no schema change; no
-   gate change.)
+   `schema/source_authority.schema.json` etc. **Done in PR #89**
+   (alongside the evidence pack itself). RFC-0014 now correctly
+   references `schema/...`. (No spec content change; no schema
+   change; no gate change.)
 
 2. **PR-5 atomspeak smoke** — book-derived domain exercise. Per
    work plan §4.2 PR-4 boundary, deferred to PR-5 after PR-1~4
@@ -370,6 +377,6 @@ Specifically:
 
 ### Work plan and audit
 
-- Work plan: `Kdna内部思考/KDNA 协议升级工作计划 2026-06-16.md`
+- Work plan: internal work plan, 2026-06-16 (not in repo; lives in the maintainer's personal internal-thinking space)
 - RFC-0013 audit note (PR-1 + §1.6 cleanup): `docs/audits/2026-06-16-rfc-0013-audit-note.md`
 - RFC status: [`docs/rfc-status.md`](https://github.com/aikdna/kdna/blob/main/docs/rfc-status.md)


### PR DESCRIPTION
## What

Docs-only sweep to make the RFC-0013 audit trail reflect real
code and repo state. No code / schema / gate / RFC content
change. 5 files under `docs/audits/`, +76/-19.

## Files

| File | Change | Reason |
|------|--------|--------|
| `docs/audits/rfc-0013-implementation-evidence-pack.md` | **modify** (33 lines) | Audit pack now matches reality: "byte-for-byte equivalent" → "identical compiled file set", explicit PR #s (#86/#87/#88/#89), F1 follow-up flipped to "Done in PR #89", work plan path → internal-only. |
| `docs/audits/phase-2-rfc-0014-0015-filing.md` | **modify** (4 lines) | Typo `RFC-015` → `RFC-0015` (line 15); work plan path → internal-only. |
| `docs/audits/2026-06-16-rfc-0013-audit-note.md` | **modify** (54 lines) | Add "Subsequent Status Update" section at the top acknowledging the 7-PR implementation series that followed this note's three commits. Work plan paths → internal-only. |
| `docs/audits/pr-1-acceptance.md` | **modify** (2 lines) | Work plan path → internal-only. |
| `docs/audits/pr-2-acceptance.md` | **modify** (2 lines) | Work plan path → internal-only. |

## Drift summary (5 categories, all fixed)

1. **Factual inaccuracy:** Audit pack §3.4 claimed "byte-for-byte
   equivalent" between PR-4 and PR-4b runtimes. The actual test
   (`test_B4_load_contract_matches_pr4` in
   `kdna-lab/tests/test_rfc0013_migration_synthesis.py`) only
   asserts *set equality of compiled file names* — not byte-equal
   content. Wording now accurate.

2. **PR count ambiguity:** Audit pack §3.7 said "the four
   `aikdna/kdna` PRs (#86, #87, #88, plus the docs-correct PR
   for the tiny path fix in RFC-0014)". The path fix was actually
   part of #89, not a separate PR. Wording now lists all four
   PRs explicitly.

3. **Stale follow-up:** Audit pack §6 F1 said "Suggest a separate
   tiny docs-fix PR after external review" for the RFC-0014
   `specs/...` → `schema/...` path correction. The fix was
   actually merged in #89 (the same PR that added the evidence
   pack). F1 now reads "Done in PR #89".

4. **Broken / private path references:** 5 docs referenced
   `Kdna内部思考/KDNA 协议升级工作计划 2026-06-16.md` (and 2
   alternative names) — paths that do not exist in any repo and
   live in the maintainer's personal internal-thinking space.
   All replaced with "internal work plan, 2026-06-16 (not in
   repo)".

5. **Audit-trail staleness:** The earlier audit note
   (`2026-06-16-rfc-0013-audit-note.md`) was written BEFORE the
   7-PR implementation series merged. It only documents the
   three pre-series commits. A new "Subsequent Status Update"
   section at the top points readers to the evidence pack and
   the seven PRs that followed.

## Verification

All claims in the modified docs were cross-checked against
real code in all four repos:

- `schema/source_authority.schema.json` /
  `schema/truth_charter.schema.json` /
  `schema/module_manifest.schema.json` — confirmed present.
- `kdna-cli/src/cmds/anti-monolithic.js` — confirmed 192 lines
  with the 2-condition rule + module_manifest sign-off.
- `kdna-studio-core/src/compile/source-authority-gate.js` (R1-R5)
  and `truth-charter-gate.js` (R1-R6 + cross-file) — confirmed
  present.
- `kdna-lab/scripts/rfc0013_lifecycle_smoke.mjs` emits exactly
  11 trace events (S1-S11).
- `kdna-lab/scripts/rfc0013_migration_smoke.mjs` emits exactly
  6 trace events (S1-S6).
- `kdna-lab/tests/test_rfc0013_lifecycle_smoke.py` has tests
  `test_1` through `test_10`; the audit pack's reference to
  `test_8_trace_events_contain_sag_version_and_tc_status` is
  correct.
- `kdna-lab/tests/test_rfc0013_migration_synthesis.py` has
  tests `test_A1` through `test_A6` and `test_B1` through
  `test_B5`; the audit pack's references to
  `test_B2_compiled_runtime_shape_is_v2_contract`,
  `test_B3_trace_events_contain_sag_version_and_tc_status`,
  and `test_B4_load_contract_matches_pr4` are correct.
- 7 commit hashes (`c00601c`, `bb64821`, `f328ca0`, `e2dddf4`,
  `d8c466c`, `3849ae1`, `c2103aa`) all exist on the respective
  repos' `main` branches.
- `examples/sag-tc-roundtrip/code_review/` fixture in kdna-lab
  has all 5 expected files (KDNA_Core.json, KDNA_Patterns.json,
  module_manifest.json, source_authority.json, truth_charter.json).
- RFC-0013 line count is still 638 (matches older audit note).
- `kdna-studio-core` `npm test` shows `# fail 11` — matches the
  audit pack's "11 pre-existing test failures" claim.

## Out of scope

- No kdna-studio-core test-suite migration (the 11 pre-existing
  failures are still out of band; this is a docs sweep only).
- No RFC-0013 status promotion (still `Draft`).
- No follow-ups to PR-2 question-count heuristic, PR-5
  atomspeak, Card v2 / Trace v2 implementation — all unchanged
  in scope.

## Status

RFC-0013 remains `Draft`. RFC-0013 §9 implementation acceptance
criteria remain 7/7 covered. No code or status change.