### PR TITLE
docs: align Chinese and legacy docs with KDNA toolchain sovereignty

### DIFF
--- a/README.zh.md
+++ b/README.zh.md
@@ -1,22 +1,24 @@
-# KDNA — 面向 AI 系统的开放判断协议
+# KDNA
 
-> [aikdna.com](https://aikdna.com) — 官方网站 . [![npm](https://img.shields.io/npm/v/@aikdna/kdna-cli)](https://www.npmjs.com/package/@aikdna/kdna-cli)
+> **KDNA Core 是 KDNA 官方判断资产格式与运行时加载契约。**
 
-**KDNA 是面向 AI 系统的开放判断协议。**
+> `.kdna` 资产通过 KDNA 官方工具链创建、检查、保护、加载和消费。第三方产品可以通过 KDNA 官方 SDK、CLI、Loader 或 API 接入 KDNA。
 
-它把经过人类治理的领域判断，转化为 Agent 可加载、可追踪、可验证、可进化的可携带结构资产。
+> KDNA Core 内容中立，不评价判断内容好坏，不提供官方内容推荐、交易、评级或信任背书。
 
-Prompt 改变表达。RAG 扩展信息获取。Skill/工具扩展行动能力。  
-**KDNA 加载领域判断。**
+> 官方网站: [aikdna.com](https://aikdna.com) · [![npm](https://img.shields.io/npm/v/@aikdna/kdna-cli)](https://www.npmjs.com/package/@aikdna/kdna-cli)
 
-KDNA 不是让 Agent 扮演专家，而是让 Agent 在一套明确的判断系统中工作。
+KDNA Core 把经过人类治理的领域判断，转化为 Agent 可加载、可追踪、可验证、可进化的可携带结构资产。
 
-KDNA 不是提示词库，不是知识库，也不是操作手册。它是一种结构化方式，封装一个领域的判断层：公理、术语边界、常见误解、场景信号、推理链条和能力演进。
+Prompt 改变表达。RAG 扩展信息获取。Skill / 工具扩展行动能力。  
+**KDNA Core 加载领域判断。**
 
-> **本仓库仅定义 KDNA 协议、Schema、校验规则与治理方式。**  
-> 具体领域的 KDNA 应放在[独立仓库](#领域仓库)中，符合收录标准后进入官方 [kdna-registry](https://github.com/aikdna/kdna-registry)。
-> 安装 KDNA 到你的 Agent，使用 [kdna-skills](https://github.com/aikdna/kdna-skills)。  
-> 添加领域到注册表的标准详见 [docs/registry-policy.md](./docs/registry-policy.md)。
+KDNA Core 不是让 Agent 扮演专家，而是让 Agent 在一套明确的判断系统中工作。
+
+KDNA Core 不是提示词库，不是知识库，也不是操作手册。它是一种结构化方式，封装一个领域的判断层:公理、术语边界、常见误解、场景信号、推理链条和能力演进。
+
+> 本仓库定义 KDNA Core 格式、Schema、运行时加载契约与官方工具链核心实现。
+> KDNA 官方工具链由本仓库及配套仓库共同发布。第三方产品通过官方 SDK、CLI、Loader 或 API 接入 KDNA。
 
 ## 为什么现在需要 KDNA
 
@@ -30,15 +32,19 @@ KDNA 不是提示词库，不是知识库，也不是操作手册。它是一种
 
 每个领域都有专家级的判断模式，目前只存在于资深从业者的头脑中。KDNA 是一种把这些模式提取出来、编码为可机器验证的结构、作为判断参照层加载到 Agent 中的格式——独立于 Prompt，独立于知识库，独立于工具。
 
-## KDNA 三层体系
+## KDNA Core 与官方工具链
 
-AIKDNA = 生态/品牌  
-KDNA Protocol = 开放判断协议  
-KDNA Domain Asset = 可携带的领域判断资产
+KDNA Core 是本仓库定义的官方判断资产格式与运行时加载契约。
+`.kdna` 资产的创建、加载、消费、验证、保护都由 KDNA 官方工具链负责。
 
-**协议优先。产品是参考实现。**
+| 工具链组件 | 角色 | 仓库 |
+|---|---|---|
+| **KDNA Studio** | 人类判断资产创作环境 | [aikdna/kdna-studio-core](https://github.com/aikdna/kdna-studio-core) |
+| **KDNA CLI** | 官方命令行入口（inspect / validate / pack / unpack / load） | 本仓库 + [aikdna/kdna-cli](https://github.com/aikdna/kdna-cli) |
+| **KDNA Loader** | 官方运行时 loader，集成到 Agent | [aikdna/kdna-skills](https://github.com/aikdna/kdna-skills) |
+| **KDNA SDK** | 官方可嵌入库，供第一方集成 | 本仓库 `packages/kdna-core/` |
 
-KDNA Protocol 是开放协议。KDNA CLI 是参考工具。兼容 KDNA 的客户端可以用于加载、使用和对比领域判断；兼容 KDNA 的作者工具可以用于创建、锁定和导出领域资产。第三方应用可以实现同样的运行时协议。
+第三方产品通过官方 SDK、CLI、Loader 或 API 接入 KDNA,而不独立实现 KDNA 工具链。
 
 ## 为什么需要 KDNA
 
@@ -195,7 +201,7 @@ kdna verify dist/my_expertise.kdna --judgment
 kdna publish dist/my_expertise.kdna
 ```
 
-可信 `.kdna` 不是通过手写 JSON 或 CLI 打包创建的，而是由兼容 Studio 的创建管线编译生成。VS Code 和 `kdna dev` 命令只用于开发源工作区的诊断。
+由 KDNA Studio 编译产出的 `.kdna` 是 KDNA 官方工具链的最终产物。VS Code 和 `kdna dev` 命令只用于开发源工作区的诊断。
 
 ## 规范
 
@@ -211,7 +217,7 @@ node examples/minimal-agent/agent.js
 
 ## 领域仓库
 
-领域认知包存放在独立仓库中。官方机器可读索引见 [aikdna/kdna-registry](https://github.com/aikdna/kdna-registry)。
+领域认知包存放在独立仓库中。KDNA Core 不维护官方目录、不定义收录标准；第三方按需引用各领域仓库即可。
 
 | 领域 | 仓库 | 状态 |
 |---|---|---|
@@ -222,9 +228,9 @@ node examples/minimal-agent/agent.js
 | Open-source Project | [kdna-open_source_project](https://github.com/aikdna/kdna-open_source_project) | experimental |
 | Content Strategy | [kdna-content_strategy](https://github.com/aikdna/kdna-content_strategy) | experimental |
 
-### 参考示例
+### 演示样例
 
-`examples/` 目录包含最小参考实现，用于测试校验器和说明规范。这些 **不是** 官方领域目录——它们是规范示例。
+`examples/` 目录包含最小演示样例，用于测试校验器和说明规范。这些 **不是** 官方领域目录——它们是规范示例。
 
 | 示例 | 用途 |
 |---------|---------|
@@ -240,7 +246,7 @@ node examples/minimal-agent/agent.js
 | [docs/getting-started.zh.md](./docs/getting-started.zh.md) | 安装、创建和使用 KDNA |
 | [docs/evaluation.zh.md](./docs/evaluation.zh.md) | 如何检验 KDNA 是否改善了判断力 |
 | [docs/meta-cognition.zh.md](./docs/meta-cognition.zh.md) | 何时用 KDNA、冲突仲裁、领域组合 |
-| [docs/registry-policy.zh.md](./docs/registry-policy.zh.md) | 领域收录标准 |
+| [docs/archive/legacy-registry-policy.zh.md](./docs/archive/legacy-registry-policy.zh.md) | 历史 KDNA 收录标准（已废弃,仅作存档） |
 | [docs/kdna-in-chinese.md](./docs/kdna-in-chinese.md) | 中文 KDNA 编写指南 |
 
 ## 工具
@@ -254,7 +260,7 @@ node examples/minimal-agent/agent.js
 - [README.zh.md](./README.zh.md) — 中文 README（当前页面）
 - [docs/getting-started.zh.md](./docs/getting-started.zh.md) — 快速上手指南
 - [docs/kdna-in-chinese.md](./docs/kdna-in-chinese.md) — 中文 KDNA 编写指南
-- [docs/registry-policy.zh.md](./docs/registry-policy.zh.md) — 注册表收录标准
+- [docs/archive/legacy-registry-policy.zh.md](./docs/archive/legacy-registry-policy.zh.md) — 历史 KDNA 收录标准（已废弃,仅作存档）
 - [docs/i18n.md](./docs/i18n.md) — KDNA 国际化策略
 
 ## 许可

--- a/STATE_OF_KDNA.md
+++ b/STATE_OF_KDNA.md
@@ -1,5 +1,13 @@
 # State of KDNA
 
+> ⚠️ **Historical snapshot. This document is dated 2026-06-09 and does not represent the current KDNA Core positioning.**
+>
+> Current positioning is documented in `README.md`, `README.zh.md`, `docs/core/definition.md`, and `docs/core/principles.md`. Several of the references and assumptions below (e.g. registry, marketplace, quality badge) are out of scope for KDNA Core v1 and are tracked separately. Do not use this document as a source of current public narrative.
+>
+> ⚠️ **历史状态快照。本文件日期为 2026-06-09,不代表当前 KDNA Core 定位。**
+>
+> 当前定位以 `README.md`、`README.zh.md`、`docs/core/definition.md`、`docs/core/principles.md` 为准。文中涉及的 registry / marketplace / quality badge 等表述,已不在 KDNA Core v1 范围之内,另作处理。本文件不应作为当前公开叙事的来源。
+
 Date: 2026-06-09
 
 KDNA is the open judgment asset protocol for AI agents. It is not another prompt format. A `.kdna` asset is a verifiable, signed, inspectable domain judgment asset that an agent can load before it acts.
@@ -26,7 +34,7 @@ KDNA is the open judgment asset protocol for AI agents. It is not another prompt
 ## Evidence-Gated
 
 - `validated` quality badges require at least 30 eval cases, automated scoring, raw outputs, rubric, benchmark report, and limitations.
-- The first validated candidates are `@aikdna/writing`, `@aikdna/prompt_diagnosis`, and `@aikdna/agent_safety`; all three source repos now have 30 eval cases, but signed release assets still need to be republished before registry `test_count` can claim 30. They also need raw model outputs and completed automated scoring artifacts. The evidence contract is defined in the [registry policy](./docs/registry-policy.md) and [quality badge evidence gate](./specs/quality-badge-evidence-gate.md).
+- The first validated candidates are `@aikdna/writing`, `@aikdna/prompt_diagnosis`, and `@aikdna/agent_safety`; all three source repos now have 30 eval cases, but signed release assets still need to be republished before registry `test_count` can claim 30. They also need raw model outputs and completed automated scoring artifacts. The evidence contract is defined in the [legacy registry policy](./docs/archive/legacy-registry-policy.md) and [quality badge evidence gate](./specs/quality-badge-evidence-gate.md).
 - Existing early benchmark evidence should be described as early evidence until those gates pass.
 - External contributor readiness is not complete until a non-maintainer completes fork, install, conformance, registry-entry draft, and PR.
 

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -99,7 +99,7 @@ The KDNA logo may **not** be used:
 
 ## Official Certification
 
-Official KDNA certification and the right to use "Certified KDNA" or "Official KDNA" marks is granted through the registry governance process. See [GOVERNANCE.md](./docs/GOVERNANCE.md) and [registry-policy.md](./docs/registry-policy.md).
+Official KDNA certification and the right to use "Certified KDNA" or "Official KDNA" marks is granted through the registry governance process. See [GOVERNANCE.md](./docs/GOVERNANCE.md) and [the legacy registry policy](./docs/archive/legacy-registry-policy.md).
 
 ---
 

--- a/docs/archive/legacy-registry-policy.md
+++ b/docs/archive/legacy-registry-policy.md
@@ -1,6 +1,12 @@
-# Registry Policy
+# Registry Policy (Historical)
 
-> [中文版](./registry-policy.zh.md)
+> ⚠️ **Historical / deprecated.** This document is the legacy KDNA registry policy. KDNA Core v1 no longer defines a registry, marketplace, or quality-badge system, and the canonical `kdna-registry` repository is out of scope for KDNA Core. This file is kept for reference only.
+>
+> Current KDNA Core positioning: `README.md`, `README.zh.md`, `docs/core/definition.md`, `docs/core/principles.md`.
+>
+> 中文版:[./legacy-registry-policy.zh.md](./legacy-registry-policy.zh.md)
+>
+> ⚠️ **历史 / 已废弃。** 本文件是旧版 KDNA 注册表策略。KDNA Core v1 不再定义 registry、marketplace 或 quality-badge 系统,官方 `kdna-registry` 仓库已不在 KDNA Core 范围。本文件仅作存档。
 
 This document defines the criteria a domain KDNA repository must meet to be listed in the canonical [kdna-registry](https://github.com/aikdna/kdna-registry).
 

--- a/docs/archive/legacy-registry-policy.zh.md
+++ b/docs/archive/legacy-registry-policy.zh.md
@@ -1,6 +1,12 @@
-# 注册表收录标准
+# 注册表收录标准（历史）
 
-> [English](./registry-policy.md)
+> ⚠️ **历史 / 已废弃。** 本文件是旧版 KDNA 注册表策略。KDNA Core v1 不再定义 registry、marketplace 或 quality-badge 系统,官方 `kdna-registry` 仓库已不在 KDNA Core 范围。本文件仅作存档。
+>
+> 当前 KDNA Core 定位:`README.md`、`README.zh.md`、`docs/core/definition.md`、`docs/core/principles.md`。
+>
+> English:[./legacy-registry-policy.md](./legacy-registry-policy.md)
+>
+> ⚠️ **Historical / deprecated.** This document is the legacy KDNA registry policy. KDNA Core v1 no longer defines a registry, marketplace, or quality-badge system, and the canonical `kdna-registry` repository is out of scope for KDNA Core. This file is kept for reference only.
 
 本文档定义了领域 KDNA 仓库被列入官方 [kdna-registry](https://github.com/aikdna/kdna-registry) 必须满足的条件。
 


### PR DESCRIPTION
## Summary

PR-98a: 主仓库中文入口与历史公开文档主权清理。

This PR aligns Chinese and legacy public docs with the current
KDNA Core positioning.

PR-97 fixed the English top-level README and `docs/core/`. This
PR continues the same alignment onto the files that PR-97's
commit message explicitly listed as the highest-priority
follow-up: the Chinese README, the historical state doc, and
the legacy registry policy.

No functional code is changed. No schema, CLI implementation,
or PR-96 surface is touched. No encryption, signature,
conformance, or core-extraction work is started.

## What this PR does

### 1. README.zh.md — first screen and key sections rewritten

The old top section claimed KDNA is "an open judgment protocol",
called the CLI "a reference tool", and invited "third-party
applications [to] implement the same runtime protocol". The
old "KDNA 三层体系" section made the same claims in different
words.

The new top section reads:

> KDNA Core 是 KDNA 官方判断资产格式与运行时加载契约。
>
> .kdna 资产通过 KDNA 官方工具链创建、检查、保护、加载和消费。
> 第三方产品可以通过 KDNA 官方 SDK、CLI、Loader 或 API 接入 KDNA。
>
> KDNA Core 内容中立，不评价判断内容好坏，不提供官方内容
> 推荐、交易、评级或信任背书。

A new "KDNA Core 与官方工具链" section replaces the old
"三层体系" section. It treats Studio, CLI, Loader, and SDK as
the components of the **official KDNA toolchain**. The "可信
.kdna" sentence becomes "由 KDNA Studio 编译产出的 .kdna 是
KDNA 官方工具链的最终产物".

The "参考示例" subsection header is renamed "演示样例", and
"最小参考实现" becomes "最小演示样例". The two archive
links to `docs/registry-policy.zh.md` are repointed to
`docs/archive/legacy-registry-policy.zh.md` and labelled
"历史 KDNA 收录标准（已废弃,仅作存档）".

### 2. STATE_OF_KDNA.md — historical snapshot banner

A CN+EN dual-language ⚠️ banner is added at the top:

> ⚠️ **Historical snapshot. This document is dated 2026-06-09
> and does not represent the current KDNA Core positioning.**
>
> Current positioning is documented in `README.md`,
> `README.zh.md`, `docs/core/definition.md`, and
> `docs/core/principles.md`. Several of the references and
> assumptions below (e.g. registry, marketplace, quality
> badge) are out of scope for KDNA Core v1 and are tracked
> separately. Do not use this document as a source of
> current public narrative.

The body is unchanged per the brief: the file is a historical
snapshot and should keep its original wording for traceability.
The internal link to the legacy registry policy is repointed
to the archive location.

### 3. docs/registry-policy.{md,zh.md} → docs/archive/legacy-registry-policy.{md,zh.md}

Both English and Chinese versions are moved into
`docs/archive/` and given a CN+EN dual-language
"Historical / deprecated" banner. The banner explicitly
states that KDNA Core v1 no longer defines a registry,
marketplace, or quality-badge system, and that the canonical
`kdna-registry` repository is out of scope.

The body is preserved verbatim — the file's value is as a
historical record of the prior approach.

The cross-reference between the two language versions is
updated to point at the new archive paths.

### 4. TRADEMARK.md — broken link repair

`TRADEMARK.md` is not in this PR's strict scope, but the
registry-policy file move would leave one of its links
broken. The single link is repointed to the archive
location. The body of TRADEMARK.md is otherwise unchanged.

## Files changed

```
README.zh.md                                                 modified
STATE_OF_KDNA.md                                             modified
TRADEMARK.md                                                 modified (link only)
docs/registry-policy.md          → docs/archive/legacy-registry-policy.md  (rename)
docs/registry-policy.zh.md       → docs/archive/legacy-registry-policy.zh.md  (rename)
```

5 files, 2 renames, no functional code.

## Out of scope (intentionally not in this PR)

- `docs/tools/viewer.md` — contains "viewer" terminology;
  belongs to PR-98b cross-repo audit.
- `docs/kdna-registry-ci.md` — old registry CI doc.
- `specs/kdna-registry.md` — old registry spec.
- `docs/ecosystem-map.md`, `docs/start-here.md`,
  `docs/V1RC_RELEASE_*.md` — still reference kdna-registry;
  cleaned up in PR-98b/c/d/e.
- All other repos (`kdna-cli`, `kdna-core`,
  `kdna-studio-*`, `kdna-website`, `kdna-registry`, etc.).
- The PR-96 CLI implementation, schemas, conformance, core
  extraction (PR-99), encryption / signature (PR-101+).

## Verification

| Step | Result |
|---|---|
| `npm run format:check` | ✓ |
| `npm run test:cli-v1` | 32 pass / 0 fail |
| `npm test` | 73 pass / 0 fail / 6 skipped |
| `node scripts/core-smoke.js` | ✓ |
| `npm run validate:runtime-contract` | ✓ |
| `npm run validate:protocol-fixtures` | ✓ |
| `kdna inspect examples/minimal` | content-neutral JSON ✓ |
| `kdna validate examples/minimal` | all gates valid ✓ |

## PR chain / base

This PR is **stacked on PR #97** (which is itself stacked on
PR #96 → PR #95 → main via #94). The base here is
`feat/public-wording-sovereignty`. When the chain merges in
order, this PR will retarget to main.