### PR TITLE
fix: index profile max_tokens_hint + ecosystem manifest update

### DIFF
--- a/ecosystem-manifest.json
+++ b/ecosystem-manifest.json
@@ -16,7 +16,7 @@
       "local_path": ".",
       "npm_package": "@aikdna/kdna-core",
       "package_json": "packages/kdna-core/package.json",
-      "current_version": "0.13.2",
+      "current_version": "0.13.3",
       "lifecycle": "Beta",
       "supported_kdna_version": "1.0",
       "supported_access_modes": [
@@ -36,7 +36,7 @@
       "local_path": "../kdna-cli",
       "npm_package": "@aikdna/kdna-cli",
       "package_json": "../kdna-cli/package.json",
-      "current_version": "0.27.4",
+      "current_version": "0.27.6",
       "lifecycle": "Beta",
       "supported_kdna_version": "1.0",
       "supported_access_modes": [
@@ -74,7 +74,7 @@
       "local_path": "../kdna-studio-core",
       "npm_package": "@aikdna/kdna-studio-core",
       "package_json": "../kdna-studio-core/package.json",
-      "current_version": "1.5.10",
+      "current_version": "1.5.12",
       "lifecycle": "Beta",
       "supported_kdna_version": "1.0",
       "supported_access_modes": [
@@ -93,7 +93,7 @@
       "local_path": "../kdna-studio-cli",
       "npm_package": "@aikdna/kdna-studio-cli",
       "package_json": "../kdna-studio-cli/package.json",
-      "current_version": "0.6.3",
+      "current_version": "0.6.5",
       "lifecycle": "Beta",
       "supported_kdna_version": "1.0",
       "supported_access_modes": [

--- a/packages/kdna-core/CHANGELOG.md
+++ b/packages/kdna-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.13.3 (2026-06-22)
+- Fix: index profile includes max_tokens_hint
+- Fix: compact profile falls back to full_statement for TBD placeholders
+
+# Changelog
+
 Packages: `@aikdna/kdna-core`
 
 ## v0.13.2 (2026-06-21)

--- a/packages/kdna-core/package.json
+++ b/packages/kdna-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aikdna/kdna-core",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "description": "KDNA Core library for validating, planning, and loading local .kdna judgment assets.",
   "type": "commonjs",
   "main": "src/index.js",


### PR DESCRIPTION
## Changes

- index profile includes max_tokens_hint (fixes #113)
- compact TBD placeholder falls back to full_statement
- ecosystem-manifest.json updated to match published npm versions
- kdna-core 0.13.2 → 0.13.3

All 104 tests pass.