### PR TITLE
docs: add status banners to Cluster/Work Pack docs + create FAQ

### DIFF
--- a/demos/skill-plus-kdna-demo/README.md
+++ b/demos/skill-plus-kdna-demo/README.md
@@ -25,8 +25,9 @@ Then load the compact prompt context:
 kdna load ./minimal.kdna --profile=compact --as=prompt
 ```
 
-For a real writing demo, use `writing-v1.kdna` from the legacy writing proof
-artifact once that artifact is accepted in the `kdna-writing` repository.
+For a real domain demo, use `kdna-x` assets from the
+[kdna-x](https://github.com/aikdna/kdna-x) repository (viral-topic-selection,
+title-attraction, short-video-script, etc.).
 
 ## Files
 

--- a/docs/faq-kdna-vs-skill.md
+++ b/docs/faq-kdna-vs-skill.md
@@ -1,0 +1,164 @@
+# FAQ: KDNA vs Skill, Prompt, and AI Ecosystem
+
+## What is KDNA?
+
+KDNA is a **judgment asset format**. A `.kdna` file encodes how to judge the quality
+of work in a specific domain — when something is good enough, when to stop, what
+not to say, what misunderstandings to avoid.
+
+It is NOT a prompt, a skill, a workflow, a knowledge base, or a rules file.
+
+---
+
+## Is KDNA a Skill?
+
+No. **Skill is execution, KDNA is judgment.**
+
+| | Skill | KDNA |
+|---|-------|------|
+| What it does | Executes a procedure | Judges quality |
+| Answers | "How do I do this?" | "Is this good enough?" |
+| Example | "Write a PR review" | "Is this review rubber-stamp or behavior-first?" |
+| Format | Code / tool calls / steps | Structured judgment axioms, stances, banned terms |
+
+---
+
+## Can KDNA and Skill be used together?
+
+Yes. This is the recommended pattern:
+
+1. **Skill** executes the task (e.g., review a PR, write a blog post)
+2. **KDNA** loads alongside it and injects judgment guidance into the agent's context
+3. The agent uses KDNA to judge its own output before delivering it
+
+Example: a PR review Skill + a code-review KDNA → the agent catches architectural
+issues that a rule-based Skill would miss.
+
+---
+
+## Can a .kdna file contain a Skill?
+
+No. `.kdna` files contain structured judgment data (axioms, stances, banned terms,
+misunderstandings, self-checks). They do not contain executable code, tool calls,
+or workflow steps.
+
+---
+
+## What is a Work Pack?
+
+A Work Pack is a **future concept** (design phase). It would define a multi-step
+agent task with role bindings, review gates, and KDNA domain dependencies.
+
+**Is Work Pack available now?** No. Work Pack is not part of KDNA Core v1 GA.
+Do not use it in production. See [tool-status-matrix.md](tool-status-matrix.md).
+
+---
+
+## What is a Cluster?
+
+A Cluster is a **future concept** (experimental). It would compose multiple KDNA
+domains into a single judgment system with routing rules.
+
+**Is Cluster available now?** No. Cluster is not part of KDNA Core v1 GA.
+For current stable usage, use a single `.kdna` asset.
+
+---
+
+## When should I write a Skill?
+
+Write a Skill when:
+- You need the agent to follow a specific procedure
+- The task has clear steps (validate → review → report)
+- The value is in the execution, not the judgment
+
+---
+
+## When should I write a KDNA?
+
+Write a KDNA when:
+- The task requires judgment, not just execution
+- You want the agent to catch its own mistakes
+- You have domain expertise to encode (banned terms, failure modes, misunderstandings)
+- You want consistent quality standards across different agents/models
+
+---
+
+## Can one Skill use multiple KDNA assets?
+
+Yes. A Skill can load multiple KDNA assets if the task spans multiple judgment domains.
+For example, a "publish blog post" Skill might load:
+- `writing.kdna` (primary — judge the content)
+- `brand-voice.kdna` (constraint — enforce brand boundaries)
+
+---
+
+## Can one KDNA guide multiple Skills?
+
+Yes. A single KDNA asset is domain-specific, not task-specific. A `code-review.kdna`
+asset can guide any Skill that does code review, regardless of the specific tool
+or workflow.
+
+---
+
+## KDNA vs Prompt — what's the difference?
+
+| | Prompt | KDNA |
+|---|--------|------|
+| Format | Free text | Structured (axioms, stances, banned terms) |
+| Verification | None | `kdna validate` + schema gate |
+| Reuse | Copy-paste | Installable `.kdna` file |
+| Judgment depth | Surface-level | Encodes failure modes, misunderstandings |
+| Versioning | Ad-hoc | `judgment_version` + lineage |
+
+---
+
+## KDNA vs Memory (RAG) — what's the difference?
+
+Memory/RAG retrieves **facts**. KDNA encodes **judgment**.
+
+RAG says "this document contains X." KDNA says "when you see X, consider Y; Z is
+a common misunderstanding; don't say W."
+
+They are complementary. You can use RAG for facts and KDNA for judgment.
+
+---
+
+## KDNA vs MCP — what's the difference?
+
+MCP (Model Context Protocol) connects agents to **tools**. KDNA connects agents to
+**judgment standards**.
+
+MCP says "here's a function to search the database." KDNA says "before you search,
+check if the query is safe; if the user asks for PII, refuse."
+
+---
+
+## Current GA capabilities
+
+| Command | Status |
+|---------|--------|
+| `kdna inspect` | GA |
+| `kdna validate` | GA |
+| `kdna plan-load` | GA |
+| `kdna load --profile=compact --as=prompt` | GA |
+| `kdna pack` | GA |
+| `kdna unpack` | GA |
+| `kdna demo minimal` | GA |
+| `kdna lint` | GA |
+| `kdna workpack` | GA |
+
+Commands to **not** use: `kdna available`, `kdna match`, `--as=json`, `--as=raw`,
+`kdna load @scope/name`. These are legacy or removed.
+
+---
+
+## Where should I start?
+
+1. `npm install -g @aikdna/kdna-cli`
+2. `kdna demo minimal /tmp/hello`
+3. `kdna pack /tmp/hello /tmp/hello.kdna`
+4. `kdna validate /tmp/hello.kdna`
+5. `kdna plan-load /tmp/hello.kdna`
+6. `kdna load /tmp/hello.kdna --profile=compact --as=prompt`
+
+For creating your own: see [first-domain-walkthrough.md](first-domain-walkthrough.md).

--- a/docs/kdna-clusters.md
+++ b/docs/kdna-clusters.md
@@ -1,5 +1,9 @@
 # KDNA Clusters
 
+> **Status: Design / Experimental** — Not part of KDNA Core v1 GA.
+> For current stable usage, use single `.kdna` assets with `kdna validate` / `kdna plan-load` / `kdna load`.
+> See [tool-status-matrix.md](tool-status-matrix.md) for GA capabilities.
+
 A KDNA Cluster is a composable judgment system: multiple scoped KDNA domain assets working together under defined roles and route policy to handle complex tasks.
 
 A cluster is not a broader merged `.kdna`. Each domain asset keeps its own scope, version, provenance, and evaluation boundary. The cluster defines which assets participate, when they load, how conflicts surface, and how the combined system is reviewed.

--- a/docs/status.md
+++ b/docs/status.md
@@ -20,7 +20,7 @@ KDNA Core is content-neutral. It validates file structure, integrity, and loadin
 - **Load contract** — `index` / `compact` / `scenario` / `full` profiles
 - **Checksums** — per-entry SHA-256 / SHA-512 / BLAKE2b-256
 - **Content-neutral output boundary** — Core validation does not emit recommendation, endorsement, or quality-ranking claims
-- **`kdna inspect`** — inspect local v1 `.kdna` containers (available via `npm install -g @aikdna/kdna-cli@0.27.2`)
+- **`kdna inspect`** — inspect local v1 `.kdna` containers (available via `npm install -g @aikdna/kdna-cli@0.27.6`)
 - **`kdna validate`** — validate local v1 `.kdna` containers (schema + format + payload + checksums + load-contract)
 - **`kdna plan-load`** — return the Core LoadPlan before runtime loading, with structured `input_fingerprint` and entitlement state diagnostics
 - **`kdna load`** — render v1 `.kdna` assets into agent-readable context (`--profile=index|compact|scenario|full`, `--as=json|prompt`)
@@ -28,14 +28,14 @@ KDNA Core is content-neutral. It validates file structure, integrity, and loadin
 - **`kdna unpack`** — unpack `.kdna` container, refuse path traversal
 - **`kdna demo minimal`** — create a minimal v1 fixture for first-run testing
 - **CLI tests** — 30 tests pass for inspect, validate, LoadPlan, load, pack, unpack, and contract shape
-- **Studio CLI** — v1 authoring/export published through `@aikdna/kdna-studio-cli@0.6.0` and `@aikdna/kdna-studio-core@1.5.8`
+- **Studio CLI** — v1 authoring/export published through `@aikdna/kdna-studio-cli@0.6.5` and `@aikdna/kdna-studio-core@1.5.12`
 
 All stable commands are available in the public v1 Core CLI surface. `kdna --help` shows the complete v1 Core command surface.
 
 ## Recommended first-run path
 
 ```bash
