### PR TITLE
docs: reorder CHANGELOG so latest version is at top (fixes #111)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.13.2
+
+**2026-06-22**
+
+- Moved ajv + ajv-formats to dependencies for self-contained install path.
+
+## 0.13.1
+
+**2026-06-22**
+
+- loadV1 reports profile_available and available_profiles, no silent scenario fallback.
+
+## 0.13.0
+
+**2026-06-22**
+
+- planLoad returns structured input_fingerprint with entitlement state diagnostics.
+
+---
+
 ## 0.9.0 — Phase 2: Judgment-Driven Artifacts and Products
 
 **2026-06-08**
@@ -42,26 +62,6 @@ Phase 2 extends KDNA from "judgment asset protocol" to "judgment-driven artifact
 ---
 
 Historical note: 0.10.x–0.12.x were pre-v1-GA cleanup releases. Full human-readable release notes resume from 0.13.0.
-
-## 0.13.2
-
-**2026-06-22**
-
-- Moved ajv + ajv-formats to dependencies for self-contained install path.
-
-## 0.13.1
-
-**2026-06-22**
-
-- loadV1 reports profile_available and available_profiles, no silent scenario fallback.
-
-## 0.13.0
-
-**2026-06-22**
-
-- planLoad returns structured input_fingerprint with entitlement state diagnostics.
-
----
 
 ## 0.7.0 — v1.0-rc: Open Judgment Protocol
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,17 @@ kdna/
 
 This repository follows [SemVer 2.0](https://semver.org/) for the KDNA Core specification. The current target is `kdna_version: "1.0"` (Phase 1 baseline). Breaking changes to the manifest schema or payload profile require a major version bump and an RFC.
 
+## Ecosystem
+
+| Repo | Package | Purpose |
+|------|---------|---------|
+| [kdna-cli](https://github.com/aikdna/kdna-cli) | `@aikdna/kdna-cli` | Core v1 runtime CLI |
+| [kdna-studio-cli](https://github.com/aikdna/kdna-studio-cli) | `@aikdna/kdna-studio-cli` | AI-powered authoring CLI |
+| [kdna-studio-core](https://github.com/aikdna/kdna-studio-core) | `@aikdna/kdna-studio-core` | Studio SDK for creators |
+| [kdna-skills](https://github.com/aikdna/kdna-skills) | — | AI agent skill loader |
+| [kdna-assets](https://github.com/aikdna/kdna-assets) | — | Public asset releases |
+| [kdna-website](https://aikdna.com) | — | Documentation & gallery |
+
 ## License
 
 Apache 2.0. See [LICENSE](./LICENSE).


### PR DESCRIPTION
Fixes #111 (P2). The 0.9.0 Phase 2 entry was above the 0.13.x entries, giving the impression that June 8 was the latest release. Reordered so 0.13.2 → 0.13.1 → 0.13.0 → 0.9.0 → 0.7.0.