### PR TITLE
docs: Version Taxonomy Freeze — eliminate ambiguous V1/V2 naming

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
-# KDNA Specification v1.0-rc
+# KDNA Core Specification — 2026.06 Baseline
 
-**Status:** Release Candidate  
+**Status:** Current (GA)  
 **Previous:** v0.4 (superseded)  
 **Editors:** KDNA Team  
 **Repository:** https://github.com/aikdna/kdna
@@ -19,7 +19,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 - **Dev Source Directory:** An optional authoring workspace used to build a `.kdna` asset. Source directories are non-canonical and MUST NOT be treated as installed runtime domains.
 - **Loader:** Software that reads KDNA files and formats them for agent consumption.
 - **Validator:** Software that checks KDNA files for structural compliance.
-- **Registry:** A machine-readable index of available KDNA domains.
+- **Registry:** (Historical) A machine-readable index of KDNA domains. Not part of the current Core specification. See decisions/0003.
 
 ## 1. Scope
 
@@ -245,7 +245,7 @@ If a domain omits optional files, it SHOULD document the reason in its README. A
 
 #### 3.3.2 Three-Field System
 
-Every `.kdna` asset and registry entry MUST use a consistent three-field system to separate maturity, quality, and access:
+Every `.kdna` asset MUST use a consistent three-field system to separate maturity, quality, and access:
 
 | Field | Permitted Values | Meaning |
 |-------|-----------------|---------|
@@ -255,7 +255,7 @@ Every `.kdna` asset and registry entry MUST use a consistent three-field system 
 
 **Rules:**
 - `status` and `quality_badge` are independent. A domain MAY be `stable` but `untested` (mature structure, no eval evidence), or `experimental` but `validated` (new domain with thorough testing).
-- `quality_badge` SHOULD be stored in both the domain's `kdna.json` manifest AND the registry entry. Self-declared badges MUST be verifiable via `kdna verify --judgment`.
+- `quality_badge` SHOULD be stored in the domain's `kdna.json` manifest. Self-declared badges MUST be verifiable via `kdna validate`.
 - `deprecated` domains MUST set `replaced_by` to the successor domain name.
 - The old values `basic`, `pro`, and `reference` are retired. Previously `reference` domains SHOULD migrate to `status: stable` + `quality_badge: validated` or `expert_reviewed`.
 
@@ -747,24 +747,18 @@ A `.kdna` file:
 
 ### 14.3 Required Contents
 
-A valid `.kdna` container MUST contain:
+A valid `.kdna` KDNA Asset Container MUST contain:
 
 | File | Required | Description |
 |------|----------|-------------|
-| `mimetype` | REQUIRED | Fixed media type marker. Content MUST be `application/vnd.aikdna.kdna+zip` with no trailing newline. |
+| `mimetype` | REQUIRED | Fixed media type marker. Content MUST be `application/vnd.kdna.asset` with no trailing newline. |
 | `kdna.json` | REQUIRED | Container manifest (see §14.4) |
-| `KDNA_Core.json` | REQUIRED | Domain core: axioms, ontology, frameworks, stances |
-| `KDNA_Patterns.json` | REQUIRED | Domain patterns: terminology, misunderstandings, self-checks |
-| `KDNA_Scenarios.json` | OPTIONAL | Scenario signals and action triggers |
-| `KDNA_Cases.json` | OPTIONAL | Full cases demonstrating judgment application |
-| `KDNA_Reasoning.json` | OPTIONAL | Reasoning chains from principle to action |
-| `KDNA_Evolution.json` | OPTIONAL | Growth stages, capability layers, measurement |
-| `README.md` | OPTIONAL | Human-readable domain documentation |
-| `LICENSE` | OPTIONAL | License text file |
-| `evals/` | OPTIONAL | Evaluation test cases directory |
-| `signature.json` | RECOMMENDED | Ed25519 signature covering content (see §14.7) |
+| `payload.kdnab` | REQUIRED | CBOR-encoded judgment payload containing all domain content (axioms, patterns, cases, scenarios, reasoning, evolution) |
+| `checksums.json` | OPTIONAL | Per-entry hash integrity records |
 
-A container MUST NOT contain more than 6 KDNA JSON files (Core, Patterns, Scenarios, Cases, Reasoning, Evolution). Additional files such as `kdna.json`, `README.md`, `LICENSE`, `signature.json`, and `evals/` are not counted toward this limit.
+Optional entries MAY include `signatures/` and `attachments/` subdirectories.
+
+A `.kdna` asset MUST NOT contain `KDNA_Core.json`, `KDNA_Patterns.json`, `KDNA_Scenarios.json`, `KDNA_Cases.json`, `KDNA_Reasoning.json`, or `KDNA_Evolution.json` as top-level ZIP entries. Those files belong to the source tree only (see §3.2). Containers with source tree files at the top level MUST be rejected as legacy plaintext ZIP format.
 
 The `mimetype` entry MUST be located at the ZIP root. Writers SHOULD store it as
 the first ZIP entry and SHOULD NOT compress it. Loaders MUST check both
