### PR TITLE
fix(workpack): align bundled access enum with canonical schema

### DIFF
--- a/packages/kdna-core/src/workpack-pure.js
+++ b/packages/kdna-core/src/workpack-pure.js
@@ -25,7 +25,7 @@ const WORK_PACK_SCHEMA = {
     version: { type: 'string', pattern: '^\\d+\\.\\d+\\.\\d+(-[a-zA-Z0-9.]+)?(\\+[a-zA-Z0-9.]+)?$' },
     description: { type: 'string', maxLength: 280 },
     status: { type: 'string', enum: ['draft', 'experimental', 'stable', 'deprecated'] },
-    access: { type: 'string', enum: ['public', 'licensed', 'remote', 'enterprise', 'partner'], default: 'public' },
+    access: { type: 'string', enum: ['open', 'licensed', 'runtime', 'enterprise', 'partner'], default: 'open' },
     license: { type: 'string', default: 'Apache-2.0' },
     kdna: {
       type: 'object',
@@ -179,7 +179,7 @@ function inspectWorkPack(manifest, rootDir) {
     version: manifest.version,
     description: manifest.description,
     status: manifest.status,
-    access: manifest.access || 'public',
+    access: manifest.access || 'open',
     license: manifest.license || 'Apache-2.0',
     format_version: manifest.format_version,
     kdna: {


### PR DESCRIPTION
The `@aikdna/kdna-core` bundled copy of the Work Pack schema used
access: [public, licensed, remote, enterprise, partner], but the
canonical schema in kdna-workpack/specs/work-pack.schema.json uses
access: [open, licensed, runtime, enterprise, partner].

The create-kdna-workpack and kdna workpack init commands both write
access: 'open' (matching the canonical), so a user's very first
command — `workpack init my-pack` followed by `workpack validate my-pack`
— failed with 'must be equal to one of the allowed values'.

Align the bundled schema to the canonical values. A follow-up (T13 / PR-5
in the audit plan) will make kdna-core load the schema from kdna-workpack
directly so the two cannot drift again.

```bash
$ kdna workpack init my-pack
✓ Work Pack 'my-pack' created

$ kdna workpack validate my-pack
✓ Valid: my-pack v0.1.0
  Level: L1 — structurally complete
```

Companion PR: aikdna/kdna-workpack#pr-2-workpack-schema (conformance script accepts user paths)