### PR TITLE
docs: finish version taxonomy residual cleanup

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -823,7 +823,7 @@ Every `.kdna` container MUST include a `kdna.json` at the archive root. This fil
 
 **Optional fields:** `core_insight`, `keywords`, `file_count`, `risk_level`, `privacy_level`, `asset_type`, `created`, `updated`, `content_digest`, `signature`, `fitness_for_purpose`, `creator`, `lineage`.
 
-The `name` field follows the format `@scope/domain-name`. This is a structural naming convention; it does not require registration in any registry. The `kdna_spec` field is not part of v1.0 and MUST be rejected.
+The `name` field follows the format `@scope/domain-name`. This is a structural naming convention; it does not require registration in any system. The `kdna_spec` field is not part of the current Core specification and MUST be rejected.
 
 #### 14.4.1 Source Mode
 
@@ -870,7 +870,7 @@ Trust is NOT inherited through lineage. Forked, adapted, or migrated assets SHOU
 - **Asset digest:** `asset_digest` is the SHA-256 hash of the complete `.kdna` file bytes. It MUST be recorded outside the container, such as in a local receipt or lockfile.
 - **Content digest:** `content_digest` is the canonical SHA-256 hash of the internal content tree. The content tree includes all non-directory ZIP entries except `signature.json`, `.DS_Store`, `build-receipt.json`, `reports/*`, and local installation metadata. Reports and build receipts are build evidence, not judgment content — they are not part of the content digest. If stored in `kdna.json`, the `content_digest` field itself (and other self-referencing digest fields) are excluded from its own digest calculation.
 - Registries MUST use `asset_digest` for every installable `.kdna` asset and MAY also publish `content_digest`.
-- Installers MUST verify `asset_digest` before registration.
+- Consumers that rely on local receipts or lockfiles MUST verify `asset_digest` before trusting the asset.
 - Digest verification MUST fail closed: any mismatch prevents installation.
 
 The complete asset digest MUST NOT be embedded as a self-referential `container_sha256` field inside `kdna.json`.