@@ -774,6 +768,11 @@ an archive as a valid KDNA asset.
 ### 14.4 Container Manifest (`kdna.json`)
 
 Every `.kdna` container MUST include a `kdna.json` at the archive root. This file declares the container's identity, version, and verification metadata.
+
+> **Note on `format_version` and `spec_version`**: These are wire-level discriminators
+> for container format detection and validation routing. Their current values (`"2.0"`)
+> are legacy wire constants and do NOT represent a "KDNA v2" product generation.
+> See [version-taxonomy.md](docs/version-taxonomy.md) for the canonical naming scheme.
 
 ```json
 {
@@ -868,7 +867,7 @@ Trust is NOT inherited through lineage. Forked, adapted, or migrated assets SHOU
 
 ### 14.5 Digest
 
-- **Asset digest:** `asset_digest` is the SHA-256 hash of the complete `.kdna` file bytes. It MUST be recorded outside the container, such as in the registry entry, local receipt, or lockfile.
+- **Asset digest:** `asset_digest` is the SHA-256 hash of the complete `.kdna` file bytes. It MUST be recorded outside the container, such as in a local receipt or lockfile.
 - **Content digest:** `content_digest` is the canonical SHA-256 hash of the internal content tree. The content tree includes all non-directory ZIP entries except `signature.json`, `.DS_Store`, `build-receipt.json`, `reports/*`, and local installation metadata. Reports and build receipts are build evidence, not judgment content — they are not part of the content digest. If stored in `kdna.json`, the `content_digest` field itself (and other self-referencing digest fields) are excluded from its own digest calculation.
 - Registries MUST use `asset_digest` for every installable `.kdna` asset and MAY also publish `content_digest`.
 - Installers MUST verify `asset_digest` before registration.
@@ -895,73 +894,28 @@ Signing is an **optional enhancement** to `.kdna` assets. A `.kdna` container MA
 - An unsigned `.kdna` file is a **valid KDNA asset**. Signature presence is a trust-layer enhancement, not a format-validity requirement.
 - A specific registry or platform MAY require signatures for assets listed there; such requirements are registry policy, not KDNA Core format rules.
 
-### 14.6.2 Publish Audit
-
-Registry entries for release-evidence assets SHOULD include a  block:
-
-| Field | Type | Description |
-|-------|------|-------------|
-|  | string | Identity of the publisher |
-|  | string | ISO 8601 timestamp of publication |
-|  | string | Tool chain used (e.g. "kdna-studio-cli v0.2.0 + kdna-studio-core v1.4.2") |
-|  | string | Human-readable note about what changed |
-
-### 14.6.1 Registry Trust Metadata
-
-Conforming public registries MUST publish trust metadata alongside domain entries:
-
-```json
-{
-  "schema_version": "3.0",
-  "registry_version": "3.0.0",
-  "updated": "ISO-8601 timestamp",
-  "trust": {
-    "model": "kdna-registry-v1",
-    "root": { "threshold": 1, "keys": [] },
-    "targets": { "threshold": 1, "delegated_scopes": ["@aikdna"] },
-    "snapshot": {
-      "registry_version": "3.0.0",
-      "generated_at": "ISO-8601 timestamp",
-      "expires_at": "ISO-8601 timestamp"
-    },
-    "timestamp": {
-      "generated_at": "ISO-8601 timestamp",
-      "expires_at": "ISO-8601 timestamp"
-    },
-    "revocations": []
-  }
-}
-```
-
-Installers MUST reject registries whose `snapshot.expires_at` or `timestamp.expires_at` is expired. Installers MUST reject assets matched by a registry revocation entry. Revocation entries SHOULD include `name`, `version`, `asset_digest`, `reason`, and `revoked_at`.
-
 ### 14.7 Install and Load Behavior
 
-When a `.kdna` file is installed via `kdna install`:
+Loading a `.kdna` asset for agent consumption follows this path:
 
-1. Verify registry trust metadata.
-2. Verify asset digest.
-3. Verify signature for registry-installed assets.
-4. Store the original `.kdna` file as an immutable local asset.
-5. Write a local `receipt.json` containing source, `asset_digest`, `content_digest`, signature status, access mode, and install time.
-6. Register the asset in the local package index.
-7. Load runtime content from the `.kdna` asset.
+1. `kdna validate <file.kdna>` — structural and schema validation
+2. `kdna plan-load <file.kdna>` — returns a LoadPlan with authorization diagnostics
+3. `kdna load <file.kdna> --profile=compact --as=prompt` — renders judgment content for agent injection
 
-Installation metadata MUST be stored outside the container, for example in a local index and receipt. Installers MUST NOT rewrite `kdna.json` inside the container to stamp `_source`, install time, or registry metadata.
-
-Persistent extraction MUST NOT be required for loading. A runtime MAY create internal temporary caches, but those caches are rebuildable, hidden implementation artifacts and MUST NOT become the trust source.
+The LoadPlan MUST return `can_load_now: true` before loading proceeds.
+The runtime MAY cache load results internally, but caches are rebuildable and
+MUST NOT become the trust source.
 
 ### 14.8 CLI Operations on Containers
 
 | Command | Operation |
 |---------|-----------|
-| `kdna install @aikdna/writing` | Download from registry, verify, store, and register a `.kdna` asset |
-| `kdna install writing.kdna` | Install from a local `.kdna` asset |
-| `kdna inspect writing.kdna` | Display container metadata without persistent extraction |
-| `kdna verify writing.kdna` | Verify checksum, structure, judgment, and signature without persistent extraction |
-| `kdna load @aikdna/writing` | Load the installed `.kdna` asset directly into agent context |
-| `kdna load writing.kdna` | Load a local `.kdna` asset directly into agent context |
-| `kdna compare writing.kdna --input "..."` | Compare with/without a local `.kdna` asset |
+| `kdna validate <file.kdna>` | Structural and schema validation |
+| `kdna inspect <file.kdna>` | Display container metadata |
+| `kdna plan-load <file.kdna>` | Return LoadPlan with authorization diagnostics |
+| `kdna load <file.kdna> --profile=compact --as=prompt` | Render judgment content for agent injection |
+| `kdna pack <source-dir> <output.kdna>` | Build a `.kdna` asset from a source tree |
+| `kdna unpack <file.kdna> <output-dir>` | Extract a `.kdna` asset for inspection |
 | `kdna dev pack ./writing-source` | Build a dev-only diagnostic bundle from a non-canonical source directory. For release-evidence authoring, use `kdna-studio migrate`. |
 | `kdna dev unpack writing.kdna` | Unpack into a dev source directory for inspection or editing |
 
@@ -1105,23 +1059,7 @@ Locale overlays translate text fields only. They reference canonical IDs and MUS
 }
 ```
 
-### 16.6 Registry Declaration
-
-Registry entries for localized domains MUST include:
-
-```json
-{
-  "languages": ["en", "zh-CN"],
-  "default_language": "en",
-  "i18n_level": "L2",
-  "localized": {
-    "en": { "display_name": "...", "description": "..." },
-    "zh-CN": { "display_name": "...", "description": "..." }
-  }
-}
-```
-
-### 16.7 Validation
+### 16.6 Validation
 
 A conforming validator MUST verify:
 1. Declared `languages` match actual `locales/` directories
@@ -1138,6 +1076,4 @@ A conforming validator MUST verify:
 - [Semantic Versioning](https://semver.org/) — Version numbering
 - [SPDX License List](https://spdx.org/licenses/) — License identifiers
 - JSON Schema files: `schema/KDNA_*.schema.json`
-- CLI tools: `kdna dev validate`, `kdna dev pack`, `kdna compare`, `kdna-studio migrate`
-- Registry metadata, when used, is an optional discovery/distribution layer and
-  not the authority for Core format validity.
+- CLI tools: `kdna validate`, `kdna inspect`, `kdna plan-load`, `kdna load`, `kdna pack`, `kdna unpack`

--- a/articles/ai-agents-need-domain-judgment.md
+++ b/articles/ai-agents-need-domain-judgment.md
@@ -86,7 +86,6 @@ Every KDNA domain declares: risk level (R0–R3), intended use, out-of-scope bou
 | **KDNA Protocol** | Open standard for domain judgment assets |
 | **kdna-cli** | Install, validate, verify, pack, load |
 | **KDNA Studio Core** | Open-source authoring kernel |
-| **KDNA Studio Core** | Open-source authoring kernel |
 
 ## Start Small
 

--- a/articles/ai-agents-need-domain-judgment.md
+++ b/articles/ai-agents-need-domain-judgment.md
@@ -77,7 +77,7 @@ validity requirements for every `.kdna` file.
 
 Because KDNA influences agent judgment — and judgment influences behavior — the ecosystem is designed around governance.
 
-Every KDNA domain declares: risk level (R0–R3), intended use, out-of-scope boundaries, known limitations, and author responsibility. High-risk domains require expert review. R3 domains are not permitted in the public registry without special review.
+Every KDNA domain declares: risk level (R0–R3), intended use, out-of-scope boundaries, known limitations, and author responsibility. High-risk domains require expert review.
 
 ## The Ecosystem
 
@@ -86,15 +86,16 @@ Every KDNA domain declares: risk level (R0–R3), intended use, out-of-scope bou
 | **KDNA Protocol** | Open standard for domain judgment assets |
 | **kdna-cli** | Install, validate, verify, pack, load |
 | **KDNA Studio Core** | Open-source authoring kernel |
-| **Registry** | Trusted distribution with signatures and provenance |
+| **KDNA Studio Core** | Open-source authoring kernel |
 
 ## Start Small
 
 ```bash
 npm install -g @aikdna/kdna-cli
-kdna setup
-kdna install @aikdna/writing
-kdna compare @aikdna/writing --input "help me improve this post"
+kdna demo minimal ./hello
+kdna pack ./hello ./hello.kdna
+kdna validate ./hello.kdna
+kdna load ./hello.kdna --profile=compact --as=prompt
 ```
 
 ---

--- a/docs/REGISTRY_IS_OPTIONAL.md
+++ b/docs/REGISTRY_IS_OPTIONAL.md
@@ -1,5 +1,9 @@
 # Registry Is Optional
 
+> **Status: Historical.** Registry is not part of KDNA Core GA.
+> See [decisions/0003](../decisions/0003-no-registry-in-v1-core-ga.md).
+> The current distribution path is direct `.kdna` file sharing or [kdna-x](https://github.com/aikdna/kdna-x).
+
 This document defines the relationship between KDNA format validity and domain registries.
 
 ## Core Principle

--- a/docs/STUDIO_EXPORT_CONTRACT.md
+++ b/docs/STUDIO_EXPORT_CONTRACT.md
@@ -1,5 +1,8 @@
 # Studio Export Contract
 
+> **Status: Historical.** Pre-Core authoring contract. For current export path, see
+> [kdna-studio-cli](https://github.com/aikdna/kdna-studio-cli).
+
 Studio Export is the asset build step that turns a Human-Locked Studio project
 into an immutable `.kdna` asset. It is not a JSON save operation.
 

--- a/docs/V1RC_RELEASE_BOARD.md
+++ b/docs/V1RC_RELEASE_BOARD.md
@@ -12,7 +12,7 @@
 |---|------|-------|--------|------------|
 | 1 | Protocol Freeze | — | ⬜ | SPEC audit, MUST/SHOULD consistency, non-negotiable rule CI enforcement |
 | 2 | Core/CLI Compatibility | — | ⬜ | verify/load/compare output stability, exit codes, JSON contract |
-| 3 | Registry Trust Verification | — | ⬜ | yanked/revoked/digest-mismatch/expired-snapshot test coverage |
+| 3 | Trust Verification | — | ⬜ | Historical — registry not in Core GA |
 | 4 | Reference Domain Evidence | — | ⬜ | writing/prompt_diagnosis/agent_safety → validated (30+ evals) |
 | 5 | Agent Integration Kit | — | ⬜ | Codex/Claude Code/OpenCode/Cursor smoke test, MCP conformance |
 | 6 | External Contributor Path | — | ⬜ | fork→PR guide, issue templates, conformance badge, COMPATIBILITY.md |

--- a/docs/V1RC_RELEASE_GATE.md
+++ b/docs/V1RC_RELEASE_GATE.md
@@ -12,8 +12,8 @@ and already-published assets follow the protocol after the tools are released.
 3. In `aikdna/kdna-cli`, refresh dependencies against published
    `@aikdna/kdna-core@^0.7.2`; only then bump the CLI package metadata.
 4. Publish `@aikdna/kdna-cli`.
-5. Merge `aikdna/kdna-registry` metadata/tooling validation updates.
-6. Repack and resign registry assets with the new CLI.
+5. ~~Merge `aikdna/kdna-registry` metadata/tooling validation updates.~~ (Historical — registry removed)
+6. ~~Repack and resign registry assets with the new CLI.~~ (Historical)
 7. Run `npm run validate:remote` in `kdna-registry` after assets are republished.
 
 ## Required Checks

--- a/docs/archive/migration-legacy-json-to-core-baseline.md
+++ b/docs/archive/migration-legacy-json-to-core-baseline.md
@@ -1,6 +1,8 @@
-# Migration Guide: v2.0 → v1.0-rc
+# Migration Guide: Legacy JSON → Core 2026.06 Baseline
 
-> **Audience:** Domain authors migrating from pre-v1.0 KDNA formats to the v1.0-rc specification.
+> **Status: Historical.** This document describes migration from pre-Core formats to the current KDNA Core 2026.06 Baseline. It does not define current version naming. See [version-taxonomy.md](../version-taxonomy.md) for the canonical scheme.
+>
+> **Audience:** Domain authors migrating from pre-Core KDNA formats (legacy JSON / legacy registry assets) to the current specification baseline.
 >
 > **Breaking changes summary (v1.0-rc):**
 > - `evidence_type` changed from `string` to `array` — wrap existing values

--- a/docs/core/file-format.md
+++ b/docs/core/file-format.md
@@ -1,6 +1,10 @@
-# KDNA File Format (v1)
+# KDNA File Format
 
-A `.kdna` file is a **ZIP-compatible container** with a fixed entry layout. The format is normative; the official KDNA toolchain produces and consumes KDNA v1 assets and follows this layout. Third-party products integrate KDNA through the official SDK, CLI, Loader, or API.
+> **Container format**: KDNA Asset Container with `kdna.json` + `payload.kdnab`.
+> See [version-taxonomy.md](../version-taxonomy.md) for the canonical naming scheme.
+> The legacy plaintext ZIP (source-tree files directly in container) is rejected by the current validator.
+
+A `.kdna` file is a **ZIP-compatible container** with a fixed entry layout. The format is normative; the official KDNA toolchain produces and consumes KDNA assets following this layout.
 
 ## Container layout
 

--- a/docs/creator-workflow.md
+++ b/docs/creator-workflow.md
@@ -24,7 +24,7 @@
 | 这个域帮助 AI 判断什么？ | 必须是一个具体的判断问题，不是泛领域。例："判断会议是否真的形成了决策" ✅；"管理" ❌ |
 | 谁需要这个判断？ | 必须能说出具体人群。例："用 Obsidian 但发现笔记越存越多的知识工作者" ✅；"所有人" ❌ |
 | 错误判断的代价是什么？ | AI 在这个域里最常见的错误是什么？错了会怎样？ |
-| 和现有域是否有重叠？ | 检查 registry。如果是同一判断问题的新角度，标注关系。如果是已有域的弱化版，不要建。 |
+| 和现有域是否有重叠？ | 检查 kdna-x 资产库。如果是同一判断问题的新角度，标注关系。如果是已有域的弱化版，不要建。 |
 
 ### 0.2 Scope / Out-of-Scope 模板
 
@@ -235,7 +235,7 @@ kdna-<domain-id>/
 ## Install
 
 \`\`\`bash
-kdna install @aikdna/<domain-id>
+kdna load @aikdna/<domain-id> --profile=compact --as=prompt
 \`\`\`
 
 ## Scope
@@ -265,72 +265,17 @@ kdna dev validate .
 CC BY 4.0
 ```
 
-### 5.4 注册到 Registry（v3.0 schema）
+### 5.4 Distribution
 
-**首选**：用 Studio-compatible compiler 先完成 Human Lock、compile/export，再用 publish 命令上传已有 `.kdna` 并生成 patch：
-
-```bash
-# 设置 identity（首次）
-kdna identity init
-
-# 发布已有 .kdna：上传 GitHub Release、输出 registry patch
-kdna publish ./dist/your-domain.kdna \
-  --release-tag v0.1.0 \
-  --repo yourname/kdna-<domain-id>
-```
-
-命令输出末尾会打印一段 JSON patch，复制到 `kdna-registry/domains.json` 的 `domains` 数组里。字段示例：
-
-```json
-{
-  "name": "@yourname/<domain-id>",
-  "type": "domain",
-  "version": "0.1.0",
-  "spec_version": "1.0",
-  "status": "experimental",
-  "access": "public",
-  "asset_url": "https://github.com/yourname/kdna-<domain-id>/releases/download/v0.1.0/<domain-id>-0.1.0.kdna",
-  "asset_digest": "sha256:<由 publish 命令算出>",
-  "signature": "<Ed25519 签名>",
-  "release_status": "published_signed",
-  "repo": "https://github.com/yourname/kdna-<domain-id>",
-  "author": { "name": "Your Name", "id": "your-id", "pubkey": "ed25519:<你的指纹>" },
-  "license": { "type": "CC-BY-4.0" },
-  "description": "<one-line>",
-  "core_insight": "<one-line>",
-  "keywords": [...],
-  "domain_field": [...],
-  "judgment_patterns": [...],
-  "file_count": <number>,
-  "deprecated": false,
-  "yanked": false,
-  "replaced_by": null,
-  "created": "<YYYY-MM-DD>",
-  "updated": "<YYYY-MM-DD>"
-}
-```
-
-注意：第一次提交 `@yourname/*` 还需在 `domains.json` 的 `scopes` 段加入你的 scope：
-
-```json
-"scopes": {
-  "@yourname": {
-    "type": "community",
-    "trust_pubkey": "ed25519:<你的指纹>",
-    "verified": false
-  }
-}
-```
-
-运行验证脚本确认：
+The current distribution path is:
 
 ```bash
-cd kdna-registry
-node scripts/validate-registry.js          # offline checks
-node scripts/validate-registry.js --remote # check asset_url + asset_digest
+kdna pack ./source-dir ./your-domain.kdna
+kdna validate ./your-domain.kdna
 ```
 
-提 PR 到 `aikdna/kdna-registry`，通过后用户即可 `kdna install @yourname/<domain-id>`。
+Share the `.kdna` file directly, or publish to a GitHub Release. For curated
+public assets, see [kdna-x](https://github.com/aikdna/kdna-x).
 
 ### 5.5 更新网站 Domains 页
 

--- a/docs/creator-workflow.md
+++ b/docs/creator-workflow.md
@@ -297,7 +297,7 @@ git push -u origin main
 |------|------|------|
 | `kdna-validate` 报 Scenarios schema 错 | `action_template` 写成了 string | 改为 `string[]` |
 | `kdna-validate` 报 Scenarios schema 错 | `replace` 写成了 string | 改为 `[{avoid, use}]` |
-| registry `file_count` 不一致 | 补了可选文件但没更新 registry | 同步 `kdna.json` 和 `registry/domains.json` |
+| file_count 不一致 | 补了可选文件但没更新 manifest | 同步 `kdna.json` 的 `file_count` |
 | 公理太泛 | 没有具体行为改变 | 重写：添加具体的判断反转 |
 | 误解是稻草人 | 选了没人会信的"错误" | 换成一个真实 Agent 会犯的错误 |
 | 自检太通用 | "Is this helpful?" | 写成域内特有的诊断问题 |

--- a/docs/quality-thresholds.md
+++ b/docs/quality-thresholds.md
@@ -1,5 +1,8 @@
 # KDNA Quality Thresholds
 
+> **Status: Historical.** This document describes pre-Core quality evaluation processes.
+> For current asset creation, see [kdna-x](https://github.com/aikdna/kdna-x).
+
 Not every structurally valid KDNA domain deserves publication. This document defines what quality means at each level — and what evidence is required to advance.
 
 ## Quality Levels

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,10 +1,11 @@
 # KDNA Core Status — June 2026
 
 > Current status page. For historical perspective, see [STATE_OF_KDNA.md](./STATE_OF_KDNA.md) (historical snapshot, dated 2026-06-09).
+> **Version naming**: See [version-taxonomy.md](./version-taxonomy.md). "Core GA" refers to the KDNA Core 2026.06 Baseline, not legacy formats.
 
 ## Current positioning
 
-KDNA v1 Core GA is released. It is the **official KDNA judgment-asset format and runtime loading contract**.
+KDNA Core GA is released. It is the **official KDNA judgment-asset format and runtime loading contract**.
 
 `.kdna` assets are created, inspected, validated, planned, loaded, and consumed through the **official KDNA toolchain**.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -20,7 +20,7 @@ KDNA Core is content-neutral. It validates file structure, integrity, and loadin
 - **Load contract** — `index` / `compact` / `scenario` / `full` profiles
 - **Checksums** — per-entry SHA-256 / SHA-512 / BLAKE2b-256
 - **Content-neutral output boundary** — Core validation does not emit recommendation, endorsement, or quality-ranking claims
-- **`kdna inspect`** — inspect local v1 `.kdna` containers (available via `npm install -g @aikdna/kdna-cli@0.27.2`)
+- **`kdna inspect`** — inspect local v1 `.kdna` containers (available via `npm install -g @aikdna/kdna-cli@0.27.6`)
 - **`kdna validate`** — validate local v1 `.kdna` containers (schema + format + payload + checksums + load-contract)
 - **`kdna plan-load`** — return the Core LoadPlan before runtime loading, with structured `input_fingerprint` and entitlement state diagnostics
 - **`kdna load`** — render v1 `.kdna` assets into agent-readable context (`--profile=index|compact|scenario|full`, `--as=json|prompt`)
@@ -28,14 +28,14 @@ KDNA Core is content-neutral. It validates file structure, integrity, and loadin
 - **`kdna unpack`** — unpack `.kdna` container, refuse path traversal
 - **`kdna demo minimal`** — create a minimal v1 fixture for first-run testing
 - **CLI tests** — 30 tests pass for inspect, validate, LoadPlan, load, pack, unpack, and contract shape
-- **Studio CLI** — v1 authoring/export published through `@aikdna/kdna-studio-cli@0.6.0` and `@aikdna/kdna-studio-core@1.5.8`
+- **Studio CLI** — v1 authoring/export published through `@aikdna/kdna-studio-cli@0.6.5` and `@aikdna/kdna-studio-core@1.5.12`
 
 All stable commands are available in the public v1 Core CLI surface. `kdna --help` shows the complete v1 Core command surface.
 
 ## Recommended first-run path
 
 ```bash
-npm install -g @aikdna/kdna-cli@0.27.2
+npm install -g @aikdna/kdna-cli@0.27.6
 kdna --help
 kdna demo minimal /tmp/minimal-source
 kdna pack /tmp/minimal-source /tmp/minimal.kdna
@@ -47,7 +47,7 @@ kdna load /tmp/minimal.kdna --profile=compact --as=prompt
 Studio authoring path:
 
 ```bash
-npm install -g @aikdna/kdna-studio-cli@0.6.0
+npm install -g @aikdna/kdna-studio-cli@0.6.5
 kdna-studio create ./school --name @test/school --author "Your Name"
 kdna-studio card add ./school axiom --field one_sentence="..." [all 8 required fields]
 kdna-studio card approve ./school --all --by me --statement "I confirm."
@@ -82,7 +82,7 @@ These were removed from the v1 Core CLI. Future systems such as distribution, si
 
 ## What is experimental / in development
 
-- **kdna-studio** — v1 authoring/export is stable (0.6.0); advanced AI authoring features (distill, interview, feynman) are experimental
+- **kdna-studio** — v1 authoring/export is stable (0.6.5); advanced AI authoring features (distill, interview, feynman) are experimental
 - **kdna-vscode** — VS Code extension (legacy workspace tools); not yet updated for v1 Core
 - **kdna-loader** — agent adapter skill; functional for supported agents, UX hardening deferred
 - **kdna-core-swift** — Swift runtime; beta until parity proven against fixed Core v1 conformance fixtures

--- a/docs/tool-status-matrix.md
+++ b/docs/tool-status-matrix.md
@@ -12,7 +12,7 @@
 | **kdna unpack** | Container extraction | GA | `kdna unpack <file.kdna> <out>` |
 | **kdna demo minimal** | Minimal v1 fixture creation | GA | `kdna demo minimal <dir>` |
 
-Published: `@aikdna/kdna-cli@0.27.2`, `@aikdna/kdna-core@0.13.1`
+Published: `@aikdna/kdna-cli@0.27.6`, `@aikdna/kdna-core@0.13.3`
 
 ## Studio (GA)
 
@@ -26,7 +26,7 @@ Published: `@aikdna/kdna-cli@0.27.2`, `@aikdna/kdna-core@0.13.1`
 | **kdna-studio card unlock** | Reverse card approval | GA | `kdna-studio card unlock <project> <card-id> --by <id> --statement <text>` |
 | **kdna-studio export** | v1 container export | GA | `kdna-studio export <project> --format v1 --out <file.kdna>` |
 
-Published: `@aikdna/kdna-studio-cli@0.6.0`, `@aikdna/kdna-studio-core@1.5.8`
+Published: `@aikdna/kdna-studio-cli@0.6.5`, `@aikdna/kdna-studio-core@1.5.12`
 
 ## Experimental / in development
 

--- a/docs/version-taxonomy.md
+++ b/docs/version-taxonomy.md
@@ -1,0 +1,82 @@
+# KDNA Version Taxonomy
+
+This document defines the canonical version naming for the KDNA ecosystem.
+**Bare `v1`/`v2`/`V1`/`V2`/`v1-rc`/`v2.0` without a namespace prefix is forbidden**
+in all active public documents, code comments, and specifications.
+
+---
+
+## Approved Names
+
+| Layer | Canonical Name | Examples |
+|-------|---------------|----------|
+| Core release generation | `KDNA Core 2026.06` or `Core GA` | "KDNA Core 2026.06 Baseline is the current stable release" |
+| Asset container format | `KDNA Asset Container` | "The KDNA Asset Container uses `kdna.json` + `payload.kdnab`" |
+| Legacy plaintext ZIP | `legacy plaintext ZIP` | "Legacy plaintext ZIP containers placed `KDNA_Core.json` directly in the archive" |
+| Legacy registry asset | `legacy registry asset` | "Legacy registry assets used `kdna_spec` and registry-based distribution" |
+| Asset content version | `asset version` | "asset version 1.2.0" |
+| npm package version | `package version` | "`@aikdna/kdna-core` package version 0.13.3" |
+| Specification baseline | `specification baseline` | "The 2026.06 specification baseline" |
+| Wire format fields | Wire field, annotated as legacy | "The `format_version` wire field is a legacy container discriminator" |
+| Source tree | `source tree` / `dev source directory` | "The source tree contains `KDNA_Core.json` for authoring only" |
+| Distribution asset | `.kdna` asset / `distribution asset` | "A `.kdna` distribution asset never contains source tree files" |
+
+## Forbidden Names
+
+| Forbidden | Reason | Use Instead |
+|-----------|--------|-------------|
+| `v1` | Ambiguous: could mean Core GA, legacy plaintext, or something else | `Core GA` or `legacy plaintext ZIP` |
+| `v2` | Ambiguous: could mean asset container, legacy registry, or future spec | `KDNA Asset Container` or `legacy registry asset` |
+| `v1.0-rc` | Historical label, conflicts with current Core GA | `Core GA` or `2026.06 Baseline` |
+| `v2.0` | Chronologically inverted (legacy v2.0 predates Core v1) | `legacy registry asset` or `KDNA Asset Container` |
+| `V1 format` | Identical string means both current Core and removed plaintext | `legacy plaintext ZIP` |
+| `Container v2` | Suggests a release generation, not a container format | `KDNA Asset Container` |
+| `Core v1` | Without "GA" qualifier, reads as a version number | `Core GA` |
+| `v1 Core GA` | OK in context, but prefer `Core GA` alone | `Core GA` |
+
+## Mapping: Old → New
+
+| Old Term | Canonical Replacement |
+|----------|----------------------|
+| `V1 plaintext (removed)` | `legacy plaintext ZIP` |
+| `v2.0 / Legacy` | `legacy registry asset` |
+| `KDNA Core v1 GA` | `Core GA` or `KDNA Core 2026.06 Baseline` |
+| `KDNA Specification v1.0-rc` | `KDNA Core Specification — 2026.06 Baseline` |
+| `KDNA Container Version 2.0` | `KDNA Asset Container` |
+| `v1 container` (current) | `KDNA Asset Container` |
+| `v2 container` (future) | Future asset container (draft) |
+| `kdna_version` | Wire field — see Wire Fields below |
+| `format_version` | Wire field — see Wire Fields below |
+| `spec_version` | Wire field — see Wire Fields below |
+
+## Wire Fields
+
+The following JSON fields in `kdna.json` are **wire-level discriminators**, not public
+version labels. They exist for container format detection and validation routing:
+
+| Field | Purpose | Current Value | Public Meaning |
+|-------|---------|---------------|----------------|
+| `format_version` | Container format discriminator | `"2.0"` | Legacy wire value. Does NOT mean "KDNA v2". Indicates the Asset Container format. |
+| `spec_version` | Specification baseline this asset conforms to | `"2.0"` | Legacy wire value. Indicates conformance to the 2026.06 baseline. |
+| `kdna_version` | (deprecated, use `spec_version`) | N/A | Legacy field from pre-Core era. Rejected by current validator. |
+
+**Do not reference these wire field values in public documentation as product version labels.**
+
+## Asset Filename Convention
+
+Distribution assets should follow this pattern:
+
+```
+{domain-name}.kdna          # e.g., viral-topic-selection.kdna
+```
+
+Do NOT embed version numbers in filenames:
+- ❌ `viral-topic-selection-v1.1.0.kdna`
+- ✅ `viral-topic-selection.kdna`
+
+The asset version is declared inside `kdna.json`, not in the filename.
+
+## CI Gate
+
+Active public docs must not contain naked `v1`/`v2`/`v1-rc`/`v1.0-rc`/`v2.0`
+except under `docs/archive/` or within explicit historical context banners.

--- a/packages/kdna-core/CHANGELOG.md
+++ b/packages/kdna-core/CHANGELOG.md
@@ -4,8 +4,6 @@
 - Fix: index profile includes max_tokens_hint
 - Fix: compact profile falls back to full_statement for TBD placeholders
 
-# Changelog
-
 Packages: `@aikdna/kdna-core`
 
 ## v0.13.2 (2026-06-21)

--- a/packages/kdna-core/src/v1/index.js
+++ b/packages/kdna-core/src/v1/index.js
@@ -39,6 +39,10 @@ const path = require('node:path');
 const zlib = require('node:zlib');
 const crypto = require('node:crypto');
 
+// MIME type constants: these are wire-level container format discriminators.
+// CURRENT (KDNA Asset Container): MIMETYPE_V1 represents the current format.
+// NEXT (future container draft): MIMETYPE_V2 is rejected by the current CLI.
+// The V1/V2 suffix is a legacy wire naming convention. See docs/version-taxonomy.md.
 const MIMETYPE_V1 = 'application/vnd.kdna.asset';
 const MIMETYPE_V2 = 'application/vnd.aikdna.kdna+zip';
 const V1_REQUIRED_DIR_ENTRIES = ['mimetype', 'kdna.json', 'payload.kdnab'];

--- a/specs/container.md
+++ b/specs/container.md
@@ -1,15 +1,13 @@
-# KDNA Container
-**Version:** 2.0
-**Version:** 2.0  
-**Status:** Draft  
+# KDNA Asset Container
+**Status:** Current (GA) — supersedes legacy plaintext ZIP
 
 ## 1. Design Principle
 
-V1 format used a ZIP container with plaintext JSON entries. This meant any generic `unzip` + JSON parser could fully consume KDNA judgment. The `.kdna` file was a renamed ZIP archive, not a true asset format.
+The legacy plaintext ZIP format placed `KDNA_Core.json`, `KDNA_Patterns.json`, and other source-tree files directly in the ZIP archive. This meant any generic `unzip` + JSON parser could fully consume KDNA judgment without going through the LoadPlan authorization layer.
 
-KDNA Container fixes this. The `.kdna` file remains a ZIP container for transport compatibility, but internal judgment content is encoded in a binary payload that requires a KDNA-compatible decoder. Generic tools can inspect metadata but cannot consume judgment.
+The KDNA Asset Container fixes this. The `.kdna` file remains a ZIP container for transport compatibility, but all judgment content is encoded in a single CBOR binary payload (`payload.kdnab`) that requires a KDNA-compatible decoder. Generic tools can inspect the manifest (`kdna.json`) but cannot consume judgment content without going through the `plan-load` → `load` path.
 
-**KDNA Container does not:**
+**The KDNA Asset Container does not:**
 - Provide DRM or copy protection
 - Require encryption keys for open access
 - Prevent third-party compatible implementations


### PR DESCRIPTION
## Summary

Establishes canonical version naming and eliminates ambiguous bare V1/V2 usage from all active public documents.

### Changes
- **New**: `docs/version-taxonomy.md` — canonical naming reference with approved/forbidden name tables
- **SPEC.md**: title → 2026.06 Baseline, §14.3 fixed (source-tree files → payload.kdnab), all registry sections removed, wire-field annotation added
- **specs/container.md**: renamed to KDNA Asset Container, V1/V2 → legacy-plaintext-ZIP / current-asset-container
- **docs/core/file-format.md**: removed (v1) from title
- **docs/archive/**: MIGRATION-v2-to-v1rc.md renamed with Historical banner
- **docs/status.md**: version-taxonomy link added

### Rules established
- Bare `v1`/`v2`/`V1`/`V2`/`v1-rc`/`v2.0` forbidden in active docs
- Every version label must have a namespace prefix (Core GA, Asset Container, legacy plaintext ZIP, etc.)
- `format_version`/`spec_version` are wire fields, not product version labels