### PR TITLE
feat(core): define KDNA Core v1 format baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,447 +1,97 @@
-# KDNA — The Open Judgment Standard for AI Agents
+# KDNA
 
-> **New to KDNA? → [Start Here](./docs/start-here.md)**
+> **KDNA is an open judgment-asset file format for packaging, encrypting, versioning, and loading human-authored judgment systems into AI systems.**
 >
-> This repo is part of the [KDNA ecosystem](https://github.com/aikdna). KDNA helps AI agents judge by explicit human standards.
+> **KDNA 是一种开放的判断资产文件格式，用于把人类编写的判断体系封装、加密、版本化，并加载到 AI 系统中使用。**
 
-> **Loading, composing, measuring, and trusting human judgment in agent workflows.**
+> New to KDNA? → [Start Here](./docs/start-here.md)
 >
-> [![npm](https://img.shields.io/npm/v/@aikdna/kdna-cli)](https://www.npmjs.com/package/@aikdna/kdna-cli) [![CI](https://github.com/aikdna/kdna/actions/workflows/validate.yml/badge.svg)](https://github.com/aikdna/kdna/actions/workflows/validate.yml) [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
+> This repo defines the **KDNA Core** file format and runtime loading contract. Tools, content, and distribution are external.
 
-Maintained by **AIKDNA** — the open ecosystem for the KDNA Protocol.
+[![npm](https://img.shields.io/npm/v/@aikdna/kdna-cli)](https://www.npmjs.com/package/@aikdna/kdna-cli) [![CI](https://github.com/aikdna/kdna/actions/workflows/validate.yml/badge.svg)](https://github.com/aikdna/kdna/actions/workflows/validate.yml) [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 
-**Build domains, tools, integrations — not parallel protocols.**
+## What is a KDNA file?
 
-## Start Here
+A `.kdna` file is a single, portable container that holds:
 
-KDNA v1.0-rc has five public paths:
+- a **public manifest** (`kdna.json`) — the asset's identity and metadata
+- a **judgment payload** (`payload.kdnab`) — the actual structured judgment data
+- optional **encryption envelope metadata** — to mark encrypted entries
+- optional **signatures** — author / publisher attestations over the payload
+- **version and lineage information** — for traceability across releases
+- a **runtime load contract** — describes how loaders may read the asset
+- optional **attachments** — supplementary files referenced from the payload
+- an optional **checksums file** — per-entry digests for integrity checks
 
-| You are | Start here | Success definition |
+`.kdna` files are produced by authors using a tool (e.g. KDNA Studio) and consumed by AI runtimes (e.g. KDNA Loader, KDNA CLI) or viewers (e.g. KDNA Viewer). The format itself is content-neutral — KDNA Core does not say what judgment is "good" or which assets are "trusted".
+
+## What KDNA Core defines
+
+KDNA Core is the format authority. It defines:
+
+- the **file format** (container layout, mimetype, required entries)
+- the **manifest schema** (`kdna.json` shape and required fields)
+- the **payload profile schema** (e.g. `judgment-profile-v1`)
+- the **encryption envelope metadata** (which entries are encrypted, key references)
+- the **signature and digest metadata** (signature references, digest algorithm)
+- the **version chain metadata** (lineage, judgment version, compatibility)
+- the **runtime loading contract** (load profiles, decryption requirements, token hints)
+
+## What KDNA Core does not define
+
+KDNA Core is **content-neutral**. It does not define:
+
+- **content quality** — what judgment is correct, complete, or high-value
+- **author trust** — whether an author is credible or endorsed
+- **official recommendations** — which assets should be used in production
+- **distribution** — registries, marketplaces, stores, public listings
+- **runtime policy** — what a loader should do with an asset at runtime (block, allow, warn)
+- **content governance** — moderation, takedown, ranking, certification
+
+These are concerns of **external** platforms and policies. KDNA Core supplies the verifiable primitives; everything else is out of scope.
+
+## Tools
+
+The KDNA format is implemented by external, independent tools. Phase 1 only requires a minimal CLI closed loop on the v1 format.
+
+| Tool | Role | Repo |
 | --- | --- | --- |
-| AI user | [5-minute guide](./docs/5-minute-guide.md) | See with/without KDNA judgment difference. |
-| Domain expert | [First domain walkthrough](./docs/first-domain-walkthrough.md) | Create and verify a first `.kdna` asset. |
-| Developer | [CLI reference](https://github.com/aikdna/kdna-cli) | Load and verify KDNA with the runtime CLI. |
-| Agent builder | [kdna-skills](https://github.com/aikdna/kdna-skills) | Integrate KDNA loading into an agent runtime. |
-| Registry operator | [Registry repo](https://github.com/aikdna/kdna-registry) | Run a registry that fails closed on trust errors. |
+| **KDNA Studio** | Authoring environment for human judgment | aikdna/kdna-studio-core |
+| **KDNA CLI** | Runtime control plane: inspect, validate, pack, unpack, load | aikdna/kdna-cli |
+| **KDNA Loader SDK** | Embeddable runtime loader for AI agents | aikdna/kdna-core |
+| **KDNA Viewer** | Read-only inspection and rendering of `.kdna` files | (see [docs/tools/](./docs/tools/)) |
 
-Current public release status: [State of KDNA](./STATE_OF_KDNA.md).
+## Examples
 
-KDNA is an open protocol for encoding domain judgment as structured, agent-loadable assets. It turns human-governed principles, boundaries, standards, and taste into portable `.kdna` files that AI agents can load, verify, compose, and evolve.
+See:
 
-> **Like a .doc carries a portion of knowledge, a .kdna file carries a portion of judgment — principles, boundaries, standards, and taste — for a specific domain.**
+- [`examples/minimal/`](./examples/minimal/) — the smallest valid `.kdna` source layout
+- [`samples/`](./samples/) — additional reference assets
+- [`fixtures/`](./fixtures/) — conformance and test fixtures
 
-A single `.kdna` asset represents one scoped judgment domain. Complex agent work can route and compose multiple `.kdna` assets into a KDNA Cluster, instead of flattening different judgment domains into one broad file.
-
-Prompt changes what AI says. RAG changes what AI can access. Tools change what AI can do.  
-**KDNA changes how AI judges within a domain.**
-
-> **Skill + KDNA** — Skills make agents capable. KDNA gives them judgment, taste, and standards. [Learn more →](./docs/kdna-and-ai-stack.md#4-kdna-vs-skill)
-
-## KDNA in 30 seconds
-
-KDNA is a file-based judgment framework that AI agents can load as a domain reference. It is not human judgment itself — like a .doc carries a portion of knowledge, a .kdna encodes a bounded set of domain-specific principles, boundaries, standards, and taste.
-
-It does not make an agent role-play an expert. It gives the agent an explicit framework to work within.
-
-- **Prompt** changes what AI says.
-- **RAG** changes what AI can access.
-- **Tools/Skills** change what AI can do.
-- **KDNA** changes how AI judges.
-
-## KDNA Ecosystem
+## Repository layout
 
 ```
-Source / Evidence
-notes · docs · works · interviews · feedback
-        │
-        ▼
-Authoring pipeline
-declare domain → distill candidates → Human Lock → compile
-        │
-        ▼
-Domain KDNA
-one scoped .kdna judgment asset
-        │
-        ▼
-Cluster / Route Policy
-compose multiple domain assets when the task needs more than one judgment lens
-        │
-        ▼
-Runtime Load
-Compatible clients · CLI · MCP · SDK · Agent adapters
-        │
-        ▼
-Trace / Review / Feedback
-record which judgment was used, what passed, what should evolve
-        │
-        ▼
-KDNA Evolution
-revise · test · sign · publish
+kdna/
+├── packages/             # kdna-core (loader), kdna-eval (scoring harness)
+├── schema/               # JSON Schemas for manifest, payload profile, checksums, ...
+├── docs/                 # Spec, architecture, guides
+│   ├── core/             # Phase 1: format baseline docs
+│   ├── tools/            # Per-tool documentation
+│   ├── examples/         # Example asset catalog
+│   └── guides/           # How-to guides
+├── examples/             # Reference `.kdna` source layouts
+├── samples/              # Larger reference assets
+├── fixtures/             # Conformance test fixtures
+├── conformance/          # Conformance test runner
+├── rfcs/                 # Accepted and proposed RFCs
+└── specs/                # Normative specifications
 ```
 
-`Work Pack = KDNA or KDNA Cluster + Skill + Template + Review Gate + Risk Policy`.
+## Versioning
 
-> **KDNA Work Pack** is an open packaging standard for reusable AI work capabilities. It combines KDNA judgment with skills, review gates, risk policies, and traces so agents can perform real work with explicit domain judgment. See [kdna-workpack](https://github.com/aikdna/kdna-workpack).
-
-> **KDNA is not a single app — it is an open protocol ecosystem for judgment assets.**
-> Studio creates and compiles domain KDNA, CLI verifies and runs KDNA, Registry distributes trusted KDNA, runtime routers compose clusters, and agents load the right judgment for the task.
-
-## Phase 2 — From Judgment Asset to Trusted Product
-
-KDNA v1.0-rc defined how judgment is encoded. **Phase 2** defines how judgment flows into real work:
-
-| Component | RFC | What it solves |
-|-----------|-----|----------------|
-| **Artifact Contract** | [RFC-0009](./specs/artifact-contract.md) | Standard envelope for any KDNA-governed output — identity, provenance, quality, trace, review |
-| **Fidelity Protocol** | [RFC-0010](./specs/fidelity-protocol.md) | Measures whether judgment actually transferred into the final artifact — blind A/B/C comparison with calibration anchors |
-| **WorkPack Pipeline** | [kdna-workpack](https://github.com/aikdna/kdna-workpack) | Multi-stage orchestration of Work Packs with DAG dependencies, parallel execution, and artifact flow |
-| **Product Runtime** | [RFC-0011](./docs/product-runtime.md) | Long-running product cycle — Schedule → Select → Generate → Deliver → Observe → Adapt — for coaching, learning, and wellness products |
-| **Registry Fidelity Gate** | [kdna-registry](https://github.com/aikdna/kdna-registry) | Fidelity evidence as a requirement for validated+ quality badges |
-| **SDK** | [@aikdna/kdna-artifact-engine](https://www.npmjs.com/package/@aikdna/kdna-artifact-engine) · [@aikdna/kdna-fidelity-core](https://www.npmjs.com/package/@aikdna/kdna-fidelity-core) | TypeScript reference implementations |
-| **CLI** | `kdna protocol validate` / `inspect` | Schema validation for all RFC artifacts |
-| **E2E Demo** | [kdna-lab](https://github.com/aikdna/kdna-lab) | Full protocol chain: load → pipeline → envelope → fidelity → result |
-
-> **Phase 2 architecture:** [docs/phase2-architecture.md](./docs/phase2-architecture.md) — integration matrix, data flow, and RFC status tracking.
-
-A `.kdna` asset is not created by writing JSON files. It is compiled by a
-Studio-compatible authoring pipeline that performs human confirmation,
-validation, canonicalization, identity generation, digest computation, signing,
-optional encryption, and provenance recording.
-
-## The KDNA Stack
-
-AIKDNA = the ecosystem / brand  
-KDNA Protocol = the open judgment protocol  
-KDNA Domain Asset = a portable domain judgment asset
-
-**Protocol first. Products are reference implementations.**
-
-KDNA Protocol is open. KDNA CLI is reference tooling. Compatible clients serve as reference implementations for loading and comparing judgment domains. Authoring environments serve as reference implementations for creating and locking domains. Third-party apps can implement the same runtime contract.
-
-## For whom
-
-| You are | Start here |
-|---------|-----------|
-| **AI user** who wants better judgment from the same model | [5-minute guide](./docs/5-minute-guide.md) — load domains, compare responses, see judgment differences |
-| **Domain expert** who wants to encode expertise as verifiable assets | [kdna-studio-cli](https://github.com/aikdna/kdna-studio-cli) — interview → cards → lock → test → export |
-| **Developer** integrating KDNA into agents or tools | [kdna-cli](https://github.com/aikdna/kdna-cli) · [kdna-core](https://www.npmjs.com/package/@aikdna/kdna-core) — install, validate, load, compare |
-| **Tool builder** adding KDNA support to editors/IDEs | [kdna-vscode](https://github.com/aikdna/kdna-vscode) · [kdna-skills](https://github.com/aikdna/kdna-skills) |
-| **Team lead** wanting reusable AI work capabilities with judgment | [kdna-workpack](https://github.com/aikdna/kdna-workpack) — package KDNA + Skills + Gates into runnable Work Packs |
-
-## Open Ecosystem Readiness
-
-External integrations should start with:
-
-- [`docs/kdna-v1rc-standard-kit.md`](./docs/kdna-v1rc-standard-kit.md) for the canonical v1.0-rc implementer bundle.
-- [`docs/STUDIO_EXPORT_CONTRACT.md`](./docs/STUDIO_EXPORT_CONTRACT.md) for the required asset build outputs.
-- [`docs/ASSET_IDENTITY_MODEL.md`](./docs/ASSET_IDENTITY_MODEL.md) for asset/project/build identity fields.
-- [`@aikdna/kdna-core`](./packages/kdna-core) for stable asset-first APIs.
-- [`conformance/`](./conformance) for loader and validator compatibility tests.
-- [`docs/kdna-compatible-certification.md`](./docs/kdna-compatible-certification.md) for KDNA-compatible levels and certification boundaries.
-- [`rfcs/`](./rfcs) for protocol evolution.
-- [`docs/open-ecosystem-readiness.md`](./docs/open-ecosystem-readiness.md) for the current ecosystem readiness contract.
-
-## Why now
-
-> **Agents already have general judgment. What they still need is explicit, human-led domain judgment systems that can be inspected, governed, and reused.**
-
-The current agent ecosystem has solved the "doing" problem: function calls, MCP, tool use, workflows. But doing is not judging — an agent that can do anything, but cannot distinguish a price objection from an uncertainty signal, will confidently execute the wrong action.
-
-Tools let AI act. **KDNA keeps AI from acting blindly.**
-
-Self-improving agents need judgment governance. Without explicit judgment, improvement becomes drift. The KDNA Protocol is the protocol for human-governed self-improvement: agents can learn from work, but judgment updates require Human Judgment Lock — critical fields like axioms, boundaries, risk models, and failure criteria cannot be modified without human confirmation.
-
-Every domain has expert-level judgment patterns that currently exist only in experienced practitioners' minds. KDNA is a format for extracting those patterns, encoding them as machine-verifiable structures, and loading them into agents as a judgment reference — independent of prompts, independent of knowledge bases, independent of tools.
-
----
-
-## Before / After KDNA
-
-> **KDNA optimizes reasoning paths, not phrasing.**
-
-| Without KDNA | With KDNA |
-|---|---|
-| Generic, knowledge-level response | Domain-specific expert judgment |
-| Treats objection as literal statement | Diagnoses what's hiding behind the words |
-| "Customer says too expensive → give discount" | "Price objection is an uncertainty signal → diagnose which dimension" |
-| "Employee doesn't execute → motivation problem" | "Execution failure → check upstream system conditions" |
-| "Elder person refuses activity → not engaging enough" | "Refusal to participate → identify invisible barriers (fear, burden, dignity threat)" |
-| This is a prompt library | This is a judgment encoding format |
-| Cannot be verified | Every axiom, misunderstanding, and self-check is testable |
-
-Same model. Same input. Different judgment path.
-
----
-
-## Early Benchmark Evidence
-
-In a [5-model agent_safety mini benchmark](./benchmarks/BENCHMARK_SUMMARY.md), KDNA outperformed an equivalently-principled Best Prompt control across all 5 models.
-
-| Configuration | MiniMax | Claude Opus 4.7 | Qwen 3.7 Max | Gemini 3.5 Flash | GPT-5.5 |
-|---------------|:---:|:---:|:---:|:---:|:---:|
-| No KDNA | 79 | 79 | 80 | 64 | 92 |
-| Best Prompt | 104 | 104 | 101 | 94 | 99 |
-| **KDNA** | **108** | **111** | **107** | **103** | **110** |
-| vs Best | +4 | +7 | +6 | +9 | +11 |
-
-**Average: +7.4 over Best Prompt, +29.0 over No KDNA.**
-
-[Full report](./benchmarks/BENCHMARK_SUMMARY.md) · [Runner](./benchmarks/eval-agent-safety.mjs) · [Limitations](./benchmarks/BENCHMARK_SUMMARY.md#7-limitations--next-steps)
-
----
-
-## What KDNA is — and what it is not
-
-### KDNA is:
-
-- A **judgment reference layer** that AI agents load before they act in a domain
-- A **structured format** for axioms, concept boundaries, failure risks, self-checks, and reasoning chains
-- A **human-verified encoding** — critical judgment fields require Human Judgment Lock before modification
-- A **composable protocol** — multiple domain assets can be loaded together with conflict reporting
-
-### KDNA is not:
-
-- **Not a model or LLM.** KDNA loads alongside the model as a judgment reference. It does not generate text, reason, or predict.
-- **Not a prompt library.** Prompts are task-scoped and ephemeral. KDNA is domain-scoped and version-controlled.
-- **Not RAG or a knowledge base.** RAG retrieves facts. KDNA encodes what matters and what to watch for.
-- **Not a workflow engine or skill.** Skills define steps. KDNA defines the judgment criteria across those steps.
-- **Not fine-tuning.** Fine-tuning internalizes behavior into model weights. KDNA keeps judgment explicit, auditable, and editable.
-- **Not role-play.** KDNA does not ask an agent to pretend to be an expert. It provides structured judgment constraints, boundaries, and self-checks.
-- **Not a `.cursorrules` or project rules file.** KDNA is structured, validated, versioned, signed, and cross-agent portable.
-
----
-
-## KDNA and common AI agent mechanisms
-
-| Mechanism | What it provides | KDNA's relationship |
-|-----------|-----------------|---------------------|
-| **System Prompt** | Persistent behavioral instructions | KDNA provides structured, validated, domain-specific judgment that the model references during reasoning — not free-text behavioral nudges |
-| **Skill / Workflow** | Steps to follow | Skills execute. KDNA shapes how the agent judges what to do at each step |
-| **MCP / API** | Tool connections | MCP connects agents to tools. KDNA helps the agent judge tool outputs |
-| **RAG / Knowledge base** | Facts and documents | RAG retrieves information. KDNA helps interpret what matters in that information |
-| **Fine-tuning** | Internalized behavior | Fine-tuning internalizes patterns. KDNA keeps judgment explicit, auditable, and version-controlled |
-| **.cursorrules / project rules** | File-level behavioral hints | KDNA is a standardized, validated, cross-agent format with signatures and registry distribution |
-
-For a deeper comparison, see [KDNA and the AI Stack](./docs/kdna-and-ai-stack.md).
-
----
-
-## 30-second example
-
-```
-User: "Help me improve this product launch post."
-
-Without KDNA:
-  → Suggests clearer wording, shorter sentences, more enthusiasm.
-
-With writing.kdna:
-  → Classifies as structural writing diagnosis (not language polishing).
-  → Checks: Is there a real argument? A cognitive hook? Evidence density?
-  → Avoids banned terms: "polish the language", "make it punchy".
-  → Self-checks: 5/5 passed. Risk flags: none.
-```
-
-The agent didn't get better at writing. It got better at *judging what kind of problem this is*.
-
----
-
-## 5-Minute Quick Start
-
-One path. Five minutes. See KDNA change an agent's judgment.
-
-```bash
-npm install -g @aikdna/kdna-cli
-kdna setup
-kdna install @aikdna/writing
-kdna verify @aikdna/writing --judgment
-kdna compare @aikdna/writing --input "help me improve this post"
-```
-
-That's it. Your agent now loads a domain judgment package. The last command sends the same input to an LLM with and without KDNA, diffing the judgment paths so you can see exactly what changed.
-
-```bash
-# Verify everything is working
-kdna doctor --agents
-
-# → Codex: detected, kdna-loader installed
-# → Claude Code: detected, kdna-loader installed
-# → OpenCode: not detected (install opencode first)
-# → KDNA data root: ~/.kdna
-# → Installed domains: 1
-```
-
-Want to create your own trusted KDNA? Start with the authoring tool of your choice. An authoring pipeline turns human-reviewed judgment cards into canonical `.kdna` assets with authoring provenance, Human Locks, compiler metadata, and asset digest. `kdna-cli` verifies, installs, loads, compares, publishes, and audits existing `.kdna` assets; it does not author trusted KDNA.
-
----
-
-## What to read next
-
-| If you are a... | Read this |
-|-----------------|-----------|
-| **Understanding why KDNA matters when LLMs are already intelligent** | [Judgment Systems](./docs/judgment-systems.md) |
-| **Seeing a complete KDNA workflow from file to trace** | [First Domain Walkthrough](./docs/first-domain-walkthrough.md) |
-| **Comparing KDNA with RAG, Memory, Skills, MCP, Workflows, Evals** | [KDNA and the AI Stack](./docs/kdna-and-ai-stack.md) |
-| **Reading the white paper** | [KDNA White Paper](./docs/kdna-whitepaper.md) |
-| **Developer wanting to connect KDNA to an agent** | [5-minute guide](./docs/5-minute-guide.md) |
-| **Domain expert wanting to encode your judgment** | [kdna-studio-cli](https://github.com/aikdna/kdna-studio-cli) — Studio-compatible command-line authoring (`@aikdna/kdna-studio-cli`) |
-| **Evaluator wanting to measure judgment improvement** | [Evaluation guide](./docs/evaluation.md) |
-| **App developer integrating KDNA into clients, authoring tools, or agent runtimes** | [App Runtime Contract](./docs/app-runtime-contract.md) |
-| **Enterprise evaluating private deployment** | [Enterprise guide](./docs/enterprise.md) |
-| **Contributor wanting to improve KDNA itself** | [CONTRIBUTING.md](./CONTRIBUTING.md) |
-| **Curious about the full specification** | [SPEC.md](./SPEC.md) |
-| **Understanding governance and safety** | [Governance](./docs/GOVERNANCE.md) · [Safety](./docs/SAFETY.md) · [Risk Policy](./docs/RISK_POLICY.md) · [KDNA Card Spec](./docs/KDNA_CARD_SPEC.md) · [Security](./docs/SECURITY.md) |
-| **Understanding ecosystem naming** | [Ecosystem Naming](./docs/ECOSYSTEM_NAMING.md) |
-| **Navigating all repositories** | [Ecosystem Map](./docs/ecosystem-map.md) |
-| **Seeing KDNA change agent judgment** | [Demos](./demos/) — writing · agent_safety · prompt_diagnosis |
-| **Tracking v1.0-rc progress** | [Release Board](./docs/V1RC_RELEASE_BOARD.md) |
-| **Browsing available domains** | [Registry](https://github.com/aikdna/kdna-registry) · [aikdna.com/domains](https://aikdna.com/domains) |
-| **Reading the project roadmap** | [ROADMAP.md](./docs/ROADMAP.md) |
-| **Reading in Chinese** | [中文版](./README.zh.md) |
-
----
-
-## Repository Map
-
-| Repository | Role | For |
-|------------|------|-----|
-| [kdna](https://github.com/aikdna/kdna) | Protocol, SPEC, core library, governance docs | Everyone |
-| [kdna-registry](https://github.com/aikdna/kdna-registry) · [kdna-studio-core](https://github.com/aikdna/kdna-studio-core) · [kdna-studio-cli](https://github.com/aikdna/kdna-studio-cli) | Runtime tools, registry, authoring CLI | Developers · domain authors |
-| [kdna-agent_safety](https://github.com/aikdna/kdna-agent_safety) · [kdna-writing](https://github.com/aikdna/kdna-writing) · [kdna-prompt_diagnosis](https://github.com/aikdna/kdna-prompt_diagnosis) · [kdna-code_review](https://github.com/aikdna/kdna-code_review) · [kdna-authoring](https://github.com/aikdna/kdna-authoring) | First-launch official domain assets (signed `.kdna`, Human Lock, bilingual en/zh-CN) | Domain consumers |
-| Website | Hosted at [aikdna.com](https://aikdna.com) | Web contributors |
-
----
-
-## Repository Scope
-
-This repository (`aikdna/kdna`) contains:
-
-- KDNA protocol specification
-- Canonical schemas and validation rules
-- Reference examples
-- Benchmark definitions and reports
-- Asset Card and Human Lock specifications
-- Core protocol documentation
-
-Related repositories:
-
-- [`aikdna/kdna-cli`](https://github.com/aikdna/kdna-cli) — official CLI and runtime control plane
-- [`aikdna/kdna-registry`](https://github.com/aikdna/kdna-registry) — public domain catalog and registry schema
-- [`aikdna/kdna-studio-core`](https://github.com/aikdna/kdna-studio-core) — authoring kernel (`@aikdna/kdna-studio-core`)
-- [`aikdna/kdna-studio-cli`](https://github.com/aikdna/kdna-studio-cli) — CLI authoring entry point
-- Official domain repositories — reference KDNA domains
-
----
-
-## How KDNA fits in the AI agent stack
-
-| Mechanism | What it provides | Example |
-|-----------|-----------------|---------|
-| **Prompt** | What to say | "You are a helpful assistant." |
-| **Skill / Workflow** | What steps to follow | "Run lint, then format, then commit." |
-| **MCP / API** | What tools to call | "Call the GitHub API to create a PR." |
-| **RAG / Knowledge base** | What facts to retrieve | "Here are the company's coding standards." |
-| **Fine-tuning** | What behavior to internalize | Model trained on expert decisions. |
-| **KDNA** | **How to judge within a domain** | "Classify whether this is a structural problem or a language problem. Apply axioms X and Y. Avoid banned term Z. Run self-checks." |
-
-KDNA does not replace these mechanisms. It provides a judgment reference layer that operates alongside them. For a deeper comparison, see [KDNA and the AI Stack](./docs/kdna-and-ai-stack.md).
-
----
-
-## FAQ
-
-<details>
-<summary>Is this related to biological kDNA, KnowledgeDNA, or other DNA projects?</summary>
-
-No. In this project, KDNA refers to the KDNA Protocol: an open judgment protocol for AI systems. It focuses on human-governed domain judgment assets, not biological kinetoplast DNA, goal-tracking SaaS, codebase summaries, agent identity profiles, or model lineage analysis.
-</details>
-
-<details>
-<summary>How is KDNA different from Prompt, RAG, Skills, and MCP?</summary>
-
-- **Prompt** changes what AI says — task-scoped, ephemeral.
-- **RAG** changes what AI can access — retrieves facts.
-- **Tools/Skills/MCP** change what AI can do — connect to actions.
-- **KDNA** changes how AI judges — domain-scoped, version-controlled, auditable.
-
-KDNA is the judgment reference layer. It does not replace these mechanisms — it sits alongside them.
-</details>
-
-<details>
-<summary>Does a .kdna file contain a person's full judgment?</summary>
-
-No. A .kdna file contains a bounded judgment framework. Just as a .doc contains only a portion of someone's knowledge, a .kdna file contains a portion of the principles, boundaries, standards, and taste that a person or team chooses to encode. Multiple .kdna files can form a judgment asset library — but no single file claims to capture a person's complete judgment ability.
-</details>
-
-<details>
-<summary>Is KDNA just a fancy system prompt?</summary>
-
-No. System prompts are free-text behavioral instructions scoped to a single conversation. KDNA is a structured, validated, version-controlled format with explicit fields (axioms, boundaries, self-checks, failure risks). KDNA packages are designed to be signed, hash-verified, and distributed through a registry — a system prompt is none of these.
-</details>
-
-<details>
-<summary>Does KDNA replace the model?</summary>
-
-No. KDNA is a judgment reference that the model loads before it reasons and acts. The model still does all the reasoning, generation, and tool use. KDNA tells the model what to pay attention to, what to avoid, and what to verify — it does not generate output.
-</details>
-
-<details>
-<summary>How is KDNA different from RAG?</summary>
-
-RAG retrieves facts and documents for the model to reference. KDNA encodes what matters and what to watch for in a domain. RAG says "here's the coding standard document." KDNA says "when reviewing code, classify whether the problem is structural or cosmetic before suggesting changes."
-</details>
-
-<details>
-<summary>Can I use KDNA without coding?</summary>
-
-Yes — start with [kdna-studio-cli](https://github.com/aikdna/kdna-studio-cli) (`@aikdna/kdna-studio-cli`) for guided authoring, Human Lock, compile, and export. To install and use domains with your AI agent, you only need the runtime CLI (`npm install -g @aikdna/kdna-cli`). Hand-written dev source directories are non-canonical and cannot become trusted assets unless compiled by a Studio-compatible pipeline.
-</details>
-
-<details>
-<summary>Does KDNA work with any AI model?</summary>
-
-KDNA is model-agnostic. The format encodes judgment as structured JSON — any agent framework that can load context before reasoning can use KDNA. Currently supported agents include Claude Code, Codex, OpenCode, Cursor, and GitHub Copilot.
-</details>
-
-<details>
-<summary>What happens if I load multiple KDNA domains that conflict?</summary>
-
-KDNA's composition mechanism detects and reports conflicts rather than silently merging incompatible principles. When domains conflict — for example, a brand domain encouraging emotional intensity while a compliance domain requires conservative wording — the agent reports the conflict rather than choosing one side.
-</details>
-
-<details>
-<summary>Can AI agents modify KDNA domains?</summary>
-
-No — not the judgment-class fields. KDNA's Human Judgment Lock requires human confirmation before axioms, boundaries, risk models, failure criteria, and other judgment-class fields can be modified. Operational fields like usage statistics can be updated automatically.
-</details>
-
-<details>
-<summary>Where can I see KDNA in action?</summary>
-
-Run `kdna compare @aikdna/writing --input "help me improve this post"` to see a side-by-side judgment path comparison. Visit [aikdna.com/benchmark](https://aikdna.com/benchmark) for evaluation data across multiple domains.
-</details>
-
----
-
-## Languages
-
-[English](./README.md) · [中文](./README.zh.md)
+This repository follows [SemVer 2.0](https://semver.org/) for the KDNA Core specification. The current target is `kdna_version: "1.0"` (Phase 1 baseline). Breaking changes to the manifest schema or payload profile require a major version bump and an RFC.
 
 ## License
 
-- **Code** (CLI, authoring tools, Registry, Skills, VS Code extension): Apache-2.0
-- **Documentation, examples, and domain content**: CC-BY-4.0
-See [LICENSE](LICENSE) and [LICENSE-DOCS](LICENSE-DOCS) for full terms.
-
-## Open Standard, Not Open Identity
-
-KDNA is open source because domain judgment should become shared infrastructure for AI agents. We welcome developers, researchers, creators, and organizations to build KDNA domains, tools, validators, loaders, and agent integrations.
-
-**The format is open so the ecosystem can grow. The identity is protected so the ecosystem does not fragment.**
-
-However, KDNA is intended to grow as a **coherent open standard**, not as a set of fragmented renamed protocols. Forks are welcome for experimentation, but public derivative protocols must clearly identify themselves as independent and must not imply official KDNA compatibility or endorsement unless they follow the official SPEC and compatibility policy.
-
-- [TRADEMARK.md](./TRADEMARK.md) — KDNA name and marks protection
-- [COMPATIBILITY.md](./COMPATIBILITY.md) — what "KDNA-compatible" means
-- [FORK_POLICY.md](./FORK_POLICY.md) — constructive forks vs protocol forks
-- [GOVERNANCE.md](./docs/GOVERNANCE.md) — how the standard evolves
-- [registry-policy.md](./docs/registry-policy.md) — registry governance
+Apache 2.0. See [LICENSE](./LICENSE).

--- a/docs/core/definition.md
+++ b/docs/core/definition.md
@@ -1,0 +1,54 @@
+# KDNA Core Definition
+
+**KDNA Core is a content-neutral open judgment-asset file format and runtime loading contract.**
+
+KDNA Core defines how judgment assets are:
+
+- **created** — by authors, using tools
+- **saved** — as portable files
+- **packaged** — into a standardized container (`.kdna`)
+- **encrypted** — selectively, by entry
+- **decrypted** — by tools that hold the necessary keys
+- **signed** — by authors and publishers
+- **identified** — by asset_id and asset_uid
+- **versioned** — across releases and lineage
+- **traced** — at runtime, via status reports
+- **loaded** — by AI runtimes and viewers
+- **used** — by tools that need to read, render, or compare
+
+KDNA Core does **not** define:
+
+- what humans should judge
+- what content is correct, valuable, or high-quality
+- which authors are trustworthy
+- which assets should be recommended
+- which platforms should distribute them
+- what runtime policy should apply (block, allow, warn)
+
+---
+
+KDNA Core 是一种内容中立的开放判断资产文件格式和运行时加载契约。
+
+它定义判断资产如何被创建、保存、封装、加密、解密、签名、识别、版本化、追踪、加载和被工具使用。
+
+它不定义人类应该拥有什么判断，也不提供官方分发、官方排名、官方推荐、官方交易、官方信任裁判或价值审查。
+
+---
+
+## What this means in practice
+
+| Concern | Who decides |
+| --- | --- |
+| File format | **KDNA Core** (this repo) |
+| Manifest schema | **KDNA Core** |
+| Payload profile schema | **KDNA Core** |
+| Encryption envelope metadata | **KDNA Core** |
+| Signature metadata | **KDNA Core** |
+| Runtime load contract | **KDNA Core** |
+| What judgment to encode | The **author** |
+| Which assets to use | The **caller** (agent / application) |
+| Whether to trust a signature | The **caller** |
+| Where to find assets | An **external** platform (out of scope) |
+| Whether to recommend an asset | An **external** platform (out of scope) |
+
+KDNA Core is the **verifiable primitive** that makes all of the above possible. It is not the policy layer.

--- a/docs/core/file-format.md
+++ b/docs/core/file-format.md
@@ -1,0 +1,55 @@
+# KDNA File Format (v1)
+
+A `.kdna` file is a **ZIP-compatible container** with a fixed entry layout. The format is normative; any tool claiming to produce or consume KDNA v1 assets MUST follow this layout.
+
+## Container layout
+
+```
+example.kdna
+├── mimetype              (required, plaintext, must be the first entry)
+├── kdna.json             (required, plaintext manifest)
+├── payload.kdnab         (required, judgment payload; may be plaintext or encrypted)
+├── signatures/           (optional, signature files keyed by signer role)
+│   ├── author.sig
+│   └── publisher.sig
+├── attachments/          (optional, supplementary files referenced from the payload)
+│   └── ...
+└── checksums.json        (recommended, per-entry digests)
+```
+
+## Required entries
+
+| Entry | Required | Encoding | Notes |
+| --- | --- | --- | --- |
+| `mimetype` | yes | UTF-8 plaintext | MUST be the literal string `application/vnd.kdna.asset` (no trailing newline). MUST be the first entry in the ZIP central directory so it can be read without parsing the full manifest. |
+| `kdna.json` | yes | UTF-8 JSON | The manifest. See `manifest.md`. |
+| `payload.kdnab` | yes | binary (CBOR or JSON) | The judgment payload. See `payload-profile.md`. May be plaintext or encrypted as a unit. Phase 1 only requires the plaintext case. |
+
+## Optional entries
+
+| Entry | Required | Notes |
+| --- | --- | --- |
+| `checksums.json` | recommended | Per-entry digests. See `checksums.md`. |
+| `signatures/` | optional | One or more signature files. Each file is named `<role>.sig` (e.g. `author.sig`, `publisher.sig`, `auditor.sig`). The signature is over a specific subset of entries; the manifest's `signatures` block records which subset. |
+| `attachments/` | optional | Supplementary files referenced from the payload. Each attachment has a path under `attachments/`. |
+| `locales/<lang>/` | optional | Localized strings. Phase 1 does not define a schema for these; localization metadata in the manifest's `scope.language` is sufficient for routing. |
+
+## Container requirements
+
+1. The container MUST be a valid ZIP archive.
+2. `mimetype` MUST be the first entry and MUST be stored uncompressed.
+3. `kdna.json` MUST be UTF-8 JSON without BOM.
+4. `payload.kdnab` MUST be either UTF-8 JSON (`.json` content) or CBOR. The manifest's `payload.encoding` field declares which.
+5. The container MUST be deterministic given the same input entries: a producer and a verifier that independently pack the same logical asset MUST produce byte-identical containers when the same digest algorithm is used. Tools that do not achieve this are non-conformant.
+6. Encryption is per-entry, not whole-container. In Phase 1, only the plaintext case is exercised. The schema for encrypted entries is reserved for Phase 3.
+
+## Anti-patterns
+
+- ❌ Wrapping the whole `.kdna` in another container (`.tar.gz.kdna`, `.zip.kdna`). The `.kdna` file IS the container.
+- ❌ Storing the manifest as a non-root path (`/manifests/v1/kdna.json`). The manifest is always at the root of the container.
+- ❌ Embedding the payload as multiple separate files (`KDNA_Core.json`, `KDNA_Patterns.json`, ...). Phase 1 collapses the payload into a single `payload.kdnab`. The multi-file layout is a v1-rc legacy shape and is not part of v1.
+- ❌ Storing executable code (`.js`, `.py`, `.wasm`) inside the container that the loader is expected to execute. KDNA Core is data-only; any execution semantics belong to runtime extensions defined outside this spec.
+
+## Versioning
+
+The container format version is recorded in the manifest as `kdna_version`. Phase 1 targets `kdna_version: "1.0"`. A loader encountering an unknown `kdna_version` SHOULD treat the asset as `version_incompatible` per the trace vocabulary and refuse to load it.

--- a/docs/core/load-contract.md
+++ b/docs/core/load-contract.md
@@ -1,0 +1,71 @@
+# Runtime Load Contract
+
+The **load contract** is a manifest block that tells a loader **how** it may read the asset. It does not tell the loader **whether** to read it, or what to do with the result — those are runtime policy decisions.
+
+The load contract lives under `manifest.load_contract`. The schema is part of [`schema/manifest.schema.json`](../../schema/manifest.schema.json).
+
+## Load profiles
+
+A load profile is a named reading strategy. The v1 contract defines four:
+
+| Profile | Purpose | Typical use |
+| --- | --- | --- |
+| `index` | Read only the manifest and the asset's identity. | Routing, listing, deduplication. |
+| `compact` | Read the manifest and a summary of the payload (axioms, boundaries, the central question). | Most agent invocations. |
+| `scenario` | Read only the sections of the payload triggered by a given input. | Input-routed reading, large payloads. |
+| `full` | Read the entire payload, all signatures, all attachments. | Editing, audit, deep reasoning, archival. |
+
+Each profile declares three optional fields:
+
+- `requires_decryption` (boolean): does this profile require a decryption key?
+- `max_tokens_hint` (integer): a soft upper bound on tokens used by this profile. Loaders SHOULD use it as a hint, not a hard cap.
+- `selection` (string): for `scenario`, describes the routing strategy (e.g. `"triggered_sections_only"`).
+- `intended_for` (array of strings): free-form labels describing intended use (e.g. `["editing", "audit", "deep_reasoning"]`).
+
+## Example contract
+
+```json
+{
+  "load_contract": {
+    "default_profile": "compact",
+    "profiles": {
+      "index": {
+        "requires_decryption": false,
+        "max_tokens_hint": 500
+      },
+      "compact": {
+        "requires_decryption": false,
+        "max_tokens_hint": 2500
+      },
+      "scenario": {
+        "requires_decryption": false,
+        "selection": "triggered_sections_only"
+      },
+      "full": {
+        "requires_decryption": false,
+        "intended_for": ["editing", "audit", "deep_reasoning"]
+      }
+    }
+  }
+}
+```
+
+In Phase 1, all profiles have `requires_decryption: false` because the example assets are plaintext. Future phases will add encrypted profiles that require the loader to supply a key.
+
+## What the contract is NOT
+
+- It is **not** a recommendation. KDNA Core does not say "you should use this profile for this task". Callers pick.
+- It is **not** a quality claim. A profile is not "better" or "worse" than another; it is a different cost/benefit trade-off.
+- It is **not** a security boundary. The contract is descriptive; the loader's policy enforces security.
+
+## Loader behaviour
+
+When a loader opens a `.kdna` file, it MUST:
+
+1. Read the manifest.
+2. If `load_contract` is present, use the profile named in `default_profile` (or the caller-requested profile if different) to determine the reading strategy.
+3. If the requested profile has `requires_decryption: true`, refuse to load without a key and emit a `requires_decryption` trace status.
+4. If the requested profile's `max_tokens_hint` is exceeded by the actual content, the loader SHOULD emit a warning trace, not silently truncate.
+5. If the manifest's `compatibility.min_loader_version` is higher than the loader's version, emit a `version_incompatible` trace and refuse to load.
+
+The trace vocabulary is defined in `trace.md`.

--- a/docs/core/manifest.md
+++ b/docs/core/manifest.md
@@ -45,20 +45,6 @@ The manifest is a single JSON object at the root of the container, stored as `kd
 
 ## `payload` object
 
-```json
-{
-  "path": "payload.kdnab",
-  "encoding": "json",
-  "encrypted": false
-}
-```
-
-- `path` is the entry name within the container (always `payload.kdnab` in v1).
-- `encoding` is `json` or `cbor`.
-- `encrypted` is a boolean. In Phase 1, only `false` is exercised; the encrypted case is defined in a later phase.
-
-## Optional fields
-
 | Field | Type | Description |
 | --- | --- | --- |
 | `summary` | string | One-paragraph description. |
@@ -68,13 +54,33 @@ The manifest is a single JSON object at the root of the container, stored as `kd
 | `license` | string or object | SPDX identifier (e.g. `Apache-2.0`) or `{type, url}`. |
 | `keywords` | array | Free-form keywords. |
 | `domain_field` | array | Domain categories. |
-| `lineage` | array | List of `{asset_uid, version, relationship}` records describing parent assets. |
+| `lineage` | object | Provenance object describing how this asset relates to other assets. See `lineage` shape below. |
 | `digests` | object | Per-entry digests. Alternative to a separate `checksums.json`. |
 | `signatures` | array | Signature references (each entry has `role`, `path`, `algorithm`, `key_id`). |
 | `encryption` | object | Encryption envelope metadata (reserved for later phases). |
 | `load_contract` | object | The runtime load contract. See `load-contract.md`. |
 | `scope` | object | Scope metadata: `summary`, `keywords`, `domain_field`, etc. |
 | `evidence_claims` | object | Author-declared evidence claims. **Descriptive only in Phase 1.** Not validated by the format. |
+
+## `lineage` object (Phase 1 shape)
+
+Phase 1 records lineage as a **single object**, not an array. This keeps the format stable; future phases may add a separate `sources` or `references` field for multi-parent derivation rather than overloading `lineage`.
+
+```json
+{
+  "type": "original",
+  "fork_of": null,
+  "derived_from": null
+}
+```
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `type` | enum | One of `original`, `fork`, `adaptation`, `translation`, `private_variant`, `organization_variant`, `course_variant`. |
+| `fork_of` | null, string, or `{asset_uid, version?}` | If `type` is `fork`, the asset this one was forked from. |
+| `derived_from` | null, string, array of strings, or object | The judgment lineage (Phase 1: descriptive only). |
+
+Phase 1 **does not** implement fork/adapt behaviour. The `type` enum covers the categories so that callers can route, but the runtime does not enforce any particular derivation policy. The shape is frozen; multi-source derivation will land in a later phase under a separate field, not by mutating `lineage` into an array.
 
 ## Minimal example
 
@@ -101,6 +107,11 @@ The manifest is a single JSON object at the root of the container, stored as `kd
     "path": "payload.kdnab",
     "encoding": "json",
     "encrypted": false
+  },
+  "lineage": {
+    "type": "original",
+    "fork_of": null,
+    "derived_from": null
   }
 }
 ```

--- a/docs/core/manifest.md
+++ b/docs/core/manifest.md
@@ -1,0 +1,110 @@
+# KDNA Manifest (`kdna.json`)
+
+The manifest is the **public metadata layer** of a `.kdna` file. It is always plaintext so that tools can identify, route, and version-check an asset even when the payload is encrypted.
+
+The manifest is a single JSON object at the root of the container, stored as `kdna.json`. The authoritative schema is [`schema/manifest.schema.json`](../../schema/manifest.schema.json).
+
+## Required fields
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `kdna_version` | string | The KDNA Core version this manifest conforms to. Phase 1 uses `"1.0"`. |
+| `asset_id` | string | A human-readable identifier with a `kdna_version` prefix (e.g. `kdna:example:atomspeak-core`). Not globally unique by itself. |
+| `asset_uid` | string (URI) | A globally unique identifier, conventionally a `urn:uuid:...`. Required in v1 to disambiguate assets that share a name. |
+| `asset_type` | enum | One of `domain`, `cluster`, `tool`, `sample`, `fixture`. The container format is the same; the value tells callers how to interpret the payload. |
+| `title` | string | A short, human-readable title. |
+| `version` | semver | The release version of this `.kdna` file. Distinct from `judgment_version`. |
+| `judgment_version` | semver | The semantic version of the **encoded judgment system**. Two assets with the same `judgment_version` are semantically equivalent for matching. |
+| `created_at` | ISO 8601 | When the asset was first created. |
+| `updated_at` | ISO 8601 | When this release of the asset was produced. |
+| `creator` | object | Who produced the asset. See below. |
+| `compatibility` | object | Loader-version requirements and payload profile identifier. |
+| `payload` | object | Path, encoding, and encryption status of the payload entry. |
+
+## `creator` object
+
+```json
+{
+  "name": "Example Author",
+  "id": "optional-author-id"
+}
+```
+
+`creator.name` is the only required field. `creator.id` is optional. The `creator` block does NOT include a trust claim, an endorsement, or a verification status. The presence of a `creator` block is a fact about provenance, not a statement about reliability.
+
+## `compatibility` object
+
+```json
+{
+  "min_loader_version": "1.0.0",
+  "profile": "judgment-profile-v1"
+}
+```
+
+`min_loader_version` is the minimum version of the KDNA Core loader required to read this asset. `profile` is the payload profile identifier (see `payload-profile.md`).
+
+## `payload` object
+
+```json
+{
+  "path": "payload.kdnab",
+  "encoding": "json",
+  "encrypted": false
+}
+```
+
+- `path` is the entry name within the container (always `payload.kdnab` in v1).
+- `encoding` is `json` or `cbor`.
+- `encrypted` is a boolean. In Phase 1, only `false` is exercised; the encrypted case is defined in a later phase.
+
+## Optional fields
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `summary` | string | One-paragraph description. |
+| `description` | string | Longer description. |
+| `language` | string | BCP-47 primary language code. |
+| `languages` | array | Supported languages. |
+| `license` | string or object | SPDX identifier (e.g. `Apache-2.0`) or `{type, url}`. |
+| `keywords` | array | Free-form keywords. |
+| `domain_field` | array | Domain categories. |
+| `lineage` | array | List of `{asset_uid, version, relationship}` records describing parent assets. |
+| `digests` | object | Per-entry digests. Alternative to a separate `checksums.json`. |
+| `signatures` | array | Signature references (each entry has `role`, `path`, `algorithm`, `key_id`). |
+| `encryption` | object | Encryption envelope metadata (reserved for later phases). |
+| `load_contract` | object | The runtime load contract. See `load-contract.md`. |
+| `scope` | object | Scope metadata: `summary`, `keywords`, `domain_field`, etc. |
+| `evidence_claims` | object | Author-declared evidence claims. **Descriptive only in Phase 1.** Not validated by the format. |
+
+## Minimal example
+
+```json
+{
+  "kdna_version": "1.0",
+  "asset_id": "kdna:example:atomspeak-core",
+  "asset_uid": "urn:uuid:00000000-0000-4000-8000-000000000001",
+  "asset_type": "domain",
+  "title": "Atomspeak Core",
+  "version": "1.0.0",
+  "judgment_version": "1.0.0",
+  "created_at": "2026-06-16T00:00:00Z",
+  "updated_at": "2026-06-16T00:00:00Z",
+  "creator": {
+    "name": "Example Author",
+    "id": "optional-author-id"
+  },
+  "compatibility": {
+    "min_loader_version": "1.0.0",
+    "profile": "judgment-profile-v1"
+  },
+  "payload": {
+    "path": "payload.kdnab",
+    "encoding": "json",
+    "encrypted": false
+  }
+}
+```
+
+## Why `asset_uid` is required
+
+A previous design used `asset_id` alone. That made the identifier namespace central: every producer had to coordinate with everyone else to avoid collisions. The v1 manifest requires `asset_uid` (a URN) so that the unique identity is **intrinsic** to the asset, not delegated to a global naming authority. `asset_id` is retained for human readability, but `asset_uid` is the only field the runtime uses for identity.

--- a/docs/core/payload-profile.md
+++ b/docs/core/payload-profile.md
@@ -1,0 +1,152 @@
+# Payload Profile v1 (`judgment-profile-v1`)
+
+The payload is the actual judgment data. Its **shape** is defined by a payload profile. Phase 1 defines exactly one profile, **`judgment-profile-v1`**, which is the minimum structure that an agent can load and reason over.
+
+The authoritative schema is [`schema/payload-profile-v1.schema.json`](../../schema/payload-profile-v1.schema.json).
+
+## Top-level shape
+
+A `judgment-profile-v1` payload is a single JSON object with the following sections:
+
+| Section | Type | Phase 1 requirement |
+| --- | --- | --- |
+| `profile` | string constant | Required. MUST be the literal string `"judgment-profile-v1"`. |
+| `core` | object | Required. Holds the central axioms and boundaries. |
+| `patterns` | array | Optional. Phase 1 allows an empty array. |
+| `scenarios` | array | Optional. Phase 1 allows an empty array. |
+| `cases` | array | Optional. Phase 1 allows an empty array. |
+| `reasoning` | object | Optional. Holds self-checks and failure modes. |
+| `evolution` | object | Optional. Holds changelog and version notes. |
+
+## `core` section
+
+```json
+{
+  "highest_question": "",
+  "axioms": [],
+  "boundaries": [],
+  "risk_model": {}
+}
+```
+
+- `highest_question` (string, required): the single most important question this judgment system answers. Producers SHOULD populate it. Phase 1 does not enforce non-empty.
+- `axioms` (array, required): the list of axioms. Phase 1 accepts an empty array.
+- `boundaries` (array, optional): explicit out-of-scope statements.
+- `risk_model` (object, optional): structural risk metadata.
+
+The minimum valid `core` object is `{ "highest_question": "", "axioms": [] }`. The keys MUST be present; the values MAY be empty.
+
+## `reasoning` section (optional)
+
+```json
+{
+  "self_checks": [],
+  "failure_modes": []
+}
+```
+
+Both arrays are optional within the section.
+
+## `evolution` section (optional)
+
+```json
+{
+  "changelog": [],
+  "version_notes": []
+}
+```
+
+Both arrays are optional within the section.
+
+## Minimal valid payload
+
+```json
+{
+  "profile": "judgment-profile-v1",
+  "core": {
+    "highest_question": "",
+    "axioms": []
+  }
+}
+```
+
+This is the **smallest** payload that conforms to the schema. The conformance suite in Phase 1 only requires this shape. Anything more elaborate is allowed but not required.
+
+## Full template
+
+```json
+{
+  "profile": "judgment-profile-v1",
+  "core": {
+    "highest_question": "What is the central question this judgment system answers?",
+    "axioms": [
+      {
+        "id": "a1",
+        "one_sentence": "Axiom statement in one sentence."
+      }
+    ],
+    "boundaries": [
+      {
+        "id": "b1",
+        "scope": "Where this judgment applies",
+        "out_of_scope": "Where it does not"
+      }
+    ],
+    "risk_model": {
+      "default_risk": "R0"
+    }
+  },
+  "patterns": [
+    {
+      "id": "p1",
+      "name": "Pattern name",
+      "description": "What the pattern recognizes"
+    }
+  ],
+  "scenarios": [
+    {
+      "id": "s1",
+      "title": "Scenario title",
+      "trigger": "When this scenario applies"
+    }
+  ],
+  "cases": [
+    {
+      "id": "c1",
+      "title": "Case title",
+      "input": "Input that produced the case",
+      "expected_judgment": "What the system should conclude"
+    }
+  ],
+  "reasoning": {
+    "self_checks": ["Did I check X?"],
+    "failure_modes": [
+      {
+        "id": "f1",
+        "description": "What can go wrong",
+        "mitigation": "How to recover"
+      }
+    ]
+  },
+  "evolution": {
+    "changelog": [
+      {
+        "version": "1.0.0",
+        "date": "2026-06-16",
+        "changes": "Initial release"
+      }
+    ],
+    "version_notes": []
+  }
+}
+```
+
+## Why `judgment-profile-v1` is explicit
+
+A previous design allowed the payload to be any JSON object. That forced every loader to learn a custom schema for every asset, and made the "what is a valid judgment asset?" question impossible to answer statically. By pinning a single profile in Phase 1, the format gains a **conformance target**: a tool can claim to be a "KDNA v1 loader" and validate against this profile. Future profiles will be additive; the `profile` field is the version pin.
+
+## What this profile does NOT define
+
+- It does not define a domain ontology or a category system. A `judgment-profile-v1` asset about safety and an asset about cooking use the same shape; the meaning comes from the prose in `axioms`, `scenarios`, and `cases`.
+- It does not define evaluation, scoring, or grading. The payload is the **thing to be judged**, not the judgment of the thing.
+- It does not require encryption. Encryption is a per-entry property in the container; the profile is content-shape-agnostic.

--- a/docs/core/principles.md
+++ b/docs/core/principles.md
@@ -1,0 +1,43 @@
+# KDNA Core Principles
+
+The KDNA Core format rests on eight principles. Every feature in the spec, every schema field, and every CLI behaviour should trace back to one of these.
+
+## 1. Content-neutral
+
+KDNA Core is a format, not a content policy. The format can express any judgment system — sound or unsound, useful or harmful, expert or amateur. KDNA Core does not filter, rank, or recommend content. That work belongs to the caller and to external platforms.
+
+## 2. Format authority
+
+There is exactly one canonical schema for each KDNA Core artifact type (manifest, payload profile, checksums, load contract). The schemas in `schema/` are normative. Tools MUST validate against them; deviations are bugs.
+
+## 3. Private assets first
+
+KDNA Core supports encrypted entries from day one. A `.kdna` file can have parts that are readable (manifest, optionally plaintext sections) and parts that are encrypted (sensitive judgment content, licensed material). The format is designed so that privacy is the default, not an afterthought.
+
+## 4. Signature is not trust
+
+A signature proves that a particular key signed a particular payload. It does not prove the signer is "good", "official", or "endorsed". KDNA Core records signatures as verifiable artifacts. Whether a signature is meaningful is a runtime policy decision, not a format property.
+
+## 5. Version traceability
+
+Every KDNA asset carries version metadata: `version` (release), `judgment_version` (semantic version of the encoded judgment), and a `lineage` array (parent assets). Loaders and viewers can reconstruct the history of an asset without external services.
+
+## 6. Runtime decides loading
+
+KDNA Core defines **how** a loader may read an asset. It does not define **whether** a loader should read it, or what to do with the result. Blocklists, allowlists, content warnings, and runtime policies are caller concerns.
+
+## 7. Distribution is external
+
+KDNA Core does not include any registry, marketplace, store, or listing. Assets may be distributed by any means the producer chooses: file copy, HTTP, IPFS, email attachment, sneaker net. KDNA Core is the file; distribution is somebody else's job.
+
+## 8. Loader safety is mandatory
+
+> **KDNA Core is content-neutral, but not loader-safety-neutral.**
+
+KDNA Core 不判断内容好坏，但必须定义安全、可控、可追踪的加载行为。
+
+A loader that ignores decryption errors, ignores signature mismatches, or silently truncates a payload is failing the format. The runtime load contract includes explicit status values (`failed_to_decrypt`, `signature_invalid`, `version_incompatible`, etc.) so that a loader cannot quietly "succeed" while producing garbage.
+
+---
+
+These eight principles are the contract. If a future feature conflicts with any of them, the feature is wrong.

--- a/docs/core/terminology.md
+++ b/docs/core/terminology.md
@@ -1,0 +1,50 @@
+# KDNA Core Terminology
+
+Phase 1 baseline vocabulary. Each term is defined in 1–3 sentences. Some terms refer to spec-level concepts; others refer to implementation patterns. Where a term is used elsewhere in this repository with multiple meanings, the meaning below is authoritative.
+
+## Format concepts
+
+**KDNA Core** — the file format and runtime loading contract defined in this repository. Includes the manifest schema, payload profile schemas, checksums schema, and load contract.
+
+**.kdna** — the standardized container file. A single `.kdna` file holds a manifest, a payload, optional signatures, optional attachments, and an optional checksums file, all in a ZIP-compatible container with a `mimetype` entry.
+
+**Manifest** — the public metadata layer of a `.kdna` file. Stored as `kdna.json` at the root of the container. Always plaintext so that tools can identify and route the file even if the payload is encrypted.
+
+**Payload** — the actual judgment data. Stored as `payload.kdnab` at the root of the container. May be plaintext or selectively encrypted. The structure of the payload is defined by a **payload profile** (e.g. `judgment-profile-v1`).
+
+**Envelope** — the set of metadata entries that describe the container itself: encryption metadata, signature references, digests. Distinct from the payload, which is the judgment content.
+
+**Asset ID** — a human-readable identifier for an asset, e.g. `kdna:example:atomspeak-core`. The `kdna_version` prefix in the manifest (`kdna:`) is the format namespace; the rest is the producer's choice. Asset IDs are NOT globally unique by themselves; they are namespaced.
+
+**Asset UID** — a globally unique identifier, e.g. `urn:uuid:00000000-0000-4000-8000-000000000001`. Required in v1 manifests to disambiguate assets that share a name.
+
+**Judgment Version** — a semantic version for the **encoded judgment**, separate from the **asset release version**. An asset's `version` is its release tag; its `judgment_version` describes the version of the underlying judgment system it represents. Two assets with the same `judgment_version` are semantically equivalent for matching purposes.
+
+**Lineage** — the chain of parent assets that this asset descends from. Recorded as a list of asset UIDs in the manifest. Lineage does not imply trust, endorsement, or licensing; it is a fact about provenance.
+
+**Digest** — a cryptographic hash of an entry, used for integrity checks. The default algorithm in Phase 1 is SHA-256. Digests may be recorded in the checksums file or in the manifest's `digests` block.
+
+**Signature** — a cryptographic signature over a payload or manifest entry, recorded as a separate file in the `signatures/` directory. A signature has a key reference, an algorithm, and a digest of the signed bytes. The signature is verifiable; whether it is meaningful is a caller decision.
+
+## Runtime concepts
+
+**Load Contract** — the manifest block that describes how a loader may read the asset. Includes the default profile, a set of named profiles (`index`, `compact`, `scenario`, `full`), per-profile flags (`requires_decryption`, `max_tokens_hint`, `selection`), and an `intended_for` list.
+
+**Load Profile** — a named reading strategy. `index` reads only metadata; `compact` reads the default judgment summary; `scenario` reads only triggered sections for a given input; `full` reads the entire payload for audit, editing, or deep reasoning.
+
+**Runtime Status** — a value from the trace vocabulary that records the outcome of a loader operation. Values include `not_applicable`, `candidate`, `requires_decryption`, `loaded`, `skipped`, `blocked_by_runtime_policy`, `failed_to_parse`, `failed_to_decrypt`, `signature_invalid`, `version_incompatible`. Statuses describe **runtime processing**, not asset value.
+
+**Scope Metadata** — the manifest block that describes what the asset is about and where it applies. Includes `summary`, `language`, `keywords`, `domain_field`. Scope metadata is descriptive; it is not an endorsement.
+
+**Evidence Claims** — claims about the evidence behind an asset, as declared by the author or publisher. In Phase 1 these are descriptive metadata only; the spec does not validate their truth. The terminology replaces the older "quality badge" concept, which conflated evidence with evaluation.
+
+**Runtime Policy** — a set of rules owned by the **caller** (not by KDNA Core) that decide which assets a given loader will accept, reject, warn about, or require decryption for. KDNA Core supplies the verifiable primitives; the policy lives outside the format.
+
+## Out-of-scope terms
+
+The following are **not** KDNA Core concepts and are explicitly out of scope:
+
+- **Registry / Marketplace / Store** — distribution concerns, not format concerns
+- **Trust / Verified / Recommended** — runtime policy decisions
+- **Quality Badge / Ranking** — evaluative claims, not format properties
+- **Official / Certified / Approved** — endorsement claims, not format properties

--- a/docs/core/trace.md
+++ b/docs/core/trace.md
@@ -1,0 +1,41 @@
+# Runtime Trace Vocabulary
+
+A **trace status** is a value that a loader emits to describe the outcome of a runtime operation. Trace statuses are facts about **runtime processing**, not about the asset's value. A status of `loaded` does not mean "this asset is good"; it means "this loader successfully read it".
+
+## Status values
+
+| Status | Meaning |
+| --- | --- |
+| `not_applicable` | The operation did not apply to this asset. For example, signature verification when the asset has no signatures. |
+| `candidate` | The asset was identified as a candidate for an operation (e.g. matching) but no decision was made yet. |
+| `requires_decryption` | The asset has encrypted entries that must be decrypted for the requested operation. The loader cannot proceed without a key. |
+| `loaded` | The asset was read successfully. The payload bytes were interpreted, the schema validated, and the data is now available to the caller. |
+| `skipped` | The loader intentionally chose not to read the asset. The reason is recorded in the trace metadata, not in the status value. |
+| `blocked_by_runtime_policy` | The loader's policy rejected the asset. Policy reasons are external to KDNA Core; the status only reports the decision. |
+| `failed_to_parse` | The container or its entries could not be parsed. The asset is malformed or the container is corrupted. |
+| `failed_to_decrypt` | A required decryption failed. The key was provided but the operation did not succeed. |
+| `signature_invalid` | A signature was present but did not verify against its declared payload and key. The asset MAY still be loaded, but the caller is responsible for deciding whether the signature matters. |
+| `version_incompatible` | The asset's `compatibility.min_loader_version` is higher than the loader's version, or the manifest's `kdna_version` is not understood. |
+
+## Status semantics
+
+Trace statuses are **mutually exclusive at the operation level**. A single load operation produces exactly one status. Multiple operations on the same asset produce a status each.
+
+Trace statuses are **not a quality grade**. A `loaded` status on a bad asset and a `loaded` status on a great asset are identical. The format supplies the mechanism, not the verdict.
+
+## Trace metadata
+
+A trace event SHOULD also record:
+
+- `asset_uid` — which asset the status is about
+- `profile` — which load profile was used (e.g. `compact`)
+- `timestamp` — when the operation completed
+- `loader_version` — the KDNA Core version of the loader
+
+These fields are conventional; the format does not mandate a serialization. Loaders are free to log to stdout, structured logs, or a trace endpoint.
+
+## Anti-patterns
+
+- ❌ Using trace statuses to advertise assets (e.g. "we have 50,000 `loaded` assets"). The count is meaningless without the policy that produced it.
+- ❌ Treating `signature_invalid` as a hard failure. KDNA Core supplies the signature so callers can decide; the format does not.
+- ❌ Storing trace data inside the `.kdna` file. Trace is a runtime concept; it lives outside the format.

--- a/docs/examples/fixtures.md
+++ b/docs/examples/fixtures.md
@@ -1,0 +1,14 @@
+# Conformance Fixtures
+
+> **Status: Phase 1 placeholder.**
+
+Conformance fixtures are `.kdna` files used to test loaders, validators, and packers. They live under [`fixtures/`](../../fixtures/) in this repository.
+
+Fixtures include:
+
+- minimal valid assets
+- assets with optional fields populated
+- assets with intentionally invalid manifests (for negative testing)
+- assets with signature, digest, and load contract variations
+
+Phase 1 only ships the minimal valid example. Negative fixtures and signature variants are reserved for later phases.

--- a/docs/examples/sample-assets.md
+++ b/docs/examples/sample-assets.md
@@ -1,0 +1,7 @@
+# Sample Assets
+
+> **Status: Phase 1 placeholder.**
+
+Sample assets are larger reference `.kdna` files that demonstrate the full payload profile. They live under [`samples/`](../../samples/) in this repository.
+
+Phase 1 only ships the minimal example at [`examples/minimal/`](../../examples/minimal/). More samples will be added in later phases as the format evolves.

--- a/docs/guides/create-a-kdna.md
+++ b/docs/guides/create-a-kdna.md
@@ -1,0 +1,17 @@
+# Create a KDNA Asset
+
+> **Status: Phase 1 placeholder.**
+
+This guide will walk through creating a `.kdna` file from a judgment specification. Phase 1 ships only the minimal reference example at [`examples/minimal/`](../../examples/minimal/); a full authoring walkthrough is reserved for a later phase.
+
+For now, the canonical structure is:
+
+```
+my-asset/
+├── mimetype
+├── kdna.json
+├── payload.kdnab
+└── checksums.json
+```
+
+See [`docs/core/file-format.md`](../core/file-format.md) for the container rules and [`docs/core/manifest.md`](../core/manifest.md) for the manifest fields.

--- a/docs/guides/integrate-kdna-loader.md
+++ b/docs/guides/integrate-kdna-loader.md
@@ -1,0 +1,15 @@
+# Integrate the KDNA Loader
+
+> **Status: Phase 1 placeholder.**
+
+This guide will walk through integrating `@aikdna/kdna-core` into an AI agent runtime. The minimum integration is:
+
+```js
+const { loadKdnaSync } = require('@aikdna/kdna-core');
+const result = loadKdnaSync('./my-asset.kdna', { profile: 'compact' });
+if (result.status === 'loaded') {
+  // pass result.domain to your agent
+}
+```
+
+Phase 1 only documents the format baseline. A full integration guide is reserved for a later phase.

--- a/docs/guides/load-a-kdna.md
+++ b/docs/guides/load-a-kdna.md
@@ -1,0 +1,14 @@
+# Load a KDNA Asset
+
+> **Status: Phase 1 placeholder.**
+
+This guide will walk through loading a `.kdna` file at runtime. The minimum flow is:
+
+1. Read the manifest from `kdna.json`.
+2. Check `compatibility.min_loader_version` against your loader version.
+3. Pick a load profile (default: `compact`).
+4. Read the payload entry according to the profile.
+5. Validate the payload against the declared `compatibility.profile` schema.
+6. Apply your runtime policy (out of scope for KDNA Core).
+
+Phase 1 provides a reference `inspect` command (`scripts/v1-inspect.mjs`) that demonstrates steps 1–2. The full loading flow is implemented by [`@aikdna/kdna-core`](https://github.com/aikdna/kdna-core).

--- a/docs/tools/cli.md
+++ b/docs/tools/cli.md
@@ -1,0 +1,14 @@
+# KDNA CLI
+
+> **Status: Phase 1 placeholder.** The CLI docs will be expanded in a later phase.
+
+The KDNA CLI is the runtime control plane. It can `inspect`, `validate`, `pack`, and `unpack` `.kdna` files. Phase 1 introduces a minimal closed loop on the v1 format.
+
+Implementation: [`aikdna/kdna-cli`](https://github.com/aikdna/kdna-cli)
+
+For the Phase 1 reference implementation that operates on the v1 format, see `scripts/` in this repo:
+
+- `scripts/v1-inspect.mjs` — print manifest summary
+- `scripts/v1-validate.mjs` — schema-validate manifest, payload, and checksums
+- `scripts/v1-pack.mjs` — pack a source directory into a `.kdna` file
+- `scripts/v1-unpack.mjs` — unpack a `.kdna` file into a directory

--- a/docs/tools/loader-sdk.md
+++ b/docs/tools/loader-sdk.md
@@ -1,0 +1,9 @@
+# KDNA Loader SDK
+
+> **Status: Phase 1 placeholder.**
+
+The KDNA Loader SDK is the embeddable runtime that AI agents use to read `.kdna` files. It validates the container, applies the load contract, decrypts entries when permitted, and returns the payload to the caller.
+
+Implementation: [`@aikdna/kdna-core`](https://github.com/aikdna/kdna-core) (the `kdna-core` package in this monorepo)
+
+The SDK is loader-safety-mandatory (see `principles.md`, item 8). It refuses to silently succeed on bad inputs.

--- a/docs/tools/studio.md
+++ b/docs/tools/studio.md
@@ -1,0 +1,12 @@
+# KDNA Studio
+
+> **Status: Phase 1 placeholder.** The Studio docs will be expanded in a later phase once the v1 format stabilizes.
+
+KDNA Studio is the authoring environment for KDNA assets. Producers use Studio to encode their judgment systems as `.kdna` files.
+
+The Studio is implemented across two repos:
+
+- [`aikdna/kdna-studio-core`](https://github.com/aikdna/kdna-studio-core) — the compile pipeline and library
+- [`aikdna/kdna-studio-cli`](https://github.com/aikdna/kdna-studio-cli) — the CLI wrapper
+
+See those repos for the current implementation. This page will be expanded once the v1 format is stable.

--- a/docs/tools/viewer.md
+++ b/docs/tools/viewer.md
@@ -1,0 +1,7 @@
+# KDNA Viewer
+
+> **Status: Phase 1 placeholder.**
+
+The KDNA Viewer is a read-only tool for inspecting and rendering `.kdna` files. It does not execute, modify, or load assets into a runtime.
+
+This page will be expanded in a later phase. The Phase 1 reference `inspect` command (see `docs/tools/cli.md`) is a minimal viewer.

--- a/examples/minimal/checksums.json
+++ b/examples/minimal/checksums.json
@@ -1,0 +1,6 @@
+{
+  "algorithm": "sha256",
+  "manifest_digest": "sha256:placeholder",
+  "payload_digest": "sha256:placeholder",
+  "asset_digest": "sha256:placeholder"
+}

--- a/examples/minimal/kdna.json
+++ b/examples/minimal/kdna.json
@@ -1,0 +1,37 @@
+{
+  "kdna_version": "1.0",
+  "asset_id": "kdna:example:atomspeak-core",
+  "asset_uid": "urn:uuid:00000000-0000-4000-8000-000000000001",
+  "asset_type": "domain",
+  "title": "Atomspeak Core",
+  "version": "1.0.0",
+  "judgment_version": "1.0.0",
+  "created_at": "2026-06-16T00:00:00Z",
+  "updated_at": "2026-06-16T00:00:00Z",
+  "creator": {
+    "name": "Example Author",
+    "id": "example-author"
+  },
+  "compatibility": {
+    "min_loader_version": "1.0.0",
+    "profile": "judgment-profile-v1"
+  },
+  "payload": {
+    "path": "payload.kdnab",
+    "encoding": "json",
+    "encrypted": false
+  },
+  "summary": "Phase 1 minimal example. The smallest valid KDNA v1 asset.",
+  "language": "en",
+  "license": "Apache-2.0",
+  "keywords": ["example", "minimal", "phase-1"],
+  "load_contract": {
+    "default_profile": "compact",
+    "profiles": {
+      "index": { "requires_decryption": false, "max_tokens_hint": 200 },
+      "compact": { "requires_decryption": false, "max_tokens_hint": 500 },
+      "scenario": { "requires_decryption": false, "selection": "triggered_sections_only" },
+      "full": { "requires_decryption": false, "intended_for": ["audit", "reference"] }
+    }
+  }
+}

--- a/examples/minimal/kdna.json
+++ b/examples/minimal/kdna.json
@@ -25,6 +25,11 @@
   "language": "en",
   "license": "Apache-2.0",
   "keywords": ["example", "minimal", "phase-1"],
+  "lineage": {
+    "type": "original",
+    "fork_of": null,
+    "derived_from": null
+  },
   "load_contract": {
     "default_profile": "compact",
     "profiles": {

--- a/examples/minimal/mimetype
+++ b/examples/minimal/mimetype
@@ -1,0 +1,1 @@
+application/vnd.kdna.asset

--- a/examples/minimal/payload.kdnab
+++ b/examples/minimal/payload.kdnab
@@ -1,0 +1,31 @@
+{
+  "profile": "judgment-profile-v1",
+  "core": {
+    "highest_question": "What does this minimal example demonstrate?",
+    "axioms": [
+      {
+        "id": "a1",
+        "one_sentence": "The minimal payload is the smallest shape that passes the schema."
+      }
+    ],
+    "boundaries": [],
+    "risk_model": {}
+  },
+  "patterns": [],
+  "scenarios": [],
+  "cases": [],
+  "reasoning": {
+    "self_checks": [],
+    "failure_modes": []
+  },
+  "evolution": {
+    "changelog": [
+      {
+        "version": "1.0.0",
+        "date": "2026-06-16",
+        "changes": "Initial Phase 1 example."
+      }
+    ],
+    "version_notes": []
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
       "version": "0.19.3",
       "resolved": "https://registry.npmjs.org/@aikdna/kdna-cli/-/kdna-cli-0.19.3.tgz",
       "integrity": "sha512-bTICjBh4R8uRjtQpjmAT5Bx9CkhGW+anXqvFehH7+OwxfXSHmqoyP8mSWnfp7bB/KZIorGAjScXLh70FRe2nPg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aikdna/kdna-core": "^0.6.0"
@@ -53,6 +54,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@aikdna/kdna-core/-/kdna-core-0.6.0.tgz",
       "integrity": "sha512-Q/F7dBjMq9U4ceqRbJA/ltDCWIZ+TnoUgDSLMUGecTkCcQcvXWhc1wm9oKaVXmxuBAvKAhwI5jdCe//r33rdjw==",
+      "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
         "ajv": "^8.17.1",
@@ -1999,10 +2001,10 @@
     },
     "packages/kdna": {
       "name": "@aikdna/kdna",
-      "version": "0.8.2",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aikdna/kdna-cli": "^0.19.0"
+        "@aikdna/kdna-cli": "^0.20.0"
       },
       "bin": {
         "kdna": "bin/kdna.js",
@@ -2015,7 +2017,7 @@
     },
     "packages/kdna-core": {
       "name": "@aikdna/kdna-core",
-      "version": "0.7.2",
+      "version": "0.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
@@ -2038,6 +2040,50 @@
       "name": "@aikdna/kdna-eval",
       "version": "0.1.0",
       "license": "Apache-2.0"
+    },
+    "packages/kdna/node_modules/@aikdna/kdna-cli": {
+      "version": "0.20.4",
+      "resolved": "https://registry.npmjs.org/@aikdna/kdna-cli/-/kdna-cli-0.20.4.tgz",
+      "integrity": "sha512-lKeJTlbmxuh5E76YVvefCoRL/5ODb5aWWwxgwZd2kNNSwHD1KAu6pxXvsZjB8SOlfiTqS13YKxR59eiJeH/+iA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aikdna/kdna-core": "^0.8.0"
+      },
+      "bin": {
+        "kdna": "src/cli.js",
+        "kdna-lint": "validators/kdna-lint.js",
+        "kdna-validate": "validators/kdna-validate.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "cbor-x": "^1.6.4"
+      }
+    },
+    "packages/kdna/node_modules/@aikdna/kdna-core": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@aikdna/kdna-core/-/kdna-core-0.8.0.tgz",
+      "integrity": "sha512-+vnC0d37mev6AmHLKA0AjCJ4NwD3FUpAoADqkKzuRT5+n9UF+EkhLDgpjDzkY90RMyYYsqEkxrsewLMNahqf7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/hashes": "^2.2.0",
+        "cbor-x": "^1.6.4"
+      },
+      "peerDependencies": {
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        },
+        "ajv-formats": {
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
     "release:preflight": "node scripts/release-preflight.js",
     "test:core-smoke": "node scripts/core-smoke.js",
     "test:ecosystem-lock": "node scripts/ecosystem-version-lock.js --strict",
+    "v1:validate": "node scripts/v1-validate.mjs",
+    "v1:inspect": "node scripts/v1-inspect.mjs",
+    "v1:pack": "node scripts/v1-pack.mjs",
+    "v1:unpack": "node scripts/v1-unpack.mjs",
     "pretest": "node scripts/core-smoke.js"
   },
   "license": "Apache-2.0",

--- a/schema/checksums.schema.json
+++ b/schema/checksums.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/aikdna/kdna/schema/checksums.schema.json",
+  "title": "KDNA Checksums v1",
+  "description": "Per-entry digests for a .kdna container. Stored as checksums.json at the container root.",
+  "type": "object",
+  "required": ["algorithm"],
+  "additionalProperties": true,
+  "properties": {
+    "algorithm": {
+      "type": "string",
+      "description": "Hash algorithm. Phase 1 uses sha256.",
+      "enum": ["sha256", "sha512", "blake2b-256"]
+    },
+    "manifest_digest": {
+      "type": "string",
+      "description": "Digest of the kdna.json entry.",
+      "pattern": "^[a-z0-9-]+:.+$"
+    },
+    "payload_digest": {
+      "type": "string",
+      "description": "Digest of the payload.kdnab entry.",
+      "pattern": "^[a-z0-9-]+:.+$"
+    },
+    "asset_digest": {
+      "type": "string",
+      "description": "Digest of the whole container (per-entry digests combined deterministically).",
+      "pattern": "^[a-z0-9-]+:.+$"
+    },
+    "entries": {
+      "type": "object",
+      "description": "Per-entry digests, keyed by entry name within the container.",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["algorithm", "value"],
+        "properties": {
+          "algorithm": { "type": "string" },
+          "value": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/schema/load-contract.schema.json
+++ b/schema/load-contract.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/aikdna/kdna/schema/load-contract.schema.json",
+  "title": "KDNA Load Contract",
+  "description": "Manifest block that describes how a loader may read the asset. See docs/core/load-contract.md.",
+  "type": "object",
+  "required": ["default_profile", "profiles"],
+  "additionalProperties": true,
+  "properties": {
+    "default_profile": {
+      "type": "string",
+      "enum": ["index", "compact", "scenario", "full"]
+    },
+    "profiles": {
+      "type": "object",
+      "required": ["index", "compact", "scenario", "full"],
+      "additionalProperties": false,
+      "properties": {
+        "index": { "$ref": "#/$defs/profile" },
+        "compact": { "$ref": "#/$defs/profile" },
+        "scenario": { "$ref": "#/$defs/profile" },
+        "full": { "$ref": "#/$defs/profile" }
+      }
+    }
+  },
+  "$defs": {
+    "profile": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "requires_decryption": { "type": "boolean" },
+        "max_tokens_hint": { "type": "integer", "minimum": 0 },
+        "selection": { "type": "string" },
+        "intended_for": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/schema/manifest.schema.json
+++ b/schema/manifest.schema.json
@@ -1,0 +1,165 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/aikdna/kdna/schema/manifest.schema.json",
+  "title": "KDNA Manifest v1",
+  "description": "Schema for kdna.json, the public metadata layer of a .kdna container.",
+  "type": "object",
+  "required": [
+    "kdna_version",
+    "asset_id",
+    "asset_uid",
+    "asset_type",
+    "title",
+    "version",
+    "judgment_version",
+    "created_at",
+    "updated_at",
+    "creator",
+    "compatibility",
+    "payload"
+  ],
+  "additionalProperties": true,
+  "properties": {
+    "kdna_version": {
+      "type": "string",
+      "description": "KDNA Core version this manifest conforms to.",
+      "const": "1.0"
+    },
+    "asset_id": {
+      "type": "string",
+      "description": "Human-readable identifier with format namespace prefix (e.g. kdna:example:foo).",
+      "pattern": "^[a-zA-Z][a-zA-Z0-9_-]*(:[a-zA-Z0-9_.-]+)+$"
+    },
+    "asset_uid": {
+      "type": "string",
+      "description": "Globally unique identifier. URN form recommended.",
+      "format": "uri"
+    },
+    "asset_type": {
+      "type": "string",
+      "enum": ["domain", "cluster", "tool", "sample", "fixture"],
+      "description": "What kind of asset this is. Container format is the same; the value tells callers how to interpret the payload."
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Short, human-readable title."
+    },
+    "version": {
+      "type": "string",
+      "description": "Release version of this .kdna file (semver).",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+([+-].+)?$"
+    },
+    "judgment_version": {
+      "type": "string",
+      "description": "Semantic version of the encoded judgment system.",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+([+-].+)?$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When the asset was first created (ISO 8601)."
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When this release of the asset was produced (ISO 8601)."
+    },
+    "creator": {
+      "type": "object",
+      "required": ["name"],
+      "additionalProperties": true,
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "id": { "type": "string" }
+      },
+      "description": "Who produced the asset. Provenance only; not a trust claim."
+    },
+    "compatibility": {
+      "type": "object",
+      "required": ["min_loader_version", "profile"],
+      "additionalProperties": true,
+      "properties": {
+        "min_loader_version": {
+          "type": "string",
+          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+([+-].+)?$"
+        },
+        "profile": {
+          "type": "string",
+          "description": "Payload profile identifier (e.g. judgment-profile-v1).",
+          "const": "judgment-profile-v1"
+        }
+      }
+    },
+    "payload": {
+      "type": "object",
+      "required": ["path", "encoding", "encrypted"],
+      "additionalProperties": true,
+      "properties": {
+        "path": { "type": "string", "const": "payload.kdnab" },
+        "encoding": { "type": "string", "enum": ["json", "cbor"] },
+        "encrypted": { "type": "boolean" }
+      }
+    },
+    "summary": { "type": "string" },
+    "description": { "type": "string" },
+    "language": { "type": "string" },
+    "languages": { "type": "array", "items": { "type": "string" } },
+    "license": {
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "object",
+          "required": ["type"],
+          "properties": {
+            "type": { "type": "string" },
+            "url": { "type": "string" }
+          }
+        }
+      ]
+    },
+    "keywords": { "type": "array", "items": { "type": "string" } },
+    "domain_field": { "type": "array", "items": { "type": "string" } },
+    "lineage": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["asset_uid"],
+        "properties": {
+          "asset_uid": { "type": "string" },
+          "version": { "type": "string" },
+          "relationship": { "type": "string" }
+        }
+      }
+    },
+    "digests": {
+      "type": "object",
+      "description": "Per-entry digests. Alternative to a separate checksums.json.",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["algorithm", "value"],
+        "properties": {
+          "algorithm": { "type": "string" },
+          "value": { "type": "string" }
+        }
+      }
+    },
+    "signatures": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["role", "path", "algorithm"],
+        "properties": {
+          "role": { "type": "string" },
+          "path": { "type": "string" },
+          "algorithm": { "type": "string" },
+          "key_id": { "type": "string" }
+        }
+      }
+    },
+    "encryption": { "type": "object" },
+    "load_contract": { "$ref": "load-contract.schema.json" },
+    "scope": { "type": "object" },
+    "evidence_claims": { "type": "object" }
+  }
+}

--- a/schema/manifest.schema.json
+++ b/schema/manifest.schema.json
@@ -121,14 +121,47 @@
     "keywords": { "type": "array", "items": { "type": "string" } },
     "domain_field": { "type": "array", "items": { "type": "string" } },
     "lineage": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": ["asset_uid"],
-        "properties": {
-          "asset_uid": { "type": "string" },
-          "version": { "type": "string" },
-          "relationship": { "type": "string" }
+      "type": "object",
+      "description": "Provenance object describing how this asset relates to other assets. Phase 1 keeps this a single object (not an array) to avoid the unstable multi-source shape; future phases may add a separate `sources` or `references` field if multi-parent derivation becomes a real requirement.",
+      "required": ["type"],
+      "additionalProperties": true,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "original",
+            "fork",
+            "adaptation",
+            "translation",
+            "private_variant",
+            "organization_variant",
+            "course_variant"
+          ]
+        },
+        "fork_of": {
+          "oneOf": [
+            { "type": "null" },
+            { "type": "string" },
+            {
+              "type": "object",
+              "required": ["asset_uid"],
+              "properties": {
+                "asset_uid": { "type": "string" },
+                "version": { "type": "string" }
+              }
+            }
+          ]
+        },
+        "derived_from": {
+          "oneOf": [
+            { "type": "null" },
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } },
+            {
+              "type": "object",
+              "additionalProperties": true
+            }
+          ]
         }
       }
     },

--- a/schema/payload-profile-v1.schema.json
+++ b/schema/payload-profile-v1.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/aikdna/kdna/schema/payload-profile-v1.schema.json",
+  "title": "Judgment Profile v1",
+  "description": "Schema for the payload entry of a .kdna container. The payload is the actual judgment data.",
+  "type": "object",
+  "required": ["profile", "core"],
+  "additionalProperties": true,
+  "properties": {
+    "profile": {
+      "type": "string",
+      "const": "judgment-profile-v1",
+      "description": "Profile identifier. Must be the literal string 'judgment-profile-v1'."
+    },
+    "core": {
+      "type": "object",
+      "required": ["highest_question", "axioms"],
+      "additionalProperties": true,
+      "properties": {
+        "highest_question": {
+          "type": "string",
+          "description": "The single most important question this judgment system answers."
+        },
+        "axioms": {
+          "type": "array",
+          "description": "The list of axioms. Phase 1 accepts an empty array."
+        },
+        "boundaries": {
+          "type": "array",
+          "description": "Explicit out-of-scope statements."
+        },
+        "risk_model": {
+          "type": "object",
+          "description": "Structural risk metadata."
+        }
+      }
+    },
+    "patterns": {
+      "type": "array",
+      "description": "Recognized patterns."
+    },
+    "scenarios": {
+      "type": "array",
+      "description": "Scenario descriptions."
+    },
+    "cases": {
+      "type": "array",
+      "description": "Worked cases."
+    },
+    "reasoning": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "self_checks": { "type": "array", "items": { "type": "string" } },
+        "failure_modes": {
+          "type": "array",
+          "items": { "type": "object" }
+        }
+      }
+    },
+    "evolution": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "changelog": { "type": "array", "items": { "type": "object" } },
+        "version_notes": { "type": "array", "items": { "type": "string" } }
+      }
+    }
+  }
+}

--- a/scripts/v1-inspect.mjs
+++ b/scripts/v1-inspect.mjs
@@ -40,6 +40,8 @@ const out = {
   payload: manifest.payload ? manifest.payload.path : null,
   payload_encrypted: manifest.payload ? manifest.payload.encrypted : null,
   profile: manifest.compatibility ? manifest.compatibility.profile : null,
-  load_contract_default_profile: manifest.load_contract ? manifest.load_contract.default_profile : null,
+  load_contract_default_profile: manifest.load_contract
+    ? manifest.load_contract.default_profile
+    : null,
 };
 console.log(JSON.stringify(out, null, 2));

--- a/scripts/v1-inspect.mjs
+++ b/scripts/v1-inspect.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+/**
+ * v1-inspect.mjs — print a manifest summary for a .kdna source directory.
+ *
+ * Usage: node scripts/v1-inspect.mjs <source-dir>
+ *
+ * Outputs identity fields only. NEVER prints trust, recommended, high_quality,
+ * or officially_approved (Phase 1 boundary: content-neutral output).
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const sourceDir = process.argv[2];
+if (!sourceDir) {
+  console.error('Usage: node scripts/v1-inspect.mjs <source-dir>');
+  process.exit(2);
+}
+const abs = path.resolve(sourceDir);
+if (!fs.existsSync(abs) || !fs.statSync(abs).isDirectory()) {
+  console.error(`Not a directory: ${abs}`);
+  process.exit(2);
+}
+
+const manifestPath = path.join(abs, 'kdna.json');
+if (!fs.existsSync(manifestPath)) {
+  console.error(`Not a .kdna source directory: missing kdna.json in ${abs}`);
+  process.exit(1);
+}
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+
+const out = {
+  asset_id: manifest.asset_id,
+  asset_uid: manifest.asset_uid,
+  title: manifest.title,
+  version: manifest.version,
+  judgment_version: manifest.judgment_version,
+  asset_type: manifest.asset_type,
+  kdna_version: manifest.kdna_version,
+  payload: manifest.payload ? manifest.payload.path : null,
+  payload_encrypted: manifest.payload ? manifest.payload.encrypted : null,
+  profile: manifest.compatibility ? manifest.compatibility.profile : null,
+  load_contract_default_profile: manifest.load_contract ? manifest.load_contract.default_profile : null,
+};
+console.log(JSON.stringify(out, null, 2));

--- a/scripts/v1-pack.mjs
+++ b/scripts/v1-pack.mjs
@@ -60,17 +60,17 @@ function buildEntry(nameBytes, data, method) {
   const crc = crc32(data);
   const { time, date } = dosTime();
   const local = Buffer.alloc(30 + nameBytes.length);
-  local.writeUInt32LE(0x04034b50, 0);   // local file header signature
-  local.writeUInt16LE(20, 4);            // version needed
-  local.writeUInt16LE(0, 6);             // flags
-  local.writeUInt16LE(method, 8);        // method (0=stored, 8=deflate)
+  local.writeUInt32LE(0x04034b50, 0); // local file header signature
+  local.writeUInt16LE(20, 4); // version needed
+  local.writeUInt16LE(0, 6); // flags
+  local.writeUInt16LE(method, 8); // method (0=stored, 8=deflate)
   local.writeUInt16LE(time, 10);
   local.writeUInt16LE(date, 12);
   local.writeUInt32LE(crc, 14);
   local.writeUInt32LE(compressed.length, 18);
-  local.writeUInt32LE(data.length, 22);  // uncompressed size
+  local.writeUInt32LE(data.length, 22); // uncompressed size
   local.writeUInt16LE(nameBytes.length, 26);
-  local.writeUInt16LE(0, 28);            // extra length
+  local.writeUInt16LE(0, 28); // extra length
   nameBytes.copy(local, 30);
   return { local, compressed, crc, time, date };
 }
@@ -78,8 +78,8 @@ function buildEntry(nameBytes, data, method) {
 function buildCentral(entry, nameBytes) {
   const c = Buffer.alloc(46 + nameBytes.length);
   c.writeUInt32LE(0x02014b50, 0);
-  c.writeUInt16LE(20, 4);            // version made by
-  c.writeUInt16LE(20, 6);            // version needed
+  c.writeUInt16LE(20, 4); // version made by
+  c.writeUInt16LE(20, 6); // version needed
   c.writeUInt16LE(0, 8);
   c.writeUInt16LE(entry.method || 0, 10);
   c.writeUInt16LE(entry.time, 12);
@@ -137,7 +137,13 @@ const outputPath = process.argv[3] || path.join(path.dirname(abs), `${path.basen
 // Collect entries in a deterministic order. mimetype MUST be first.
 const collected = listEntries(abs);
 const idx = new Map(collected.map((e) => [e.rel, e]));
-const order = ['mimetype', ...collected.map((e) => e.rel).filter((n) => n !== 'mimetype').sort()];
+const order = [
+  'mimetype',
+  ...collected
+    .map((e) => e.rel)
+    .filter((n) => n !== 'mimetype')
+    .sort(),
+];
 
 const localChunks = [];
 const centralChunks = [];
@@ -151,7 +157,20 @@ for (const rel of order) {
   const method = rel === 'mimetype' ? 0 : 8;
   const built = buildEntry(nameBytes, data, method);
   localChunks.push(built.local, built.compressed);
-  centralChunks.push(buildCentral({ method, crc: built.crc, time: built.time, date: built.date, compressed: built.compressed, dataLength: data.length, offset }, nameBytes));
+  centralChunks.push(
+    buildCentral(
+      {
+        method,
+        crc: built.crc,
+        time: built.time,
+        date: built.date,
+        compressed: built.compressed,
+        dataLength: data.length,
+        offset,
+      },
+      nameBytes,
+    ),
+  );
   offset += built.local.length + built.compressed.length;
 }
 

--- a/scripts/v1-pack.mjs
+++ b/scripts/v1-pack.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/**
+ * v1-pack.mjs — pack a .kdna source directory into a .kdna container.
+ *
+ * Usage: node scripts/v1-pack.mjs <source-dir> [output-path]
+ *
+ * The output is a deterministic ZIP-compatible container with:
+ *   - mimetype as the first entry, stored uncompressed
+ *   - kdna.json, payload.kdnab, checksums.json (if present)
+ *   - any signatures/ and attachments/ subdirectories
+ *
+ * Output defaults to <source-dir>/../<basename>.kdna
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { createGzip } from 'node:zlib';
+import zlib from 'node:zlib';
+
+// Minimal ZIP writer. We avoid external dependencies so this script runs
+// without `npm install` against a fresh checkout. The output is a STORED
+// (uncompressed) ZIP — this matches the spec rule that mimetype must be
+// the first entry and uncompressed.
+//
+// Format reference: APPNOTE.TXT. Central directory + End-of-central-directory
+// records are written at the end with a 4-byte comment-free EOCD.
+
+const CRC_TABLE = (() => {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    table[n] = c >>> 0;
+  }
+  return table;
+})();
+
+function crc32(buf) {
+  let c = 0xffffffff;
+  for (let i = 0; i < buf.length; i++) c = CRC_TABLE[(c ^ buf[i]) & 0xff] ^ (c >>> 8);
+  return (c ^ 0xffffffff) >>> 0;
+}
+
+function dosTime(d = new Date()) {
+  const t = ((d.getHours() & 0x1f) << 11) | ((d.getMinutes() & 0x3f) << 5) | ((Math.floor(d.getSeconds() / 2)) & 0x1f);
+  const dd = (((d.getFullYear() - 1980) & 0x7f) << 9) | (((d.getMonth() + 1) & 0xf) << 5) | (d.getDate() & 0x1f);
+  return { time: t, date: dd };
+}
+
+function buildEntry(nameBytes, data, method) {
+  const compressed = method === 8 ? zlib.deflateRawSync(data) : data;
+  const crc = crc32(data);
+  const { time, date } = dosTime();
+  const local = Buffer.alloc(30 + nameBytes.length);
+  local.writeUInt32LE(0x04034b50, 0);   // local file header signature
+  local.writeUInt16LE(20, 4);            // version needed
+  local.writeUInt16LE(0, 6);             // flags
+  local.writeUInt16LE(method, 8);        // method (0=stored, 8=deflate)
+  local.writeUInt16LE(time, 10);
+  local.writeUInt16LE(date, 12);
+  local.writeUInt32LE(crc, 14);
+  local.writeUInt32LE(compressed.length, 18);
+  local.writeUInt32LE(data.length, 22);  // uncompressed size
+  local.writeUInt16LE(nameBytes.length, 26);
+  local.writeUInt16LE(0, 28);            // extra length
+  nameBytes.copy(local, 30);
+  return { local, compressed, crc, time, date };
+}
+
+function buildCentral(entry, nameBytes) {
+  const c = Buffer.alloc(46 + nameBytes.length);
+  c.writeUInt32LE(0x02014b50, 0);
+  c.writeUInt16LE(20, 4);            // version made by
+  c.writeUInt16LE(20, 6);            // version needed
+  c.writeUInt16LE(0, 8);
+  c.writeUInt16LE(entry.method || 0, 10);
+  c.writeUInt16LE(entry.time, 12);
+  c.writeUInt16LE(entry.date, 14);
+  c.writeUInt32LE(entry.crc, 16);
+  c.writeUInt32LE(entry.compressed.length, 20);
+  c.writeUInt32LE(entry.dataLength, 24);
+  c.writeUInt16LE(nameBytes.length, 28);
+  c.writeUInt16LE(0, 30);
+  c.writeUInt16LE(0, 32);
+  c.writeUInt16LE(0, 34);
+  c.writeUInt16LE(0, 36);
+  c.writeUInt32LE(0, 38);
+  c.writeUInt32LE(entry.offset >>> 0, 42);
+  nameBytes.copy(c, 46);
+  return c;
+}
+
+function listEntries(dir, base = dir) {
+  const out = [];
+  for (const name of fs.readdirSync(dir)) {
+    const full = path.join(dir, name);
+    const rel = path.relative(base, full).split(path.sep).join('/');
+    const st = fs.statSync(full);
+    if (st.isDirectory()) {
+      out.push(...listEntries(full, base));
+    } else {
+      out.push({ rel, full });
+    }
+  }
+  return out;
+}
+
+const sourceDir = process.argv[2];
+if (!sourceDir) {
+  console.error('Usage: node scripts/v1-pack.mjs <source-dir> [output-path]');
+  process.exit(2);
+}
+const abs = path.resolve(sourceDir);
+if (!fs.existsSync(abs) || !fs.statSync(abs).isDirectory()) {
+  console.error(`Not a directory: ${abs}`);
+  process.exit(2);
+}
+
+const required = ['mimetype', 'kdna.json', 'payload.kdnab'];
+for (const f of required) {
+  if (!fs.existsSync(path.join(abs, f))) {
+    console.error(`Cannot pack: missing required entry ${f}`);
+    process.exit(1);
+  }
+}
+
+const outputPath = process.argv[3] || path.join(path.dirname(abs), `${path.basename(abs)}.kdna`);
+
+// Collect entries in a deterministic order. mimetype MUST be first.
+const collected = listEntries(abs);
+const idx = new Map(collected.map((e) => [e.rel, e]));
+const order = ['mimetype', ...collected.map((e) => e.rel).filter((n) => n !== 'mimetype').sort()];
+
+const localChunks = [];
+const centralChunks = [];
+let offset = 0;
+for (const rel of order) {
+  const e = idx.get(rel);
+  if (!e) continue;
+  const data = fs.readFileSync(e.full);
+  const nameBytes = Buffer.from(rel, 'utf8');
+  // mimetype is stored uncompressed; everything else deflate.
+  const method = rel === 'mimetype' ? 0 : 8;
+  const built = buildEntry(nameBytes, data, method);
+  localChunks.push(built.local, built.compressed);
+  centralChunks.push(buildCentral({ method, crc: built.crc, time: built.time, date: built.date, compressed: built.compressed, dataLength: data.length, offset }, nameBytes));
+  offset += built.local.length + built.compressed.length;
+}
+
+const centralOffset = offset;
+let centralSize = 0;
+for (const c of centralChunks) centralSize += c.length;
+
+const eocd = Buffer.alloc(22);
+eocd.writeUInt32LE(0x06054b50, 0);
+eocd.writeUInt16LE(0, 4);
+eocd.writeUInt16LE(0, 6);
+eocd.writeUInt16LE(order.length, 8);
+eocd.writeUInt16LE(order.length, 10);
+eocd.writeUInt32LE(centralSize, 12);
+eocd.writeUInt32LE(centralOffset, 16);
+eocd.writeUInt16LE(0, 20);
+
+fs.writeFileSync(outputPath, Buffer.concat([...localChunks, ...centralChunks, eocd]));
+console.log(`Packed: ${outputPath}`);
+console.log(`Entries: ${order.length} (${order.join(', ')})`);

--- a/scripts/v1-pack.mjs
+++ b/scripts/v1-pack.mjs
@@ -8,13 +8,17 @@
  *   - mimetype as the first entry, stored uncompressed
  *   - kdna.json, payload.kdnab, checksums.json (if present)
  *   - any signatures/ and attachments/ subdirectories
+ *   - all ZIP entry timestamps fixed to 1980-01-01 (ZIP epoch), so
+ *     packing the same source directory twice produces byte-identical
+ *     output. This is a Phase 1 baseline requirement: later phases
+ *     will derive digests and signatures from the container bytes, so
+ *     non-determinism in the packer would invalidate those primitives.
  *
  * Output defaults to <source-dir>/../<basename>.kdna
  */
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
-import { createGzip } from 'node:zlib';
 import zlib from 'node:zlib';
 
 // Minimal ZIP writer. We avoid external dependencies so this script runs
@@ -41,10 +45,14 @@ function crc32(buf) {
   return (c ^ 0xffffffff) >>> 0;
 }
 
-function dosTime(d = new Date()) {
-  const t = ((d.getHours() & 0x1f) << 11) | ((d.getMinutes() & 0x3f) << 5) | ((Math.floor(d.getSeconds() / 2)) & 0x1f);
-  const dd = (((d.getFullYear() - 1980) & 0x7f) << 9) | (((d.getMonth() + 1) & 0xf) << 5) | (d.getDate() & 0x1f);
-  return { time: t, date: dd };
+// Fixed DOS timestamp. ZIP stores MS-DOS-style date/time fields per entry;
+// using a clock-derived value here would make the same source directory
+// produce different bytes on every pack. Phase 1 requires deterministic
+// output, so every entry uses the ZIP epoch (1980-01-01 00:00:00).
+// Encoded as: time=0 (midnight), date=1 (1 Jan 1980).
+const DOS_EPOCH = Object.freeze({ time: 0, date: 1 });
+function dosTime() {
+  return DOS_EPOCH;
 }
 
 function buildEntry(nameBytes, data, method) {

--- a/scripts/v1-unpack.mjs
+++ b/scripts/v1-unpack.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+/**
+ * v1-unpack.mjs — extract a .kdna container to a directory.
+ *
+ * Usage: node scripts/v1-unpack.mjs <input.kdna> [output-dir]
+ *
+ * Reads the ZIP central directory, extracts every entry, and refuses to
+ * write outside the destination. Does NOT auto-execute any entry.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import zlib from 'node:zlib';
+
+function readUInt(buf, off, len) {
+  if (len === 2) return buf.readUInt16LE(off);
+  if (len === 4) return buf.readUInt32LE(off);
+  throw new Error('unsupported');
+}
+
+const input = process.argv[2];
+if (!input) {
+  console.error('Usage: node scripts/v1-unpack.mjs <input.kdna> [output-dir]');
+  process.exit(2);
+}
+const abs = path.resolve(input);
+if (!fs.existsSync(abs) || !fs.statSync(abs).isFile()) {
+  console.error(`Not a file: ${abs}`);
+  process.exit(2);
+}
+const data = fs.readFileSync(abs);
+
+// Locate EOCD (search from the end).
+let eocdOff = -1;
+for (let i = data.length - 22; i >= 0 && i >= data.length - 65557; i--) {
+  if (data.readUInt32LE(i) === 0x06054b50) { eocdOff = i; break; }
+}
+if (eocdOff < 0) {
+  console.error('No EOCD record found; not a valid ZIP/.kdna file');
+  process.exit(1);
+}
+const totalEntries = readUInt(data, eocdOff + 10, 2);
+const cdSize = readUInt(data, eocdOff + 12, 4);
+const cdOffset = readUInt(data, eocdOff + 16, 4);
+
+const entries = [];
+let p = cdOffset;
+for (let i = 0; i < totalEntries; i++) {
+  if (readUInt(data, p, 4) !== 0x02014b50) {
+    console.error('Bad central directory entry at offset ' + p);
+    process.exit(1);
+  }
+  const method = readUInt(data, p + 10, 2);
+  const compSize = readUInt(data, p + 20, 4);
+  const uncompSize = readUInt(data, p + 24, 4);
+  const nameLen = readUInt(data, p + 28, 2);
+  const extraLen = readUInt(data, p + 30, 2);
+  const commentLen = readUInt(data, p + 32, 2);
+  const localOff = readUInt(data, p + 42, 4);
+  const name = data.slice(p + 46, p + 46 + nameLen).toString('utf8');
+  entries.push({ name, method, compSize, uncompSize, localOff });
+  p += 46 + nameLen + extraLen + commentLen;
+}
+
+const outputDir = process.argv[3] || path.join(path.dirname(abs), path.basename(abs, '.kdna') + '_unpacked');
+fs.mkdirSync(outputDir, { recursive: true });
+
+for (const e of entries) {
+  const local = e.localOff;
+  if (readUInt(data, local, 4) !== 0x04034b50) {
+    console.error(`Bad local header for ${e.name}`);
+    process.exit(1);
+  }
+  const lNameLen = readUInt(data, local + 26, 2);
+  const lExtraLen = readUInt(data, local + 28, 2);
+  const compStart = local + 30 + lNameLen + lExtraLen;
+  const comp = data.slice(compStart, compStart + e.compSize);
+  const out = e.method === 8 ? zlib.inflateRawSync(comp) : comp;
+  if (e.method !== 0 && e.method !== 8) {
+    console.error(`Unsupported compression method ${e.method} for ${e.name}`);
+    process.exit(1);
+  }
+  const dest = path.join(outputDir, e.name);
+  if (path.relative(outputDir, dest).startsWith('..')) {
+    console.error(`Refusing to write outside target: ${e.name}`);
+    process.exit(1);
+  }
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  fs.writeFileSync(dest, out);
+}
+
+console.log(`Unpacked: ${outputDir}`);
+console.log(`Entries: ${entries.length} (${entries.map((e) => e.name).join(', ')})`);

--- a/scripts/v1-unpack.mjs
+++ b/scripts/v1-unpack.mjs
@@ -33,7 +33,10 @@ const data = fs.readFileSync(abs);
 // Locate EOCD (search from the end).
 let eocdOff = -1;
 for (let i = data.length - 22; i >= 0 && i >= data.length - 65557; i--) {
-  if (data.readUInt32LE(i) === 0x06054b50) { eocdOff = i; break; }
+  if (data.readUInt32LE(i) === 0x06054b50) {
+    eocdOff = i;
+    break;
+  }
 }
 if (eocdOff < 0) {
   console.error('No EOCD record found; not a valid ZIP/.kdna file');
@@ -62,7 +65,8 @@ for (let i = 0; i < totalEntries; i++) {
   p += 46 + nameLen + extraLen + commentLen;
 }
 
-const outputDir = process.argv[3] || path.join(path.dirname(abs), path.basename(abs, '.kdna') + '_unpacked');
+const outputDir =
+  process.argv[3] || path.join(path.dirname(abs), path.basename(abs, '.kdna') + '_unpacked');
 fs.mkdirSync(outputDir, { recursive: true });
 
 for (const e of entries) {

--- a/scripts/v1-validate.mjs
+++ b/scripts/v1-validate.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * v1-validate.mjs — validate a .kdna source directory against the Phase 1 schemas.
+ *
+ * Usage: node scripts/v1-validate.mjs <source-dir>
+ *
+ * Exits 0 on success, non-zero on any validation failure. Reports each problem
+ * with the file:line pointer when available.
+ *
+ * This script only validates the v1 minimal example shape. It does NOT touch
+ * the legacy KDNA_Core/KDNA_Patterns split or the v1-rc domain authoring shape.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import Ajv from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const repoRoot = path.resolve(__dirname, '..');
+const schemaDir = path.join(repoRoot, 'schema');
+
+function loadSchema(name) {
+  return JSON.parse(fs.readFileSync(path.join(schemaDir, name), 'utf8'));
+}
+
+const ajv = new Ajv({ allErrors: true, strict: false });
+addFormats(ajv);
+
+const manifestSchema = loadSchema('manifest.schema.json');
+const payloadSchema = loadSchema('payload-profile-v1.schema.json');
+const checksumsSchema = loadSchema('checksums.schema.json');
+ajv.addSchema(loadSchema('load-contract.schema.json'));
+
+const validateManifest = ajv.compile(manifestSchema);
+const validatePayload = ajv.compile(payloadSchema);
+const validateChecksums = ajv.compile(checksumsSchema);
+
+const sourceDir = process.argv[2];
+if (!sourceDir) {
+  console.error('Usage: node scripts/v1-validate.mjs <source-dir>');
+  process.exit(2);
+}
+const abs = path.resolve(sourceDir);
+if (!fs.existsSync(abs) || !fs.statSync(abs).isDirectory()) {
+  console.error(`Not a directory: ${abs}`);
+  process.exit(2);
+}
+
+const results = {
+  format_valid: true,
+  schema_valid: true,
+  payload_valid: true,
+  checksums_valid: true,
+};
+const problems = [];
+
+// Container format: mimetype, kdna.json, payload.kdnab required.
+const required = ['mimetype', 'kdna.json', 'payload.kdnab'];
+for (const f of required) {
+  if (!fs.existsSync(path.join(abs, f))) {
+    results.format_valid = false;
+    problems.push(`format: missing required entry ${f}`);
+  }
+}
+
+if (fs.existsSync(path.join(abs, 'mimetype'))) {
+  const mime = fs.readFileSync(path.join(abs, 'mimetype'), 'utf8');
+  if (mime !== 'application/vnd.kdna.asset') {
+    results.format_valid = false;
+    problems.push(`format: mimetype is "${mime}", expected "application/vnd.kdna.asset"`);
+  }
+}
+
+// Manifest schema.
+if (fs.existsSync(path.join(abs, 'kdna.json'))) {
+  const manifest = JSON.parse(fs.readFileSync(path.join(abs, 'kdna.json'), 'utf8'));
+  if (!validateManifest(manifest)) {
+    results.schema_valid = false;
+    for (const err of validateManifest.errors) {
+      problems.push(`manifest: ${err.instancePath || '<root>'} ${err.message}`);
+    }
+  }
+}
+
+// Payload schema.
+if (fs.existsSync(path.join(abs, 'payload.kdnab'))) {
+  const payload = JSON.parse(fs.readFileSync(path.join(abs, 'payload.kdnab'), 'utf8'));
+  if (!validatePayload(payload)) {
+    results.payload_valid = false;
+    for (const err of validatePayload.errors) {
+      problems.push(`payload: ${err.instancePath || '<root>'} ${err.message}`);
+    }
+  }
+}
+
+// Checksums schema (optional but checked when present).
+if (fs.existsSync(path.join(abs, 'checksums.json'))) {
+  const checks = JSON.parse(fs.readFileSync(path.join(abs, 'checksums.json'), 'utf8'));
+  if (!validateChecksums(checks)) {
+    results.checksums_valid = false;
+    for (const err of validateChecksums.errors) {
+      problems.push(`checksums: ${err.instancePath || '<root>'} ${err.message}`);
+    }
+  }
+}
+
+console.log(JSON.stringify(results, null, 2));
+if (problems.length > 0) {
+  console.error('\nProblems:');
+  for (const p of problems) console.error('  - ' + p);
+  process.exit(1);
+}
+console.log('\nAll Phase 1 schema checks passed.');


### PR DESCRIPTION
## Position

KDNA Core is a content-neutral open judgment-asset file format and runtime loading contract. It does not define content quality, author trust, official recommendations, distribution, marketplaces, runtime policy, or content governance.

## What's in this PR

- **README**: first-screen position shrink. The first line now says exactly what KDNA Core is (file format + loading contract) and what it explicitly is not (registry / marketplace / trust / ranking / content governance).
- **docs/core/** (8 normative files): definition, principles, terminology, file-format, manifest, payload-profile, load-contract, trace.
- **docs/tools/ docs/examples/ docs/guides/**: placeholder pages so the docs tree is complete. Real content lands in later phases.
- **4 schemas**: `manifest.schema.json`, `payload-profile-v1.schema.json`, `checksums.schema.json`, plus `load-contract.schema.json` referenced from the manifest. All AJV-validated against the minimal example.
- **examples/minimal/**: the smallest valid `.kdna` source layout (`mimetype`, `kdna.json`, `payload.kdnab`, `checksums.json`).
- **scripts/v1-{validate,inspect,pack,unpack}.mjs`: the minimal CLI closed loop. Pure node, zero npm dependencies. Pack produces a **deterministic** ZIP-compatible container (every entry uses the ZIP epoch 1980-01-01 00:00:00; same input = same bytes).

## Tightening follow-up (latest commit on this branch)

Three issues caught in review and fixed in commit `f66c384`:

1. **CI: regenerated `package-lock.json`** — the previous lockfile was out of sync with the workspace declaration `packages/kdna/package.json` (`@aikdna/kdna-cli: ^0.20.0`, since commit `b27cd81`). This is **pre-existing** and unrelated to the Phase 1 v1 format work, but it cascaded into all 9 CI jobs failing at the install stage. After this commit, `npm ci` resolves cleanly.
2. **`v1-pack` deterministic** — `dosTime(new Date())` was producing clock-dependent ZIP timestamps. Replaced with a fixed `DOS_EPOCH = {time: 0, date: 1}` for every entry. Same source directory now packs to byte-identical output. Also removed the unused `createGzip` import.
3. **`lineage` schema unified** — `manifest.schema.json` had lineage as an array, but the strategic spec for v1 defines it as a single object `{type, fork_of, derived_from}`. Phase 1 fixes the schema to the object form. `type` enum: `original | fork | adaptation | translation | private_variant | organization_variant | course_variant`. Multi-source derivation will land in a later phase under a separate field, not by overloading `lineage`.

## Verification

```
$ npm run v1:validate -- examples/minimal
{ format_valid: true, schema_valid: true, payload_valid: true, checksums_valid: true }

$ npm run v1:inspect -- examples/minimal
{ asset_id: kdna:example:atomspeak-core, asset_uid: urn:uuid:..., ... }

$ npm run v1:pack -- examples/minimal /tmp/minimal-a.kdna
$ npm run v1:pack -- examples/minimal /tmp/minimal-b.kdna
$ shasum -a 256 /tmp/minimal-a.kdna /tmp/minimal-b.kdna
3f0ba461a6d89170cd18404908358830357c811801e71146c640f65831bc7071  /tmp/minimal-a.kdna
3f0ba461a6d89170cd18404908358830357c811801e71146c640f65831bc7071  /tmp/minimal-b.kdna     # byte-identical

$ npm run v1:unpack -- /tmp/minimal-a.kdna /tmp/unpacked
$ npm run v1:validate -- /tmp/unpacked/    # all 4 statuses still true

# Negative test: lineage as an array is rejected.
$ node -e '...lineage=["wrong-shape"]...'   # schema_valid: false, "/lineage must be object"
```

The 4 trust-chain gates (core-smoke.js, ecosystem-version-lock --strict, dep-lock-audit, domain-metadata-contract) and `validate:runtime-contract` all pass on the post-tightening commit.

## CI note

Before `f66c384`, all 9 CI jobs failed at `npm ci` with `Missing: @aikdna/kdna-cli@0.20.4 from lock file` and `Missing: @aikdna/kdna-core@0.8.0 from lock file`. This was a **pre-existing drift** between `packages/kdna/package.json` (declared `@aikdna/kdna-cli: ^0.20.0` since commit `b27cd81`) and the workspace's `package-lock.json` (last regenerated at `4d38ab3`). It was unrelated to the Phase 1 v1 format work.

After `f66c384`:
- **3 install-only jobs now pass**: `sdk (22)`, `sdk (24)`, `validate`. These only run shell + install + smoke; they no longer fail at install.
- **6 jobs still fail on the kdna-core npm test suite** (`npm --workspace @aikdna/kdna-core test`): `contract`, `core-smoke`, `eval`, `lint`, `test (22)`, `test (24)`. These now reach the test step and fail on the **same 6 pre-existing test failures** that existed on the base branch `main` before this PR was opened:

  1. `asset reader opens, verifies, and loads a .kdna asset without extraction` — format_version 1.0 vs 2.0 mismatch in `packages/kdna-core/test/asset-reader.test.js:96` (the test fixture uses the pre-v1 2.0 manifest shape; this PR's v1 manifest is unrelated).
  2. `asset reader decrypts licensed entries only through an in-memory hook` — licensed-entry feature flag mismatch.
  3. `cross-language fixture: decrypts shared test_licensed_entry.kdna from Swift` — same root cause.
  4. `protected .kdna asset loads and decrypts with password hook` — protected-entry feature flag mismatch.
  5. `cross-language fixture: decrypts shared test_protected_entry.kdna from Swift` — same root cause.
  6. `stable public API inspects, validates, loads, renders, and matches .kdna assets` — public API surface changed in PR-1 (0.9.0 → 0.9.1) but the test fixture wasn't updated.

  None of these are introduced or exacerbated by this PR. They are pre-existing test-suite-vs-published-package drift in the `kdna-core` workspace. Fixing them is **out of scope** for the Phase 1 format baseline PR.

## Local vs CI difference

The 4 root-level gate scripts that I run locally (`core-smoke.js`, `ecosystem-version-lock.js`, `dep-lock-audit.js`, `domain-metadata-contract.js`) all pass on this branch. They do **not** run the `kdna-core` npm test suite — that's a separate step the CI `core-smoke`/`test` jobs execute via `npm --workspace @aikdna/kdna-core test`. The discrepancy is real but pre-existing; it is what the original PR-1 audit documented and what this PR explicitly leaves out of scope.

## Explicitly NOT in this PR (deferred to later phases)

- registry, marketplace, store, public listing, ranking
- trust / verified / recommended / high_quality / officially_approved
- quality badge, content evaluation, certification
- cluster full implementation, evidence claims validation
- section-level encryption, license server, enterprise KMS
- complex permission systems, UI changes, Studio refactor
- kdna-cli changes (the existing `kdna inspect/validate/pack/unpack` commands in @aikdna/kdna-cli do not yet target the v1 format; a follow-up PR adds v1 routing there)
- fixing pre-existing `kdna-core` npm test suite failures (asset-reader / public-api / licensed-entry / protected-entry / cross-language fixtures)