@@ -892,7 +892,7 @@ Signing is an **optional enhancement** to `.kdna` assets. A `.kdna` container MA
   }
   ```
 - An unsigned `.kdna` file is a **valid KDNA asset**. Signature presence is a trust-layer enhancement, not a format-validity requirement.
-- A specific registry or platform MAY require signatures for assets listed there; such requirements are registry policy, not KDNA Core format rules.
+- A specific platform, organization, or runtime policy MAY require signatures for assets listed there; such requirements are platform policy, not KDNA Core format rules.
 
 ### 14.7 Install and Load Behavior
 
@@ -930,7 +930,7 @@ For operating system-level recognition of `.kdna` files:
 | **Linux** | MIME type `application/vnd.aikdna.kdna+zip`. Desktop file association. |
 
 The recommended media type is `application/vnd.aikdna.kdna+zip`.
-`application/x-kdna` is not a KDNA v1.0 media type and MUST be rejected in
+`application/x-kdna` is not a KDNA Core media type and MUST be rejected in
 registry metadata, HTTP responses, and OS integration files. See
 [`docs/MEDIA_TYPE.md`](./docs/MEDIA_TYPE.md).
 

--- a/docs/core/file-format.md
+++ b/docs/core/file-format.md
@@ -27,7 +27,7 @@ example.kdna
 | --- | --- | --- | --- |
 | `mimetype` | yes | UTF-8 plaintext | MUST be the literal string `application/vnd.kdna.asset` (no trailing newline). MUST be the first entry in the ZIP central directory so it can be read without parsing the full manifest. |
 | `kdna.json` | yes | UTF-8 JSON | The manifest. See `manifest.md`. |
-| `payload.kdnab` | yes | binary (CBOR or JSON) | The judgment payload. See `payload-profile.md`. May be plaintext or encrypted as a unit. Phase 1 only requires the plaintext case. |
+| `payload.kdnab` | yes | binary (CBOR or JSON) | The judgment payload. See `payload-profile.md`. May be plaintext or encrypted as a unit. The current Core GA supports plaintext public payloads; encrypted payload handling is reserved for future authorization profiles. |
 
 ## Optional entries
 
@@ -36,7 +36,7 @@ example.kdna
 | `checksums.json` | recommended | Per-entry digests. `validate` and `load` verify declared SHA-256 digests against actual entry content. A mismatch fails validation and blocks loading. See `docs/core/load-profiles.md` for the load contract. |
 | `signatures/` | optional | One or more signature files. Each file is named `<role>.sig` (e.g. `author.sig`, `publisher.sig`, `auditor.sig`). The signature is over a specific subset of entries; the manifest's `signatures` block records which subset. |
 | `attachments/` | optional | Supplementary files referenced from the payload. Each attachment has a path under `attachments/`. |
-| `locales/<lang>/` | optional | Localized strings. Phase 1 does not define a schema for these; localization metadata in the manifest's `scope.language` is sufficient for routing. |
+| `locales/<lang>/` | optional | Localized strings. Localization metadata in the manifest's `scope.language` is sufficient for routing. |
 
 ## Container requirements
 
@@ -44,16 +44,16 @@ example.kdna
 2. `mimetype` MUST be the first entry and MUST be stored uncompressed.
 3. `kdna.json` MUST be UTF-8 JSON without BOM.
 4. `payload.kdnab` MUST be either UTF-8 JSON (`.json` content) or CBOR. The manifest's `payload.encoding` field declares which.
-5. The container MUST be deterministic given the same input entries: a producer and a verifier that independently pack the same logical asset MUST produce byte-identical containers when the same digest algorithm is used. The official KDNA toolchain guarantees this for v1; assets that depend on non-deterministic packing are non-conformant.
-6. Encryption is per-entry, not whole-container. In Phase 1, only the plaintext case is exercised. The schema for encrypted entries is reserved for Phase 3.
+5. The container MUST be deterministic given the same input entries: a producer and a verifier that independently pack the same logical asset MUST produce byte-identical containers when the same digest algorithm is used. The official KDNA toolchain guarantees this for Core GA; assets that depend on non-deterministic packing are non-conformant.
+6. Encryption is per-entry, not whole-container. The current Core GA supports plaintext public payloads; the schema for encrypted entries is reserved for future authorization profiles.
 
 ## Anti-patterns
 
 - ❌ Wrapping the whole `.kdna` in another container (`.tar.gz.kdna`, `.zip.kdna`). The `.kdna` file IS the container.
 - ❌ Storing the manifest as a non-root path (`/manifests/v1/kdna.json`). The manifest is always at the root of the container.
-- ❌ Embedding the payload as multiple separate files (`KDNA_Core.json`, `KDNA_Patterns.json`, ...). Phase 1 collapses the payload into a single `payload.kdnab`. The multi-file layout is a v1-rc legacy shape and is not part of v1.
+- ❌ Embedding the payload as multiple separate files (`KDNA_Core.json`, `KDNA_Patterns.json`, ...). The current Core GA collapses the payload into a single `payload.kdnab`. The multi-file layout is a legacy plaintext ZIP shape and is not part of the current format.
 - ❌ Storing executable code (`.js`, `.py`, `.wasm`) inside the container that the loader is expected to execute. KDNA Core is data-only; any execution semantics belong to runtime extensions defined outside this spec.
 
 ## Versioning
 
-The container format version is recorded in the manifest as `kdna_version`. Phase 1 targets `kdna_version: "1.0"`. A loader encountering an unknown `kdna_version` SHOULD treat the asset as `version_incompatible` per the trace vocabulary and refuse to load it.
+The container format version is recorded in the manifest as `format_version` (wire field — see [version-taxonomy.md](../version-taxonomy.md)). A loader encountering an unknown `format_version` SHOULD treat the asset as `version_incompatible` per the trace vocabulary and refuse to load it.

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,7 +13,7 @@ Third-party products integrate KDNA through the official SDK, CLI, Loader, or AP
 
 KDNA Core is content-neutral. It validates file structure, integrity, and loading contracts; publishers and callers decide content quality, distribution, and runtime policy.
 
-## What is stable (v1 Core GA)
+## What is stable (Core GA)
 
 - **`.kdna` file format** — container layout, mimetype, required entries
 - **Manifest schema** (`schema/manifest.schema.json`) — `kdna.json` shape
@@ -29,9 +29,9 @@ KDNA Core is content-neutral. It validates file structure, integrity, and loadin
 - **`kdna unpack`** — unpack `.kdna` container, refuse path traversal
 - **`kdna demo minimal`** — create a minimal v1 fixture for first-run testing
 - **CLI tests** — 30 tests pass for inspect, validate, LoadPlan, load, pack, unpack, and contract shape
-- **Studio CLI** — v1 authoring/export published through `@aikdna/kdna-studio-cli@0.6.5` and `@aikdna/kdna-studio-core@1.5.12`
+- **Studio CLI** — Core GA authoring/export published through `@aikdna/kdna-studio-cli@0.6.5` and `@aikdna/kdna-studio-core@1.5.12`
 
-All stable commands are available in the public v1 Core CLI surface. `kdna --help` shows the complete v1 Core command surface.
+All stable commands are available in the public Core GA CLI surface. `kdna --help` shows the complete Core GA command surface.
 
 ## Recommended first-run path
 
@@ -56,9 +56,9 @@ kdna-studio export ./school --format v1 --out ./school.kdna
 kdna validate ./school.kdna
 ```
 
