### PR TITLE
docs(governance): add public documentation rules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,8 @@ KDNA is an open judgment protocol. Contributions can be:
 2. Read [State of KDNA](./STATE_OF_KDNA.md) — what's stable, what's not
 3. Check [open issues](https://github.com/aikdna/kdna/issues) — especially `good-first-kdna`
 
+Public documentation contributions (RFCs, specs, audit notes) must follow the [Public Documentation Rules](./docs/GOVERNANCE.md#9-public-documentation-rules) in GOVERNANCE.md.
+
 ## Quick Path
 
 ```bash

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -132,3 +132,139 @@ Security vulnerabilities: See [SECURITY.md](./SECURITY.md)
 Governance proposals: Open an issue in [aikdna/kdna](https://github.com/aikdna/kdna/issues)
 
 Registry moderation requests: Open an issue in [aikdna/kdna-registry](https://github.com/aikdna/kdna-registry/issues)
+
+## 9. Public documentation rules
+
+Public-facing documentation in this repository (`docs/`, `specs/`,
+`README.md`, `README.zh.md`, and public audit notes under
+`docs/audits/`) is read by external contributors, downstream
+consumers, and the open-source community. It MUST describe only
+public facts: published RFCs, merged PRs, public commit hashes on
+the remote, public issues, and accepted governance decisions.
+
+This section is the canonical rule. It is enforced by the
+pre-merge grep checklist at the end.
+
+### 9.1 What public documentation MUST NOT include
+
+Public-facing documentation MUST NOT include:
+
+- Internal file paths outside the repository (for example, paths
+  under a maintainer's local thinking space, private notes, or
+  any other private directory).
+- Private workspace paths or local machine paths (for example,
+  `/Users/<name>/...` or any other absolute path that reveals
+  the maintainer's local environment).
+- Internal work-plan section references (for example,
+  `Per the work plan §4.2 PR-3 boundary` or any other reference
+  to a private planning document's section numbering).
+- Internal planning document names, by file or by category.
+- Internal review document names, or finding numbers tied to
+  those documents (for example, references to a private
+  reverse-audit or upgrade-recommendations document, or
+  references to specific gaps / findings / items / F-numbers
+  defined only in those private documents).
+- Private conversation instructions or agent directives, in any
+  language, including direct quotes from maintainer or agent
+  instructions.
+- Personal names, personal book titles, or personal authoring
+  narratives in marketing, whitepaper, or audit documents,
+  unless they are already public metadata and necessary for
+  attribution.
+- Maintainer team identity in audit notes, unless already public
+  and necessary (use `the project maintainer` or `a single
+  maintainer`).
+- Local-only commit hashes that are not on the public remote.
+- Local backup tag names.
+- Unpublished roadmap decisions that are not already accepted
+  into an RFC, an open issue, or a merged PR.
+
+### 9.2 What public documentation SHOULD use
+
+Public-facing documentation SHOULD use:
+
+- Public RFC references (for example, `RFC-0013 §9 #4`).
+- Public PR references (for example, `PR-1 / PR-2 / PR-3 /
+  PR-4 / PR-4b` and the actual public PR number).
+- Public commit hashes on the remote (for example, the merge
+  commit SHA visible via `git log origin/main`).
+- Public issue links.
+- Neutral phrases such as:
+  - `RFC-0013 implementation scope`
+  - `RFC-0013 implementation boundary`
+  - `the RFC-0013 PR-N scope`
+  - `follow-up PR`
+  - `external review pending`
+  - `public status remains Draft`
+  - `public-facing status policy`
+  - `the public status policy`
+
+### 9.3 Examples
+
+**Bad (must not appear in public docs):**
+
+- `Work plan: Kdna内部思考/KDNA 协议升级工作计划 2026-06-16.md §4.2`
+- `Per the user's instruction`
+- `KDNA_STUDIO_CORE_PATH=/Users/AI/K/OPEN/kdna-studio-core`
+- `backup-before-reset` (a local backup tag, not pushed to origin)
+- `single maintainer (AhaSparkCoach / AIBUBB技术团队)`
+- `不要在外部审计前再引入复杂 book-derived 变量` (a directive
+  from a private conversation)
+- `atomspeak-kdna-v4.0` (a private version string on a public
+  reference domain)
+- `the反审计 file's 缺口三` (a reference to a private review
+  document's finding number)
+
+**Good (preferred public-facing wording):**
+
+- `RFC-0013 implementation scope: PR-3 SAG/TC compile gates`
+- `Per the public status policy`
+- `KDNA_STUDIO_CORE_PATH=/path/to/kdna-studio-core`
+- `a local backup tag (not pushed to origin)`
+- `single maintainer`
+- `Complex book-derived domain testing is deferred to a follow-up PR.`
+- `atomspeak` (without a private version string)
+- `an internal review's third finding` (a generic reference,
+  not a private document name or finding number)
+
+### 9.4 Required pre-merge grep checklist
+
+Before merging any PR that adds or modifies public-facing
+documentation, the contributor MUST run the following grep from
+the repository root and paste the output in the PR description:
+
+```bash
+grep -RIn \
+  -e "Kdna内部思考" \
+  -e "KDNA 协议升级工作计划" \
+  -e "Per the user's instruction" \
+  -e "用户指令" \
+  -e "等你指令" \
+  -e "不要在外部审计前" \
+  -e "/Users/AI/K" \
+  -e "AhaSparkCoach" \
+  -e "AIBUBB" \
+  -e "work plan" \
+  -e "Work plan" \
+  -e "反审计" \
+  -e "升级建议" \
+  -e "backup-before-reset" \
+  docs specs README.md README.zh.md 2>/dev/null
+```
+
+Notes on the checklist:
+
+- A non-empty grep result does not automatically block the PR.
+  Each hit MUST be either removed or explicitly justified as a
+  false positive in the PR description.
+- Public concept names (for example, `WorkPack` the KDNA
+  concept, or "WorkPack implementation") are not hits against
+  the `work plan` keyword and are allowed.
+- Synthetic example paths (for example, `/Users/me/.kdna` or
+  `/Users/alice/writing-samples/`) in clearly-marked template
+  or example code are allowed when they are obviously
+  synthetic. Real local paths (for example,
+  `/Users/<maintainer>/<project>/...`) are not.
+- A contributor who is uncertain whether a hit is a false
+  positive SHOULD default to rewording rather than rely on
+  the "obvious" exception.


### PR DESCRIPTION
## Summary

docs-only governance rule. No implementation change. No history rewrite. No status change.

This PR formalizes the public-facing documentation policy as
§9 of `docs/GOVERNANCE.md` and adds a single linking line in
`CONTRIBUTING.md`. The rule is intentionally aikdna/kdna-only
for now.

## What changed

| File | Change |
|------|--------|
| `docs/GOVERNANCE.md` | New section "9. Public documentation rules" (135 lines) covering: what public docs MUST NOT include, what they SHOULD use, Bad/Good examples, and a required pre-merge grep checklist. |
| `CONTRIBUTING.md` | One-line addition to the "Before You Start" section pointing contributors at the new rule. |

## Rule content (one-paragraph summary)

Public-facing documentation in this repo (`docs/`, `specs/`,
`README*`, public audit notes under `docs/audits/`) MUST
describe only public facts: published RFCs, merged PRs, public
commit hashes on the remote, public issues, and accepted
governance decisions. Internal paths, work-plan sections,
private review document names, private conversation
directives, personal authoring narratives, maintainer team
identity (unless already public and necessary), local-only
commit hashes, local backup tag names, and unpublished
roadmap decisions MUST NOT appear.

## Required pre-merge grep checklist — actual output

```bash
grep -RIn \
  -e "Kdna内部思考" \
  -e "KDNA 协议升级工作计划" \
  -e "Per the user's instruction" \
  -e "用户指令" \
  -e "等你指令" \
  -e "不要在外部审计前" \
  -e "/Users/AI/K" \
  -e "AhaSparkCoach" \
  -e "AIBUBB" \
  -e "work plan" \
  -e "Work plan" \
  -e "反审计" \
  -e "升级建议" \
  -e "backup-before-reset" \
  docs specs README.md README.zh.md
```

### Result (23 hits, all in `docs/GOVERNANCE.md`):

```
docs/GOVERNANCE.md:159:  `Per the work plan §4.2 PR-3 boundary` or any other reference
docs/GOVERNANCE.md:206:- `Work plan: Kdna内部思考/KDNA 协议升级工作计划 2026-06-16.md §4.2`
docs/GOVERNANCE.md:207:- `Per the user's instruction`
docs/GOVERNANCE.md:208:- `KDNA_STUDIO_CORE_PATH=/Users/AI/K/OPEN/kdna-studio-core`
docs/GOVERNANCE.md:209:- `backup-before-reset` (a local backup tag, not pushed to origin)
docs/GOVERNANCE.md:210:- `single maintainer (AhaSparkCoach / AIBUBB技术团队)`
docs/GOVERNANCE.md:211:- `不要在外部审计前再引入复杂 book-derived 变量` (a directive
docs/GOVERNANCE.md:215:- `the反审计 file's 缺口三` (a reference to a private review
docs/GOVERNANCE.md:238:  -e "Kdna内部思考" \
docs/GOVERNANCE.md:239:  -e "KDNA 协议升级工作计划" \
docs/GOVERNANCE.md:240:  -e "Per the user's instruction" \
docs/GOVERNANCE.md:241:  -e "用户指令" \
docs/GOVERNANCE.md:242:  -e "等你指令" \
docs/GOVERNANCE.md:243:  -e "不要在外部审计前" \
docs/GOVERNANCE.md:244:  -e "/Users/AI/K" \
docs/GOVERNANCE.md:245:  -e "AhaSparkCoach" \
docs/GOVERNANCE.md:246:  -e "AIBUBB" \
docs/GOVERNANCE.md:247:  -e "work plan" \
docs/GOVERNANCE.md:248:  -e "Work plan" \
docs/GOVERNANCE.md:249:  -e "反审计" \
docs/GOVERNANCE.md:250:  -e "升级建议" \
docs/GOVERNANCE.md:251:  -e "backup-before-reset" \
docs/GOVERNANCE.md:262:  the `work plan` keyword and are allowed.
```

### Justification for each hit

All 23 hits are in the new `docs/GOVERNANCE.md` §9 rule
definition itself. They fall into three categories, all of
which are intentional and required by the rule's pedagogical
purpose:

1. **Lines 159, 206–211, 215** — `Bad` examples in §9.3.
   The rule is required to show the exact bad patterns that
   are not allowed. Removing these would defeat the rule.

2. **Lines 238–251** — The pre-merge grep command itself in
   §9.4. The grep command is the canonical check; it must
   appear verbatim.

3. **Line 262** — The note explaining that `WorkPack` (the
   public KDNA concept) is not a hit against the `work plan`
   keyword. This note is a guidance for future contributors
   reading the grep output.

No hit represents actual internal content. The grep's purpose
is to catch new contributions; the rule document itself is
the source of the patterns.

## Out of scope (intentional)

- No rewrite of git history.
- No force push.
- No change to code, schema, gate, RFC content, or RFC-0013
  status.
- No change to PR links, merge commits, or test results.
- No new files outside the two already listed.
- No propagation to other aikdna/* repos in this PR. A
  follow-up may decide whether to share the same canonical
  rule across the other repos; for now the rule is
  aikdna/kdna-only as the meta repo.

## Files

- `docs/GOVERNANCE.md` (+135)
- `CONTRIBUTING.md` (+1)

Total: 2 files, +136 / -0.

## Subsequent steps (informational, not part of this PR)

- Optional follow-up: propagate the same rule to
  `aikdna/kdna-cli`, `aikdna/kdna-studio-core`, and
  `aikdna/kdna-lab` (or copy the rule into a shared
  `docs/architecture/public-documentation-rules.md` and
  link to it from each repo).
- Per the overall plan: after this PR lands, send the
  evidence pack to an external reviewer; defer PR-5 and
  question-count-heuristic work until external review
  completes.