-npm install -g @aikdna/kdna-cli@0.27.2
+npm install -g @aikdna/kdna-cli@0.27.6
 kdna --help
 kdna demo minimal /tmp/minimal-source
 kdna pack /tmp/minimal-source /tmp/minimal.kdna
@@ -47,7 +47,7 @@ kdna load /tmp/minimal.kdna --profile=compact --as=prompt
 Studio authoring path:
 
 ```bash
-npm install -g @aikdna/kdna-studio-cli@0.6.0
+npm install -g @aikdna/kdna-studio-cli@0.6.5
 kdna-studio create ./school --name @test/school --author "Your Name"
 kdna-studio card add ./school axiom --field one_sentence="..." [all 8 required fields]
 kdna-studio card approve ./school --all --by me --statement "I confirm."
@@ -82,7 +82,7 @@ These were removed from the v1 Core CLI. Future systems such as distribution, si
 
 ## What is experimental / in development
 
-- **kdna-studio** — v1 authoring/export is stable (0.6.0); advanced AI authoring features (distill, interview, feynman) are experimental
+- **kdna-studio** — v1 authoring/export is stable (0.6.5); advanced AI authoring features (distill, interview, feynman) are experimental
 - **kdna-vscode** — VS Code extension (legacy workspace tools); not yet updated for v1 Core
 - **kdna-loader** — agent adapter skill; functional for supported agents, UX hardening deferred
 - **kdna-core-swift** — Swift runtime; beta until parity proven against fixed Core v1 conformance fixtures

--- a/docs/tool-status-matrix.md
+++ b/docs/tool-status-matrix.md
@@ -12,7 +12,7 @@
 | **kdna unpack** | Container extraction | GA | `kdna unpack <file.kdna> <out>` |
 | **kdna demo minimal** | Minimal v1 fixture creation | GA | `kdna demo minimal <dir>` |
 
-Published: `@aikdna/kdna-cli@0.27.2`, `@aikdna/kdna-core@0.13.1`
+Published: `@aikdna/kdna-cli@0.27.6`, `@aikdna/kdna-core@0.13.3`
 
 ## Studio (GA)
 
@@ -26,7 +26,7 @@ Published: `@aikdna/kdna-cli@0.27.2`, `@aikdna/kdna-core@0.13.1`
 | **kdna-studio card unlock** | Reverse card approval | GA | `kdna-studio card unlock <project> <card-id> --by <id> --statement <text>` |
 | **kdna-studio export** | v1 container export | GA | `kdna-studio export <project> --format v1 --out <file.kdna>` |
 
-Published: `@aikdna/kdna-studio-cli@0.6.0`, `@aikdna/kdna-studio-core@1.5.8`
+Published: `@aikdna/kdna-studio-cli@0.6.5`, `@aikdna/kdna-studio-core@1.5.12`
 
 ## Experimental / in development
 

--- a/packages/kdna-core/CHANGELOG.md
+++ b/packages/kdna-core/CHANGELOG.md
@@ -4,8 +4,6 @@
 - Fix: index profile includes max_tokens_hint
 - Fix: compact profile falls back to full_statement for TBD placeholders
 
-# Changelog
-
 Packages: `@aikdna/kdna-core`
 
 ## v0.13.2 (2026-06-21)

--- a/templates/cluster/README.md
+++ b/templates/cluster/README.md
@@ -1,5 +1,8 @@
 # Cluster: example_cluster
 
+> **Status: Design / Experimental** — Not part of KDNA Core v1 GA.
+> For current stable usage, use single `.kdna` assets.
+
 A KDNA cluster project view groups multiple related domains before packaging.
 The public runtime asset is the exported `.kdna` container, not this folder.
 


### PR DESCRIPTION
- Add Experimental/Design status banners to kdna-clusters.md and cluster template\n- Create docs/faq-kdna-vs-skill.md covering KDNA vs Skill/Prompt/MCP/RAG/Work Pack/Cluster\n- FAQ includes current GA command list with legacy commands explicitly marked as removed