-## Removed in v1 Core 0.27.0
+## Removed in Core CLI 0.27.0
 
-The following legacy v0.7 command surfaces were removed in the hard cutover to v1 Core GA (`@aikdna/kdna-cli@0.27.0`):
+The following legacy v0.7 command surfaces were removed in the hard cutover to Core GA (`@aikdna/kdna-cli@0.27.0`):
 
 - `kdna help legacy`
 - `kdna setup`
@@ -79,12 +79,12 @@ The following legacy v0.7 command surfaces were removed in the hard cutover to v
 - `kdna dev`
 - All legacy subcommands (badge, test, changelog, etc.)
 
-These were removed from the v1 Core CLI. Future systems such as distribution, signing, encryption, entitlement, remote runtime, diagnostics, and workpacks may return only through new RFCs and separate packages. They are not part of the current v1 Core GA release.
+These were removed from the Core GA CLI. Future systems such as distribution, signing, encryption, entitlement, remote runtime, diagnostics, and workpacks may return only through new RFCs and separate packages. They are not part of the current Core GA release.
 
 ## What is experimental / in development
 
-- **kdna-studio** — v1 authoring/export is stable (0.6.5); advanced AI authoring features (distill, interview, feynman) are experimental
-- **kdna-vscode** — VS Code extension (legacy workspace tools); not yet updated for v1 Core
+- **kdna-studio** — Core GA authoring/export is stable (0.6.5); advanced AI authoring features (distill, interview, feynman) are experimental
+- **kdna-vscode** — VS Code extension (legacy workspace tools); not yet updated for Core GA
 - **kdna-loader** — agent adapter skill; functional for supported agents, UX hardening deferred
 - **kdna-core-swift** — Swift runtime; beta until parity proven against fixed Core v1 conformance fixtures
 - **kdna-lab** — pressure-test infrastructure; experimental
@@ -100,7 +100,7 @@ These were removed from the v1 Core CLI. Future systems such as distribution, si
 
 ## Known limitations
 
-1. **v2 / legacy registry containers** — old registry-distributed v2 `.kdna` assets are not supported by the v1 Core CLI. Users with legacy assets must re-export through current Studio v1 tooling. The CLI emits a clear "Unsupported legacy/registry container" error for v2 inputs.
+1. **Legacy registry containers** — old registry-distributed `.kdna` assets are not supported by the Core GA CLI. Users with legacy assets must re-export through current Studio Core GA tooling. The CLI emits a clear "Unsupported legacy/registry container" error for legacy inputs.
 2. **Cross-implementation parity** — JS Core is the public first-run path. Swift remains beta until parity is proven.
 3. **Release evidence** — npm packages are published and installable; stronger provenance, SBOM, and attestation chains remain post-baseline release hardening.
 4. **Real judgment demo** — the `kdna demo minimal` fixture proves format validity but does not demonstrate judgment value. A real-judgment demo asset is planned for the next work package (#18).

--- a/specs/container.md
+++ b/specs/container.md
@@ -34,7 +34,7 @@ kdna.json                       └── build-receipt.json
 ```
 
 - **Source Tree**: JSON files for human authoring, Git diff, and review. Never distributed as an asset.
-- **Asset Container**: `.kdna` file for registry distribution, installation, and verification. Judgment is encoded in `payload.kdnab`.
+- **Asset Container**: `.kdna` file for distribution, local receipt, transfer, verification, and runtime loading. Judgment is encoded in `payload.kdnab`.
 - **Runtime Capsule**: Structured output from `kdna load` for agent consumption. Agents MUST NOT read raw asset internals.
 
 ## 3. Container Structure
@@ -58,7 +58,7 @@ kdna.json                       └── build-receipt.json
 
 ### 3.3 Forbidden Entries
 
-The following entries MUST NOT exist in a v2 `.kdna` asset. Their presence indicates a V1 plaintext (removed) container and the asset MUST be rejected.
+The following entries MUST NOT exist in a current KDNA Asset Container. Their presence indicates a legacy plaintext ZIP container and the asset MUST be rejected.
 
 - `KDNA_Core.json`
 - `KDNA_Patterns.json`
@@ -67,7 +67,7 @@ The following entries MUST NOT exist in a v2 `.kdna` asset. Their presence indic
 - `KDNA_Reasoning.json`
 - `KDNA_Evolution.json`
 
-## 4. kdna.json Manifest (v2)
+## 4. kdna.json Manifest
 
 The manifest remains plaintext JSON inside the container. It MUST NOT contain any judgment content.
 
@@ -119,8 +119,8 @@ The manifest remains plaintext JSON inside the container. It MUST NOT contain an
 
 ### 4.1 Manifest Constraints
 
-- `format_version` MUST be `"2.0"` for v2 containers
-- `container.type` MUST be `"kdna-container-v2"`
+- `format_version` MUST be `"2.0"` as the current wire discriminator for KDNA Asset Container
+- `container.type` MUST be `"kdna-container-v2"` (legacy wire value)
 - `container.payload` MUST be `"payload.kdnab"`
 - `container.payload_digest` MUST be the SHA-256 of the encoded payload bytes
 - The manifest MUST NOT contain `axioms`, `ontology`, `frameworks`, `core_structure`, `stances`, `terminology`, `misunderstandings`, `self_check`, `scenes`, `cases`, `reasoning_chains`, `stages`, or any other judgment content fields
@@ -249,7 +249,7 @@ kdna dev decode domain.kdna --reveal
 
 A conforming loader MUST reject:
 
-1. **V1 plaintext (removed) container**: If `KDNA_Core.json` or any v1 judgment entry exists in the ZIP → `ERR_LEGACY_PLAINTEXT_CONTAINER`
+1. **Legacy plaintext ZIP container**: If `KDNA_Core.json` or any source-tree judgment entry exists in the ZIP → `ERR_LEGACY_PLAINTEXT_CONTAINER`
 2. **Missing payload**: If `payload.kdnab` is absent → `ERR_MISSING_PAYLOAD`
 3. **Digest mismatch**: If `container.payload_digest` does not match SHA-256 of decoded payload → `ERR_PAYLOAD_DIGEST_MISMATCH`
 4. **Schema violation**: If decoded judgment fails schema validation → `ERR_SCHEMA_VALIDATION_FAILED`
@@ -259,7 +259,7 @@ A conforming loader MUST reject:
 
 ## 9. Migration from v1
 
-V1 plaintext (removed) `.kdna` files are not valid assets. To migrate:
+Legacy plaintext ZIP `.kdna` files are not valid assets. To migrate:
 
 ```bash
 # From source tree (recommended):
@@ -267,14 +267,14 @@ kdna-studio migrate ./source-dir --out domain.kdna
 
 # From v1 .kdna (recovery):
 kdna dev unpack old-domain.kdna            # extract to source tree
-kdna-studio migrate ./extracted --out domain.kdna  # rebuild as v2
+kdna-studio migrate ./extracted --out domain.kdna  # rebuild as KDNA Asset Container
 ```
 
 ## 10. Reference Implementation Requirements
 
 All KDNA-compatible implementations MUST:
 
-- Reject V1 plaintext (removed) containers
+- Reject legacy plaintext ZIP containers
 - Decode `payload.kdnab` via CBOR
 - Emit context capsules (not raw JSON) from the default load path
 - Verify signatures and digests before serving content
@@ -284,4 +284,4 @@ All KDNA-compatible implementations MUST:
 
 | Version | Date | Changes |
 |---------|------|---------|
-| 2.0 | 2026-06-11 | Initial v2 specification. Removes V1 plaintext (removed) JSON entries. Introduces CBOR-encoded payload. Mandates capsule output. |
+| 2.0 | 2026-06-11 | Initial KDNA Asset Container specification. Replaces legacy plaintext ZIP entries with CBOR-encoded payload. |


### PR DESCRIPTION
Follow-up to #121. Cleans remaining P1 residuals in 4 files:

- **specs/container.md**: v2 container → KDNA Asset Container, V1 plaintext → legacy plaintext ZIP, registry distribution → distribution
- **docs/core/file-format.md**: Phase 1/3 → current Core GA, kdna_version → format_version (wire field)
- **docs/status.md**: v1 Core GA → Core GA throughout (9 replacements)
- **SPEC.md**: last 3 registry/platform semantic residues