### PR TITLE
chore(public-surface): scrub private references and mark kdna-vscode deprecated

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,7 @@ jobs:
           repository: aikdna/kdna-vscode
           ref: 810d06e77721614c3b014c9ecdd4a29ab0298454
           path: .ecosystem-repos/kdna-vscode
-# kdna-writing, kdna-prompt_diagnosis, kdna-agent_safety repos deleted — artifacts migrated to kdna-x
+# Legacy domain asset repos were removed; their artifacts are republished through the canonical release flow.
       - uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -111,7 +111,7 @@ jobs:
           repository: aikdna/kdna-vscode
           ref: 810d06e77721614c3b014c9ecdd4a29ab0298454
           path: .ecosystem-repos/kdna-vscode
-# kdna-writing, kdna-prompt_diagnosis, kdna-agent_safety repos deleted — artifacts migrated to kdna-x
+# Legacy domain asset repos were removed; their artifacts are republished through the canonical release flow.
       - uses: actions/setup-node@v6
         with:
           node-version: 22

--- a/docs/REGISTRY_IS_OPTIONAL.md
+++ b/docs/REGISTRY_IS_OPTIONAL.md
@@ -2,7 +2,7 @@
 
 > **Status: Historical.** Registry is not part of KDNA Core GA.
 > See [decisions/0003](../decisions/0003-no-registry-in-v1-core-ga.md).
-> The current distribution path is direct `.kdna` file sharing or [kdna-x](https://github.com/aikdna/kdna-x).
+> The current distribution path is direct `.kdna` file sharing or the official asset library (see release notes).
 
 This document defines the relationship between KDNA format validity and domain registries.
 

--- a/docs/audits/2026-06-16-repo-compliance.md
+++ b/docs/audits/2026-06-16-repo-compliance.md
@@ -18,32 +18,32 @@ Repos: 26
 
 REPO                             | LICENSE README  CONT SEC  CHLOG  CI   CODE  GIT | HEAD-SHA    
 ---------------------------------+-------------------------------------------------+-------------
-kdna                             | yes     yes     yes  yes  yes    yes  yes   yes | c97dc73     
-kdna-agent_safety                | yes     yes     yes  yes  yes    yes  yes   yes | 5c0a7f8     
-kdna-animation                   | yes     yes     yes  yes  yes    yes  yes   yes | e7ddc06     
-kdna-app-shared                  | yes     yes     yes  yes  yes    yes  yes   yes | 67d806d     
-kdna-authoring                   | yes     yes     yes  yes  yes    yes  yes   yes | fbcbdce     
-kdna-cli                         | yes     yes     yes  yes  yes    yes  yes   yes | c8fd958     
-kdna-code_review                 | yes     yes     yes  yes  yes    yes  yes   yes | f68ccd0     
-kdna-content_strategy            | yes     yes     yes  yes  NO     yes  yes   yes | f4312e1     
-kdna-core-swift                  | yes     yes     yes  yes  yes    yes  yes   yes | 27a18d5     
-kdna-decision_state              | yes     yes     yes  yes  NO     yes  yes   yes | 5ae7210     
-kdna-for-agent-skills            | yes     yes     yes  yes  NO     yes  yes   yes | 9fe05c3     
-kdna-knowledge_management        | yes     yes     yes  yes  NO     yes  yes   yes | f83a79a     
-kdna-lab                         | yes     yes     yes  NO   yes    yes  yes   yes | 040ffc6     
-kdna-open_source_project         | yes     yes     yes  yes  NO     yes  yes   yes | c51120c     
-kdna-prompt_diagnosis            | yes     yes     yes  yes  yes    yes  yes   yes | f0e7cfe     
-kdna-registry                    | yes     yes     yes  yes  yes    yes  yes   yes | fd606cb     
-kdna-requirement_alignment       | yes     yes     yes  yes  yes    yes  yes   NO  | a54d610     
-kdna-skills                      | yes     yes     yes  yes  yes    yes  yes   yes | a94fe5d     
-kdna-studio-cli                  | yes     yes     yes  yes  yes    yes  yes   yes | 6299f46     
-kdna-studio-core                 | yes     yes     yes  yes  yes    yes  yes   yes | 599f1a8     
-kdna-studio-swift                | yes     yes     yes  yes  yes    yes  yes   yes | 80bcbda     
-kdna-vscode                      | yes     yes     yes  yes  yes    yes  yes   yes | ef6354b     
-kdna-workpack                    | yes     yes     yes  yes  yes    yes  yes   yes | 1d238c5     
-kdna-writing                     | yes     yes     yes  yes  yes    yes  yes   yes | b8a22d4     
-sketchnote-style                 | yes     yes     yes  yes  yes    yes  yes   yes | aaada1e     
-test_domain                      | yes     yes     yes  yes  yes    yes  yes   yes | ba5153a     
+kdna                             | yes     yes     yes  yes  yes    yes  yes   yes | c97d***     
+kdna-agent_safety                | yes     yes     yes  yes  yes    yes  yes   yes | see repo compliance     
+kdna-animation                   | yes     yes     yes  yes  yes    yes  yes   yes | e7dd***     
+kdna-app-shared                  | yes     yes     yes  yes  yes    yes  yes   yes | 67d8***     
+kdna-authoring                   | yes     yes     yes  yes  yes    yes  yes   yes | fbcb***     
+kdna-cli                         | yes     yes     yes  yes  yes    yes  yes   yes | c8fd***     
+kdna-code_review                 | yes     yes     yes  yes  yes    yes  yes   yes | f68c***     
+kdna-content_strategy            | yes     yes     yes  yes  NO     yes  yes   yes | f431***     
+kdna-core-swift                  | yes     yes     yes  yes  yes    yes  yes   yes | 27a1***     
+kdna-decision_state              | yes     yes     yes  yes  NO     yes  yes   yes | 5ae7***     
+kdna-for-agent-skills            | yes     yes     yes  yes  NO     yes  yes   yes | 9fe0***     
+kdna-knowledge_management        | yes     yes     yes  yes  NO     yes  yes   yes | f83a***     
+lab (private)                         | yes     yes     yes  NO   yes    yes  yes   yes | see repo compliance     
+kdna-open_source_project         | yes     yes     yes  yes  NO     yes  yes   yes | c511***     
+kdna-prompt_diagnosis            | yes     yes     yes  yes  yes    yes  yes   yes | see repo compliance     
+kdna-registry                    | yes     yes     yes  yes  yes    yes  yes   yes | see repo compliance     
+kdna-requirement_alignment       | yes     yes     yes  yes  yes    yes  yes   NO  | a54d***     
+kdna-skills                      | yes     yes     yes  yes  yes    yes  yes   yes | a94f***     
+kdna-studio-cli                  | yes     yes     yes  yes  yes    yes  yes   yes | 6299***     
+kdna-studio-core                 | yes     yes     yes  yes  yes    yes  yes   yes | 599f***     
+kdna-studio-swift                | yes     yes     yes  yes  yes    yes  yes   yes | 80bc***     
+kdna-vscode                      | yes     yes     yes  yes  yes    yes  yes   yes | ef63***     
+kdna-workpack                    | yes     yes     yes  yes  yes    yes  yes   yes | 1d23***     
+kdna-writing                     | yes     yes     yes  yes  yes    yes  yes   yes | see repo compliance     
+sketchnote-style                 | yes     yes     yes  yes  yes    yes  yes   yes | aaad***     
+test_domain                      | yes     yes     yes  yes  yes    yes  yes   yes | ba51***     
 
 === Notes ===
 - LICENSE: LICENSE or LICENSE.md present

--- a/docs/audits/2026-06-16-repo-compliance.md
+++ b/docs/audits/2026-06-16-repo-compliance.md
@@ -30,7 +30,7 @@ kdna-core-swift                  | yes     yes     yes  yes  yes    yes  yes   y
 kdna-decision_state              | yes     yes     yes  yes  NO     yes  yes   yes | 5ae7***     
 kdna-for-agent-skills            | yes     yes     yes  yes  NO     yes  yes   yes | 9fe0***     
 kdna-knowledge_management        | yes     yes     yes  yes  NO     yes  yes   yes | f83a***     
-lab (private)                         | yes     yes     yes  NO   yes    yes  yes   yes | see repo compliance     
+the E2E test lab (private)                         | yes     yes     yes  NO   yes    yes  yes   yes | see repo compliance     
 kdna-open_source_project         | yes     yes     yes  yes  NO     yes  yes   yes | c511***     
 kdna-prompt_diagnosis            | yes     yes     yes  yes  yes    yes  yes   yes | see repo compliance     
 kdna-registry                    | yes     yes     yes  yes  yes    yes  yes   yes | see repo compliance     

--- a/docs/audits/2026-06-16-rfc-0013-audit-note.md
+++ b/docs/audits/2026-06-16-rfc-0013-audit-note.md
@@ -12,24 +12,24 @@ four repositories that turn RFC-0013 §9 from a design contract
 into a working pipeline. The full evidence is in
 `docs/audits/rfc-0013-implementation-evidence-pack.md`. Summary:
 
-- **PR-1** `c00601c` (aikdna/kdna #86) — three authoring-time
+- **PR-1** `see PR-1 acceptance` (aikdna/kdna #86) — three authoring-time
   schemas (`source_authority` / `truth_charter` /
   `module_manifest`) under `schema/`.
-- **PR-2** `bb64821` (aikdna/kdna-cli #10) — Anti-Monolithic CLI
+- **PR-2** `see PR-2 acceptance` (aikdna/kdna-cli #10) — Anti-Monolithic CLI
   lint (`src/cmds/anti-monolithic.js`) + 6 unit tests.
-- **PR-2a** `f328ca0` (aikdna/kdna #87) — `SPEC.md` §1.6.3
+- **PR-2a** `see PR-2a acceptance` (aikdna/kdna #87) — `SPEC.md` §1.6.3
   Anti-Monolithic Domain Principle.
-- **PR-3** `e2dddf4` (aikdna/kdna-studio-core #3) — SAG/TC
+- **PR-3** `see PR-3 acceptance` (aikdna/kdna-studio-core #3) — SAG/TC
   compile gates under `src/compile/`.
-- **PR-4** `d8c466c` (aikdna/kdna-lab #3) — RFC-0013 lifecycle
+- **PR-4** `see PR-4 acceptance` (lab PR) — RFC-0013 lifecycle
   smoke on `@aikdna/code_review` (11 trace events, all carrying
   `sag_version` + `tc_status`).
-- **PR-4b** `3849ae1` (aikdna/kdna-lab #4) — default SAG/TC
+- **PR-4b** `see PR-4b acceptance` (lab PR) — default SAG/TC
   synthesis migration smoke (6 trace events, default → locked TC
   flow). 11/11 pytest pass.
-- **Phase 2** `c2103aa` (aikdna/kdna #88) — files RFC-0014
+- **Phase 2** `see Phase 2 filing` (aikdna/kdna #88) — files RFC-0014
   (Card v2) and RFC-0015 (Trace v2) as Drafts.
-- **Evidence pack** `3509fd7` (aikdna/kdna #89) — this evidence
+- **Evidence pack** `3509***` (aikdna/kdna #89) — this evidence
   pack itself, plus the tiny RFC-0014 path fix (the only drift
   fix that landed in the same PR).
 
@@ -52,8 +52,8 @@ post-series status is in the evidence pack linked above.
 **Status:** PARTIALLY VERIFIED / NOT YET APPROVED
 
 ### Verified
-- Remote commit `d1f35ee` exists: RFC-0013 Judgment Asset Lifecycle (638 lines)
-- Remote commit `9b08997` exists: access enum aligned with SPEC §3.3.2
+- Remote commit `d1f3***` exists: RFC-0013 Judgment Asset Lifecycle (638 lines)
+- Remote commit `9b08***` exists: access enum aligned with SPEC §3.3.2
 - SPEC.md currently defines `access: public | licensed | remote`
 - Earlier "commit not visible" blocker (a local-only commit not present on remote, hash not on remote) is resolved via repush
 
@@ -67,15 +67,15 @@ post-series status is in the evidence pack linked above.
 
 | SHA | Subject | Files |
 |-----|---------|-------|
-| `9b08997` | fix: align all access enum references with SPEC §3.3.2 | 15 files, 49+/49- (spec layer + schema layer + code layer + registry data) |
-| `d1f35ee` | rfc: RFC-0013 KDNA Judgment Asset Lifecycle + rfc-status sync | `specs/RFC-0013-judgment-asset-lifecycle.md` (638 lines) + `docs/rfc-status.md` (RFC-0012/0013 rows) |
-| `a6e8247`, `f0a1fab`, `c97dc73`, `69396d7` | chore/docs(audit): scan script + audit evidence | `scripts/scan-repo-compliance.sh` + `docs/audits/2026-06-16-repo-compliance.md` |
+| `9b08***` | fix: align all access enum references with SPEC §3.3.2 | 15 files, 49+/49- (spec layer + schema layer + code layer + registry data) |
+| `d1f3***` | rfc: RFC-0013 KDNA Judgment Asset Lifecycle + rfc-status sync | `specs/RFC-0013-judgment-asset-lifecycle.md` (638 lines) + `docs/rfc-status.md` (RFC-0012/0013 rows) |
+| `a6e8***`, `f0a1***`, `c97d***`, `6939***` | chore/docs(audit): scan script + audit evidence | `scripts/scan-repo-compliance.sh` + `docs/audits/2026-06-16-repo-compliance.md` |
 
 A local backup tag (not pushed to origin) contains three local-only commit not present on remotes
 that were made on a stale local `main` and were intentionally not pushed.
 They are kept for forensic reference.
 
-## What `9b08997` Touched (15 files, 49 insertions, 49 deletions)
+## What `9b08***` Touched (15 files, 49 insertions, 49 deletions)
 
 The earlier report described this as "2 line example fix" — that was
 incorrect. The actual scope is broader:
@@ -164,7 +164,7 @@ External auditors can verify all claims above with these commands:
 git clone https://github.com/aikdna/kdna
 cd kdna
 git log --oneline -5
-# Should show: 69396d7, c97dc73, f0a1fab, a6e8247, d1f35ee, 9b08997
+# Should show: 6939***, c97d***, f0a1***, a6e8***, d1f3***, 9b08***
 
 # 2. RFC-0013 line count and structure
 git show origin/main:specs/RFC-0013-judgment-asset-lifecycle.md | wc -l
@@ -193,7 +193,7 @@ bash scripts/scan-repo-compliance.sh /path/to/local-workspace
   distillation (2026-06-14, ~500 lines, not in repo)
 - 6-12 doc upgrade (related but distinct): a local-only commit not present on remote
   (not on remote, hash not in main history)
-- PR #85 (foundation for the access-enum fix): commit `4090180` on remote
+- PR #85 (foundation for the access-enum fix): commit `4090***` on remote
 - local backup marker (3 local-only commit not present on remotes; not pushed to origin)
 - Subsequent RFC-0013 implementation series: see
   `docs/audits/rfc-0013-implementation-evidence-pack.md`

--- a/docs/audits/2026-06-16-rfc-0013-audit-note.md
+++ b/docs/audits/2026-06-16-rfc-0013-audit-note.md
@@ -21,10 +21,10 @@ into a working pipeline. The full evidence is in
   Anti-Monolithic Domain Principle.
 - **PR-3** `see PR-3 acceptance` (aikdna/kdna-studio-core #3) — SAG/TC
   compile gates under `src/compile/`.
-- **PR-4** `see PR-4 acceptance` (lab PR) — RFC-0013 lifecycle
+- **PR-4** `see PR-4 acceptance` (the E2E test the E2E test the E2E test lab (private) PR) — RFC-0013 lifecycle
   smoke on `@aikdna/code_review` (11 trace events, all carrying
   `sag_version` + `tc_status`).
-- **PR-4b** `see PR-4b acceptance` (lab PR) — default SAG/TC
+- **PR-4b** `see PR-4b acceptance` (the E2E test the E2E test the E2E test lab (private) PR) — default SAG/TC
   synthesis migration smoke (6 trace events, default → locked TC
   flow). 11/11 pytest pass.
 - **Phase 2** `see Phase 2 filing` (aikdna/kdna #88) — files RFC-0014

--- a/docs/audits/flagship-agent-safety-v1-migration-fidelity.md
+++ b/docs/audits/flagship-agent-safety-v1-migration-fidelity.md
@@ -14,14 +14,14 @@ failure modes, and derived boundaries.
 - Source repo: `kdna-agent_safety`
 - Source package name: `@aikdna/agent_safety`
 - v1 asset ID: `kdna:aikdna:agent_safety`
-- Output container: `/private/tmp/kdna-registry-proof/out/agent_safety.kdna`
+- Output container: `/tmp/kdna-registry-proof/out/agent_safety.kdna`
 
 ## Toolchain
 
 ```bash
-./node_modules/.bin/kdna-studio migrate /Users/AI/K/OPEN/kdna-agent_safety \
+./node_modules/.bin/kdna-studio migrate <workdir>/kdna-agent_safety \
   --format v1 \
-  --out /private/tmp/kdna-registry-proof/out/agent_safety.kdna \
+  --out /tmp/kdna-registry-proof/out/agent_safety.kdna \
   --name @aikdna/agent_safety \
   --by aikdna-maintainers \
   --statement registry-clean-install-proof
@@ -37,7 +37,7 @@ Public npm packages used:
 
 ## Validation
 
-`kdna validate /private/tmp/kdna-registry-proof/out/agent_safety.kdna` returned:
+`kdna validate /tmp/kdna-registry-proof/out/agent_safety.kdna` returned:
 
 ```json
 {

--- a/docs/audits/flagship-prompt-diagnosis-v1-migration-fidelity.md
+++ b/docs/audits/flagship-prompt-diagnosis-v1-migration-fidelity.md
@@ -14,14 +14,14 @@ runtime use.
 - Source repo: `kdna-prompt_diagnosis`
 - Source package name: `@aikdna/prompt_diagnosis`
 - v1 asset ID: `kdna:aikdna:prompt_diagnosis`
-- Output container: `/private/tmp/kdna-registry-proof/out/prompt_diagnosis.kdna`
+- Output container: `/tmp/kdna-registry-proof/out/prompt_diagnosis.kdna`
 
 ## Toolchain
 
 ```bash
-./node_modules/.bin/kdna-studio migrate /Users/AI/K/OPEN/kdna-prompt_diagnosis \
+./node_modules/.bin/kdna-studio migrate <workdir>/kdna-prompt_diagnosis \
   --format v1 \
-  --out /private/tmp/kdna-registry-proof/out/prompt_diagnosis.kdna \
+  --out /tmp/kdna-registry-proof/out/prompt_diagnosis.kdna \
   --name @aikdna/prompt_diagnosis \
   --by aikdna-maintainers \
   --statement registry-clean-install-proof
@@ -37,7 +37,7 @@ Public npm packages used:
 
 ## Validation
 
-`kdna validate /private/tmp/kdna-registry-proof/out/prompt_diagnosis.kdna`
+`kdna validate /tmp/kdna-registry-proof/out/prompt_diagnosis.kdna`
 returned:
 
 ```json

--- a/docs/audits/flagship-v1-migration-hardening-verification.md
+++ b/docs/audits/flagship-v1-migration-hardening-verification.md
@@ -41,8 +41,8 @@ with:
   `[object Object]`
 
 This is now backed by source-tree verification, a local tarball clean-install
-proof from `/private/tmp/kdna-clean-proof-2`, and an npm-registry clean-install
-proof from `/private/tmp/kdna-registry-proof`.
+proof from `/tmp/kdna-clean-proof-2`, and an npm-registry clean-install
+proof from `/tmp/kdna-registry-proof`.
 
 It is still **not final public-launch proof** until final per-asset PASS reports,
 README/release artifacts, MCP package evidence, website/docs reconciliation, and
@@ -58,61 +58,61 @@ Remaining launch work:
 ## Commands Run
 
 ```bash
-node /Users/AI/K/OPEN/kdna-studio-cli/bin/kdna-studio.js migrate \
-  /Users/AI/K/OPEN/kdna-writing \
+node <workdir>/kdna-studio-cli/bin/kdna-studio.js migrate \
+  <workdir>/kdna-writing \
   --out /tmp/kdna-v1-flagships/writing.kdna \
   --name @aikdna/writing \
   --by kdna-team \
   --statement "v1 flagship migration verification" \
   --format v1
 
-node /Users/AI/K/OPEN/kdna-studio-cli/bin/kdna-studio.js migrate \
-  /Users/AI/K/OPEN/kdna-prompt_diagnosis \
+node <workdir>/kdna-studio-cli/bin/kdna-studio.js migrate \
+  <workdir>/kdna-prompt_diagnosis \
   --out /tmp/kdna-v1-flagships/prompt_diagnosis.kdna \
   --name @aikdna/prompt_diagnosis \
   --by kdna-team \
   --statement "v1 flagship migration verification" \
   --format v1
 
-node /Users/AI/K/OPEN/kdna-studio-cli/bin/kdna-studio.js migrate \
-  /Users/AI/K/OPEN/kdna-agent_safety \
+node <workdir>/kdna-studio-cli/bin/kdna-studio.js migrate \
+  <workdir>/kdna-agent_safety \
   --out /tmp/kdna-v1-flagships/agent_safety.kdna \
   --name @aikdna/agent_safety \
   --by kdna-team \
   --statement "v1 flagship migration verification" \
   --format v1
 
-node /Users/AI/K/OPEN/kdna-cli/src/cli.js validate /tmp/kdna-v1-flagships/<asset>.kdna
+node <workdir>/kdna-cli/src/cli.js validate /tmp/kdna-v1-flagships/<asset>.kdna
 ```
 
 Additional local verification after prompt-render hardening:
 
 ```bash
 npm test
-# in /Users/AI/K/OPEN/kdna-studio-cli
+# in <workdir>/kdna-studio-cli
 # 18/18 pass
 
 npm test
-# in /Users/AI/K/OPEN/kdna-studio-core
+# in <workdir>/kdna-studio-core
 # 128/128 pass
 
 npm test
-# in /Users/AI/K/OPEN/kdna
+# in <workdir>/kdna
 # core smoke, kdna-core, kdna-eval, and cli-v1 all pass
 ```
 
 Local tarball clean-install proof:
 
 ```bash
-npm pack --pack-destination /private/tmp/kdna-pack-proof-2
+npm pack --pack-destination /tmp/kdna-pack-proof-2
 # @aikdna/kdna-core@0.11.1
 # @aikdna/kdna-studio-core@1.5.3
 # @aikdna/kdna-studio-cli@0.5.2
 
 npm install \
-  /private/tmp/kdna-pack-proof-2/aikdna-kdna-core-0.11.1.tgz \
-  /private/tmp/kdna-pack-proof-2/aikdna-kdna-studio-core-1.5.3.tgz \
-  /private/tmp/kdna-pack-proof-2/aikdna-kdna-studio-cli-0.5.2.tgz \
+  /tmp/kdna-pack-proof-2/aikdna-kdna-core-0.11.1.tgz \
+  /tmp/kdna-pack-proof-2/aikdna-kdna-studio-core-1.5.3.tgz \
+  /tmp/kdna-pack-proof-2/aikdna-kdna-studio-cli-0.5.2.tgz \
   @aikdna/kdna-cli@0.25.0
 
 ./node_modules/.bin/kdna-studio migrate <flagship-source> --format v1 --out <asset.kdna>
@@ -127,7 +127,7 @@ as readable compact prompts, and exposed non-empty `core.boundaries`.
 Npm registry clean-install proof:
 
 ```bash
-cd /private/tmp/kdna-registry-proof
+cd /tmp/kdna-registry-proof
 npm init -y
 npm install \
   @aikdna/kdna-core@0.11.1 \
@@ -136,30 +136,30 @@ npm install \
   @aikdna/kdna-studio-cli@0.5.2 \
   @aikdna/kdna@0.9.0
 
-./node_modules/.bin/kdna-studio migrate /Users/AI/K/OPEN/kdna-writing \
+./node_modules/.bin/kdna-studio migrate <workdir>/kdna-writing \
   --format v1 \
-  --out /private/tmp/kdna-registry-proof/out/writing.kdna \
+  --out /tmp/kdna-registry-proof/out/writing.kdna \
   --name @aikdna/writing \
   --by aikdna-maintainers \
   --statement registry-clean-install-proof
 
-./node_modules/.bin/kdna-studio migrate /Users/AI/K/OPEN/kdna-agent_safety \
+./node_modules/.bin/kdna-studio migrate <workdir>/kdna-agent_safety \
   --format v1 \
-  --out /private/tmp/kdna-registry-proof/out/agent_safety.kdna \
+  --out /tmp/kdna-registry-proof/out/agent_safety.kdna \
   --name @aikdna/agent_safety \
   --by aikdna-maintainers \
   --statement registry-clean-install-proof
 
-./node_modules/.bin/kdna-studio migrate /Users/AI/K/OPEN/kdna-prompt_diagnosis \
+./node_modules/.bin/kdna-studio migrate <workdir>/kdna-prompt_diagnosis \
   --format v1 \
-  --out /private/tmp/kdna-registry-proof/out/prompt_diagnosis.kdna \
+  --out /tmp/kdna-registry-proof/out/prompt_diagnosis.kdna \
   --name @aikdna/prompt_diagnosis \
   --by aikdna-maintainers \
   --statement registry-clean-install-proof
 
-./node_modules/.bin/kdna validate /private/tmp/kdna-registry-proof/out/<asset>.kdna
-./node_modules/.bin/kdna load /private/tmp/kdna-registry-proof/out/<asset>.kdna --profile=compact --as=prompt
-./node_modules/.bin/kdna load /private/tmp/kdna-registry-proof/out/<asset>.kdna --profile=full --as=json
+./node_modules/.bin/kdna validate /tmp/kdna-registry-proof/out/<asset>.kdna
+./node_modules/.bin/kdna load /tmp/kdna-registry-proof/out/<asset>.kdna --profile=compact --as=prompt
+./node_modules/.bin/kdna load /tmp/kdna-registry-proof/out/<asset>.kdna --profile=full --as=json
 ```
 
 Result: `writing`, `agent_safety`, and `prompt_diagnosis` all exported from

--- a/docs/audits/flagship-writing-v1-migration-fidelity.md
+++ b/docs/audits/flagship-writing-v1-migration-fidelity.md
@@ -6,14 +6,14 @@
 
 This report supersedes the pre-hardening failure report that recorded the old
 Studio v1 export retaining only axiom one-liners. Current evidence comes from
-public npm packages installed in `/private/tmp/kdna-registry-proof`.
+public npm packages installed in `/tmp/kdna-registry-proof`.
 
 ## Asset
 
 - Source repo: `kdna-writing`
 - Source package name: `@aikdna/writing`
 - v1 asset ID: `kdna:aikdna:writing`
-- Output container: `/private/tmp/kdna-registry-proof/out/writing.kdna`
+- Output container: `/tmp/kdna-registry-proof/out/writing.kdna`
 
 ## Toolchain
 
@@ -25,9 +25,9 @@ npm install \
   @aikdna/kdna-studio-cli@0.5.2 \
   @aikdna/kdna@0.9.0
 
-./node_modules/.bin/kdna-studio migrate /Users/AI/K/OPEN/kdna-writing \
+./node_modules/.bin/kdna-studio migrate <workdir>/kdna-writing \
   --format v1 \
-  --out /private/tmp/kdna-registry-proof/out/writing.kdna \
+  --out /tmp/kdna-registry-proof/out/writing.kdna \
   --name @aikdna/writing \
   --by aikdna-maintainers \
   --statement registry-clean-install-proof
@@ -35,7 +35,7 @@ npm install \
 
 ## Validation
 
-`kdna validate /private/tmp/kdna-registry-proof/out/writing.kdna` returned:
+`kdna validate /tmp/kdna-registry-proof/out/writing.kdna` returned:
 
 ```json
 {

--- a/docs/audits/kdna-public-narrative-audit-2026-06.md
+++ b/docs/audits/kdna-public-narrative-audit-2026-06.md
@@ -222,7 +222,7 @@ heavily tied to the registry / marketplace framing.
 | `rfcs/RFC-0001-work-pack-specification.md` | Old RFC body. | P2 | Mark as "RFC, accepted pre-v1; v1 Core positioning supersedes". |
 | `package.json` | "trust" / "registry" in description. | P1 | Update. |
 
-### 3.10 aikdna/kdna-lab
+### 3.10 lab (private)
 
 The lab is the experimental / pressure-test infrastructure. It is
 allowed to use "evidence" framing because that's what a test lab does,
@@ -272,7 +272,7 @@ The PR-100 (fixture / conformance recovery) work will cover them.
 | aikdna/kdna-vscode | 1 | 1 | 0 | 0 | 2 | PR-98d |
 | aikdna/kdna-skills | 0 | 1 | 1 | 0 | 2 | PR-98d |
 | aikdna/kdna-workpack | 0 | 2 | 1 | 0 | 3 | PR-98d |
-| aikdna/kdna-lab | 0 | 1 | 1 | 0 | 2 | PR-98c |
+| lab (private) | 0 | 1 | 1 | 0 | 2 | PR-98c |
 | aikdna/kdna-core-swift | 0 | 0 | 1 | 0 | 1 | PR-98d |
 | aikdna/kdna-studio-swift | 0 | 0 | 0 | 1 | 1 | after kdna-core-swift fix |
 | Domain repos (~12) | 0 | 0 | 12 | 3 | 15 | PR-100 |
@@ -286,7 +286,7 @@ follow-up PRs by repo group, **not** into a single big PR.
 
 | PR | Scope | Repos | Estimated effort |
 |---|---|---|---|
-| PR-98c | website + registry + main-repo deep docs | `kdna-website`, `kdna-registry`, `kdna` (deep docs), `kdna-lab`, `kdna` (CHANGELOG / RELEASE_CHECKLIST / rfcs/ marked historical) | Large. Mark `kdna-registry` repo as legacy / archived. Re-author website content. |
+| PR-98c | website + registry + main-repo deep docs | `kdna-website`, `kdna-registry`, `kdna` (deep docs), `lab (private)`, `kdna` (CHANGELOG / RELEASE_CHECKLIST / rfcs/ marked historical) | Large. Mark `kdna-registry` repo as legacy / archived. Re-author website content. |
 | PR-98d | CLI / Core / Studio / VSCode / Skills / Workpack | `kdna-cli`, `kdna-studio-core`, `kdna-studio-cli`, `kdna-vscode`, `kdna-skills`, `kdna-workpack`, `kdna-core-swift` | Large. Re-author READMEs. Audit code surfaces. |
 | PR-98e | domain repos + remaining ecosystem repos | `kdna-writing`, `kdna-agent_safety`, `kdna-prompt_diagnosis`, `kdna-content_strategy`, `kdna-decision_state`, `kdna-knowledge_management`, `kdna-open_source_project`, `kdna-requirement_alignment`, `kdna-animations`, `kdna-authoring`, `kdna-code_review`, `kdna-app-shared`, `kdna-for-agent-skills`, `kdna-releases` | Medium. Mostly archival / light rewording. Heavy data-shape changes belong in PR-100, not here. |
 

--- a/docs/audits/kdna-public-narrative-audit-2026-06.md
+++ b/docs/audits/kdna-public-narrative-audit-2026-06.md
@@ -222,7 +222,7 @@ heavily tied to the registry / marketplace framing.
 | `rfcs/RFC-0001-work-pack-specification.md` | Old RFC body. | P2 | Mark as "RFC, accepted pre-v1; v1 Core positioning supersedes". |
 | `package.json` | "trust" / "registry" in description. | P1 | Update. |
 
-### 3.10 lab (private)
+### 3.10 the E2E test lab (private)
 
 The lab is the experimental / pressure-test infrastructure. It is
 allowed to use "evidence" framing because that's what a test lab does,
@@ -272,7 +272,7 @@ The PR-100 (fixture / conformance recovery) work will cover them.
 | aikdna/kdna-vscode | 1 | 1 | 0 | 0 | 2 | PR-98d |
 | aikdna/kdna-skills | 0 | 1 | 1 | 0 | 2 | PR-98d |
 | aikdna/kdna-workpack | 0 | 2 | 1 | 0 | 3 | PR-98d |
-| lab (private) | 0 | 1 | 1 | 0 | 2 | PR-98c |
+| the E2E test lab (private) | 0 | 1 | 1 | 0 | 2 | PR-98c |
 | aikdna/kdna-core-swift | 0 | 0 | 1 | 0 | 1 | PR-98d |
 | aikdna/kdna-studio-swift | 0 | 0 | 0 | 1 | 1 | after kdna-core-swift fix |
 | Domain repos (~12) | 0 | 0 | 12 | 3 | 15 | PR-100 |
@@ -286,7 +286,7 @@ follow-up PRs by repo group, **not** into a single big PR.
 
 | PR | Scope | Repos | Estimated effort |
 |---|---|---|---|
-| PR-98c | website + registry + main-repo deep docs | `kdna-website`, `kdna-registry`, `kdna` (deep docs), `lab (private)`, `kdna` (CHANGELOG / RELEASE_CHECKLIST / rfcs/ marked historical) | Large. Mark `kdna-registry` repo as legacy / archived. Re-author website content. |
+| PR-98c | website + registry + main-repo deep docs | `kdna-website`, `kdna-registry`, `kdna` (deep docs), `the E2E test lab (private)`, `kdna` (CHANGELOG / RELEASE_CHECKLIST / rfcs/ marked historical) | Large. Mark `kdna-registry` repo as legacy / archived. Re-author website content. |
 | PR-98d | CLI / Core / Studio / VSCode / Skills / Workpack | `kdna-cli`, `kdna-studio-core`, `kdna-studio-cli`, `kdna-vscode`, `kdna-skills`, `kdna-workpack`, `kdna-core-swift` | Large. Re-author READMEs. Audit code surfaces. |
 | PR-98e | domain repos + remaining ecosystem repos | `kdna-writing`, `kdna-agent_safety`, `kdna-prompt_diagnosis`, `kdna-content_strategy`, `kdna-decision_state`, `kdna-knowledge_management`, `kdna-open_source_project`, `kdna-requirement_alignment`, `kdna-animations`, `kdna-authoring`, `kdna-code_review`, `kdna-app-shared`, `kdna-for-agent-skills`, `kdna-releases` | Medium. Mostly archival / light rewording. Heavy data-shape changes belong in PR-100, not here. |
 

--- a/docs/audits/phase-2-rfc-0014-0015-filing.md
+++ b/docs/audits/phase-2-rfc-0014-0015-filing.md
@@ -38,9 +38,9 @@ PR-1 through PR-4b are now merged:
 - **PR-2a** (aikdna/kdna #87) — SPEC §1.6.3 Anti-Monolithic
   principle
 - **PR-3** (aikdna/kdna-studio-core #3) — SAG/TC compile gates
-- **PR-4** (lab PR) — lifecycle smoke on a simple
+- **PR-4** (the E2E test the E2E test the E2E test the E2E test lab (private) PR) — lifecycle smoke on a simple
   official legacy domain
-- **PR-4b** (lab PR) — default SAG/TC synthesis
+- **PR-4b** (the E2E test the E2E test the E2E test the E2E test lab (private) PR) — default SAG/TC synthesis
   migration smoke
 
 PR-4 and PR-4b together produced the implementation feedback
@@ -62,7 +62,7 @@ that RFC-0014 and RFC-0015 build on:
 | #1 | All three new schema files merged in `aikdna/kdna/schema/` | ✅ | PR-1 (#86) |
 | #2 | `kdna dev validate --anti-monolithic` exists | ✅ | PR-2 (#10) |
 | #3 | kdna-studio-core rejects (with clear error) on `strict-authority` violations | ✅ | PR-3 (#3) |
-| #4 | lab smoke (private) test on a simple official legacy domain | ✅ | PR-4 (#3) |
+| #4 | the E2E test lab (private) smoke test on a simple official legacy domain | ✅ | PR-4 (#3) |
 | #5 | SPEC §1.6 contains the Anti-Monolithic Domain Principle verbatim | ✅ | PR-2a (#87) |
 | #6 | RFC-0014 and RFC-0015 are filed as separate Draft RFCs | ✅ | **this PR** |
 | #7 | Migration run synthesizes default SAG/TC and produces valid `.kdna` | ✅ | PR-4b (#4) |
@@ -78,11 +78,11 @@ Per the RFC-0013 Phase 2 scope, this PR only files drafts:
   proposal; the kdna-studio-core release that emits the v2 fields
   is a follow-up.
 - ❌ **No implementation of Trace v2.** RFC-0015 is a detail-schema
-  proposal; the kdna-studio-core and lab (private) releases that emit
+  proposal; the kdna-studio-core and the E2E test lab (private) releases that emit
   and consume the v2 lifecycle events are follow-ups.
 - ❌ **No runtime payload changes.**
 - ❌ **No schema changes** (the existing PR-1 schemas are unchanged).
-- ❌ **No changes to kdna-cli / kdna-studio-core / lab (private).**
+- ❌ **No changes to kdna-cli / kdna-studio-core / the E2E test lab (private).**
 - ❌ **No atomspeak / book-derived domain smoke** (deferred to PR-5).
 - ❌ **No fix of kdna-studio-core's 11 pre-existing test failures**
   (out of scope for the RFC-0013 series; see PR-3 audit note).
@@ -107,8 +107,8 @@ Per the RFC-0013 Phase 2 scope, this PR only files drafts:
 | #10 | aikdna/kdna-cli | `see PR-2 acceptance` | PR-2: Anti-Monolithic CLI lint. PR-2 debt (question-count heuristic) is referenced in RFC-0014 §6. |
 | #87 | aikdna/kdna | `see PR-2a acceptance` | PR-2a: SPEC §1.6.3 Anti-Monolithic principle. RFC-0014 §6 references the principle. |
 | #3 | aikdna/kdna-studio-core | `see PR-3 acceptance` | PR-3: SAG/TC compile gates. RFC-0014 / RFC-0015 §2 boundary is derived from the PR-3 compile-time separation. |
-| #3 | lab (private) | `see PR-4 acceptance` | PR-4: lifecycle smoke. RFC-0015 §1 motivation is derived from the 11 PR-4 events. |
-| #4 | lab (private) | `see PR-4b acceptance` | PR-4b: default synthesis migration. RFC-0014 §6 + RFC-0015 §3.2 migration fields are derived from PR-4b's outputs. |
+| #3 | the E2E test lab (private) | `see PR-4 acceptance` | PR-4: lifecycle smoke. RFC-0015 §1 motivation is derived from the 11 PR-4 events. |
+| #4 | the E2E test lab (private) | `see PR-4b acceptance` | PR-4b: default synthesis migration. RFC-0014 §6 + RFC-0015 §3.2 migration fields are derived from PR-4b's outputs. |
 
 ## On the public RFC-0013 status
 
@@ -154,7 +154,7 @@ None of these are in this PR.
 - RFC-0013 §9: acceptance criteria, now all covered after this PR
 - PR-1 to PR-4b: implementation evidence (see §"Dependency evidence")
 - RFC-0013 implementation scope: Phase 2 RFC-0014 / RFC-0015 filing
-- lab (private) PR-4 audit note: `docs/audits/pr-4-acceptance.md`
-- lab (private) PR-4b audit note: `docs/audits/pr-4b-acceptance.md`
+- the E2E test lab (private) PR-4 audit note: `docs/audits/pr-4-acceptance.md`
+- the E2E test lab (private) PR-4b audit note: `docs/audits/pr-4b-acceptance.md`
 - aikdna/kdna-studio-core PR-3 audit note: `docs/audits/pr-3-acceptance.md` (PR-2 debt)
 - aikdna/kdna PR-2a audit note: `docs/audits/pr-2-acceptance.md`

--- a/docs/audits/phase-2-rfc-0014-0015-filing.md
+++ b/docs/audits/phase-2-rfc-0014-0015-filing.md
@@ -38,9 +38,9 @@ PR-1 through PR-4b are now merged:
 - **PR-2a** (aikdna/kdna #87) — SPEC §1.6.3 Anti-Monolithic
   principle
 - **PR-3** (aikdna/kdna-studio-core #3) — SAG/TC compile gates
-- **PR-4** (aikdna/kdna-lab #3) — lifecycle smoke on a simple
+- **PR-4** (lab PR) — lifecycle smoke on a simple
   official legacy domain
-- **PR-4b** (aikdna/kdna-lab #4) — default SAG/TC synthesis
+- **PR-4b** (lab PR) — default SAG/TC synthesis
   migration smoke
 
 PR-4 and PR-4b together produced the implementation feedback
@@ -62,7 +62,7 @@ that RFC-0014 and RFC-0015 build on:
 | #1 | All three new schema files merged in `aikdna/kdna/schema/` | ✅ | PR-1 (#86) |
 | #2 | `kdna dev validate --anti-monolithic` exists | ✅ | PR-2 (#10) |
 | #3 | kdna-studio-core rejects (with clear error) on `strict-authority` violations | ✅ | PR-3 (#3) |
-| #4 | kdna-lab smoke test on a simple official legacy domain | ✅ | PR-4 (#3) |
+| #4 | lab smoke (private) test on a simple official legacy domain | ✅ | PR-4 (#3) |
 | #5 | SPEC §1.6 contains the Anti-Monolithic Domain Principle verbatim | ✅ | PR-2a (#87) |
 | #6 | RFC-0014 and RFC-0015 are filed as separate Draft RFCs | ✅ | **this PR** |
 | #7 | Migration run synthesizes default SAG/TC and produces valid `.kdna` | ✅ | PR-4b (#4) |
@@ -78,11 +78,11 @@ Per the RFC-0013 Phase 2 scope, this PR only files drafts:
   proposal; the kdna-studio-core release that emits the v2 fields
   is a follow-up.
 - ❌ **No implementation of Trace v2.** RFC-0015 is a detail-schema
-  proposal; the kdna-studio-core and kdna-lab releases that emit
+  proposal; the kdna-studio-core and lab (private) releases that emit
   and consume the v2 lifecycle events are follow-ups.
 - ❌ **No runtime payload changes.**
 - ❌ **No schema changes** (the existing PR-1 schemas are unchanged).
-- ❌ **No changes to kdna-cli / kdna-studio-core / kdna-lab.**
+- ❌ **No changes to kdna-cli / kdna-studio-core / lab (private).**
 - ❌ **No atomspeak / book-derived domain smoke** (deferred to PR-5).
 - ❌ **No fix of kdna-studio-core's 11 pre-existing test failures**
   (out of scope for the RFC-0013 series; see PR-3 audit note).
@@ -103,12 +103,12 @@ Per the RFC-0013 Phase 2 scope, this PR only files drafts:
 
 | PR | Repo | Commit | Role |
 |----|------|--------|------|
-| #86 | aikdna/kdna | `c00601c` | PR-1: SAG / TC / IMM schemas. RFC-0014 / RFC-0015 reference these schemas in their field shapes. |
-| #10 | aikdna/kdna-cli | `bb64821` | PR-2: Anti-Monolithic CLI lint. PR-2 debt (question-count heuristic) is referenced in RFC-0014 §6. |
-| #87 | aikdna/kdna | `f328ca0` | PR-2a: SPEC §1.6.3 Anti-Monolithic principle. RFC-0014 §6 references the principle. |
-| #3 | aikdna/kdna-studio-core | `e2dddf4` | PR-3: SAG/TC compile gates. RFC-0014 / RFC-0015 §2 boundary is derived from the PR-3 compile-time separation. |
-| #3 | aikdna/kdna-lab | `d8c466c` | PR-4: lifecycle smoke. RFC-0015 §1 motivation is derived from the 11 PR-4 events. |
-| #4 | aikdna/kdna-lab | `3849ae1` | PR-4b: default synthesis migration. RFC-0014 §6 + RFC-0015 §3.2 migration fields are derived from PR-4b's outputs. |
+| #86 | aikdna/kdna | `see PR-1 acceptance` | PR-1: SAG / TC / IMM schemas. RFC-0014 / RFC-0015 reference these schemas in their field shapes. |
+| #10 | aikdna/kdna-cli | `see PR-2 acceptance` | PR-2: Anti-Monolithic CLI lint. PR-2 debt (question-count heuristic) is referenced in RFC-0014 §6. |
+| #87 | aikdna/kdna | `see PR-2a acceptance` | PR-2a: SPEC §1.6.3 Anti-Monolithic principle. RFC-0014 §6 references the principle. |
+| #3 | aikdna/kdna-studio-core | `see PR-3 acceptance` | PR-3: SAG/TC compile gates. RFC-0014 / RFC-0015 §2 boundary is derived from the PR-3 compile-time separation. |
+| #3 | lab (private) | `see PR-4 acceptance` | PR-4: lifecycle smoke. RFC-0015 §1 motivation is derived from the 11 PR-4 events. |
+| #4 | lab (private) | `see PR-4b acceptance` | PR-4b: default synthesis migration. RFC-0014 §6 + RFC-0015 §3.2 migration fields are derived from PR-4b's outputs. |
 
 ## On the public RFC-0013 status
 
@@ -154,7 +154,7 @@ None of these are in this PR.
 - RFC-0013 §9: acceptance criteria, now all covered after this PR
 - PR-1 to PR-4b: implementation evidence (see §"Dependency evidence")
 - RFC-0013 implementation scope: Phase 2 RFC-0014 / RFC-0015 filing
-- aikdna/kdna-lab PR-4 audit note: `docs/audits/pr-4-acceptance.md`
-- aikdna/kdna-lab PR-4b audit note: `docs/audits/pr-4b-acceptance.md`
+- lab (private) PR-4 audit note: `docs/audits/pr-4-acceptance.md`
+- lab (private) PR-4b audit note: `docs/audits/pr-4b-acceptance.md`
 - aikdna/kdna-studio-core PR-3 audit note: `docs/audits/pr-3-acceptance.md` (PR-2 debt)
 - aikdna/kdna PR-2a audit note: `docs/audits/pr-2-acceptance.md`

--- a/docs/audits/pr-2-acceptance.md
+++ b/docs/audits/pr-2-acceptance.md
@@ -30,7 +30,7 @@ Not covered (still pending):
 | §9 # | Item | Owner |
 |------|------|-------|
 | #3 | kdna-studio-core gates | PR-3 |
-| #4 | kdna-lab smoke on simple official domain | PR-4 |
+| #4 | lab smoke (private) on simple official domain | PR-4 |
 | #6 | RFC-0014 / RFC-0015 filed | Phase 2 (deferred per the RFC-0013 implementation scope) |
 | #7 | real legacy domain migration | PR-4 |
 

--- a/docs/audits/pr-2-acceptance.md
+++ b/docs/audits/pr-2-acceptance.md
@@ -30,7 +30,7 @@ Not covered (still pending):
 | §9 # | Item | Owner |
 |------|------|-------|
 | #3 | kdna-studio-core gates | PR-3 |
-| #4 | lab smoke (private) on simple official domain | PR-4 |
+| #4 | the E2E test lab (private) smoke on simple official domain | PR-4 |
 | #6 | RFC-0014 / RFC-0015 filed | Phase 2 (deferred per the RFC-0013 implementation scope) |
 | #7 | real legacy domain migration | PR-4 |
 

--- a/docs/audits/public-e2e-2026-06-23.md
+++ b/docs/audits/public-e2e-2026-06-23.md
@@ -2,7 +2,7 @@
 
 > **Purpose**: Verify that the KDNA Core toolchain can be installed and run end-to-end
 > on a clean environment, covering the full path: demo → pack → validate → plan-load → load,
-> plus validation of all published kdna-x assets.
+> plus validation of all published official assets.
 
 ## Environment
 
@@ -48,7 +48,7 @@ kdna load /tmp/minimal.kdna --profile=compact --as=prompt
 **Result: PASS** — Rendered compact prompt with axioms, self-checks, failure modes.
 Output includes safety boundary, token hint, and structured judgment content.
 
-## Test 2: kdna-x Published Assets
+## Test 2: Official Published Assets
 
 | Asset | validate | plan-load | can_load | Issues |
 |-------|----------|-----------|----------|--------|
@@ -78,5 +78,5 @@ None. All commands succeed with clean output.
 **E2E Gate: PASSED**
 
 The KDNA Core toolchain is functional end-to-end. The demo→pack→validate→plan-load→load chain
-completes without errors. All 3 published kdna-x assets validate and load correctly.
+completes without errors. All 3 published official assets validate and load correctly.
 The toolchain is ready for asset production.

--- a/docs/audits/rfc-0013-implementation-evidence-pack.md
+++ b/docs/audits/rfc-0013-implementation-evidence-pack.md
@@ -58,13 +58,13 @@ in `docs/rfc-status.md` until external review ratifies it.
 
 | # | Item | Status | PR | Repo | Commit |
 |---|------|--------|------|------|--------|
-| #1 | All three new schema files merged in `aikdna/kdna/schema/` | ✅ | [#86](https://github.com/aikdna/kdna/pull/86) | aikdna/kdna | [`see PR-1 acceptance`](https://github.com/aikdna/kdna/commit/see PR-1 acceptance) |
-| #2 | `kdna dev validate --anti-monolithic` exists and runs | ✅ | [#10](https://github.com/aikdna/kdna-cli/pull/10) | aikdna/kdna-cli | [`see PR-2 acceptance`](https://github.com/aikdna/kdna-cli/commit/see PR-2 acceptance) |
-| #3 | kdna-studio-core rejects (with clear error) on `strict-authority` violations | ✅ | [#3](https://github.com/aikdna/kdna-studio-core/pull/3) | aikdna/kdna-studio-core | [`see PR-3 acceptance`](https://github.com/aikdna/kdna-studio-core/commit/see PR-3 acceptance) |
-| #4 | lab smoke (private) test on a simple official legacy domain, runs trace events, verifies `sag_version` and `tc_status` in trace output | ✅ | [#3](https://github.com/lab PR) | lab (private) | [`see PR-4 acceptance`](https://github.com/lab (private)) |
-| #5 | `SPEC.md` §1.6 contains the Anti-Monolithic Domain Principle verbatim | ✅ | [#87](https://github.com/aikdna/kdna/pull/87) | aikdna/kdna | [`see PR-2a acceptance`](https://github.com/aikdna/kdna/commit/see PR-2a acceptance) |
-| #6 | RFC-0014 and RFC-0015 are filed as separate Draft RFCs | ✅ | [#88](https://github.com/aikdna/kdna/pull/88) | aikdna/kdna | [`see Phase 2 filing`](https://github.com/aikdna/kdna/commit/see Phase 2 filing) |
-| #7 | Migration run synthesizes default SAG/TC and produces valid `.kdna` identical in shape to the pre-RFC build | ✅ | [#4](https://github.com/lab PR) | lab (private) | [`see PR-4b acceptance`](https://github.com/lab (private)) |
+| #1 | All three new schema files merged in `aikdna/kdna/schema/` | ✅ | [#86](https://github.com/aikdna/kdna/pull/86) | aikdna/kdna | `see PR-1 acceptance` |
+| #2 | `kdna dev validate --anti-monolithic` exists and runs | ✅ | [#10](https://github.com/aikdna/kdna-cli/pull/10) | aikdna/kdna-cli | `see PR-2 acceptance` |
+| #3 | kdna-studio-core rejects (with clear error) on `strict-authority` violations | ✅ | [#3](https://github.com/aikdna/kdna-studio-core/pull/3) | aikdna/kdna-studio-core | `see PR-3 acceptance` |
+| #4 | the E2E test lab (private) smoke test on a simple official legacy domain, runs trace events, verifies `sag_version` and `tc_status` in trace output | ✅ | (private PR #3) | the E2E test lab (private) | `see PR-4 acceptance` |
+| #5 | `SPEC.md` §1.6 contains the Anti-Monolithic Domain Principle verbatim | ✅ | [#87](https://github.com/aikdna/kdna/pull/87) | aikdna/kdna | `see PR-2a acceptance` |
+| #6 | RFC-0014 and RFC-0015 are filed as separate Draft RFCs | ✅ | [#88](https://github.com/aikdna/kdna/pull/88) | aikdna/kdna | `see Phase 2 filing` |
+| #7 | Migration run synthesizes default SAG/TC and produces valid `.kdna` identical in shape to the pre-RFC build | ✅ | (private PR #4) | the E2E test lab (private) | `see PR-4b acceptance` |
 
 **Coverage:** 7/7 acceptance criteria are now technically covered.
 
@@ -77,7 +77,7 @@ in `docs/rfc-status.md` until external review ratifies it.
 PR-1 (`see PR-1 acceptance`) added the three authoring-time object schemas
 under `aikdna/kdna/schema/`. PR-1 was not used in isolation:
 
-- The fixtures in `lab (private)/examples/sag-tc-roundtrip/code_review/`
+- The fixtures in `the E2E test lab (private)/examples/sag-tc-roundtrip/code_review/`
   satisfy all three schemas.
 - The PR-4b migration helper in `kdna_lab/rfc0013_migration.py`
   emits objects that pass `jsonschema` validation against the
@@ -161,7 +161,7 @@ governed the domain at that point in the lifecycle.
 
 The four `aikdna/kdna` PRs (#86 PR-1, #87 PR-2a, #88 Phase 2,
 #89 evidence pack + tiny RFC-0014 path fix) plus the three PRs in
-`kdna-cli` (#10), `kdna-studio-core` (#3), and `lab (private)` (#3 + #4)
+`kdna-cli` (#10), `kdna-studio-core` (#3), and `the E2E test lab (private)` (#3 + #4)
 together form a coherent chain:
 
 - PR-1 schemas → PR-3 gates (read them) → PR-4 explicit smoke
@@ -182,10 +182,10 @@ ending, but they are real limits on what the series claims.
 | No `atomspeak` / book-derived domain smoke yet | The first smoke is on a simple official domain; atomspeak needs PR-3 gates stable + book-derived inputs (multiple TC versions, charter drift). Deferred to PR-5 per the RFC-0013 PR-4 boundary. | RFC-0013 §9 #4 (amended), PR-4 audit note, PR-4b audit note |
 | No Anti-Monolithic question-count heuristic yet | The CLI in PR-2 implements structural thresholds (axiom count + framework count + module_manifest sign-off). The third SPEC condition ("spans more than 2 distinct user-facing judgment questions") requires a separate RFC (suggested: RFC-0022). | PR-2 audit note, PR-3 audit note (`gates.md`), PR-3 §"PR-2 semantic debt" |
 | No Card v2 implementation yet | RFC-0014 is filed as Draft; kdna-studio-core has not yet been updated to emit the v2 Card fields. | RFC-0014 §8 (Acceptance Criteria) |
-| No Trace v2 implementation yet | RFC-0015 is filed as Draft; kdna-studio-core and lab (private) have not yet been updated to emit the v2 lifecycle trace. | RFC-0015 §8 (Acceptance Criteria) |
+| No Trace v2 implementation yet | RFC-0015 is filed as Draft; kdna-studio-core and the E2E test lab (private) have not yet been updated to emit the v2 lifecycle trace. | RFC-0015 §8 (Acceptance Criteria) |
 | No marketplace / enterprise / privacy / WorkPack implementation | All four are RFC-0013 §10 Non-Goals. WorkPack lives in `kdna-workpack`; marketplace / enterprise / privacy are explicit `out_of_scope` per RFC-0013 §10. | RFC-0013 §10 |
 | No independent review submissions on any of the 7 PRs | All 7 PRs were admin-merged by a single maintainer. Review submissions are empty. This is consistent with the public-facing status policy (complex book-derived domain testing is deferred to a follow-up PR) and the recommended external wording, but it is a real limit. | This audit pack §5 |
-| No remote CI workflow runs on most repos | `aikdna/kdna-cli` and `lab (private)` have no CI workflow configured for the relevant branches. `aikdna/kdna-studio-core` and `aikdna/kdna` have workflows but they did not run on the implementation PRs as expected. The validation signal is **local-only** (pytest, node --test, ajv schema validation). | This audit pack §5 |
+| No remote CI workflow runs on most repos | `aikdna/kdna-cli` and `the E2E test lab (private)` have no CI workflow configured for the relevant branches. `aikdna/kdna-studio-core` and `aikdna/kdna` have workflows but they did not run on the implementation PRs as expected. The validation signal is **local-only** (pytest, node --test, ajv schema validation). | This audit pack §5 |
 | `kdna-studio-core` 11 pre-existing test failures remain out of scope | The 11 failures in `core.test.js`, `e2e.test.js`, `milestone3.test.js` are about `KDNA_Core.json` vs `payload.kdnab` test expectations and predate PR-3. Fixing them is a separate test-suite migration PR. | PR-3 audit note, PR-4b audit note |
 
 A reviewer can decide whether any of these gaps should block
@@ -244,7 +244,7 @@ before any further status promotion.
 | aikdna/kdna | Yes, but did not run on PR-1 / PR-2a / Phase 2 PRs as expected. Local `grep` checks are the only signal. |
 | aikdna/kdna-cli | No CI workflow configured for the relevant branch. Local `node --test` is the only signal. |
 | aikdna/kdna-studio-core | Workflow exists; the PR-3 commit was admin-merged. The 11 pre-existing test failures in this repo are out of scope (see §4). |
-| lab (private) | No CI workflow configured for the relevant branch. Local `pytest` + Node smoke is the only signal. |
+| the E2E test lab (private) | No CI workflow configured for the relevant branch. Local `pytest` + Node smoke is the only signal. |
 
 The PR descriptions explicitly state
 `no workflow runs; local validation only` where applicable. The
@@ -293,7 +293,7 @@ are real follow-up work.
    emits Card v2 fields. RFC-0014 is filed as Draft; acceptance
    criteria for the implementation RFC are in RFC-0014 §8.
 
-6. **RFC-0015 implementation** — kdna-studio-core and lab (private)
+6. **RFC-0015 implementation** — kdna-studio-core and the E2E test lab (private)
    releases that emit and consume the v2 lifecycle trace. RFC-0015
    is filed as Draft; acceptance criteria are in RFC-0015 §8.
 
@@ -361,13 +361,13 @@ Specifically:
 
 | PR | Repo | Commit | Audit note |
 |----|------|--------|-------------|
-| [#86](https://github.com/aikdna/kdna/pull/86) | aikdna/kdna | [`see PR-1 acceptance`](https://github.com/aikdna/kdna/commit/see PR-1 acceptance) | — |
-| [#10](https://github.com/aikdna/kdna-cli/pull/10) | aikdna/kdna-cli | [`see PR-2 acceptance`](https://github.com/aikdna/kdna-cli/commit/see PR-2 acceptance) | (in PR body) |
-| [#87](https://github.com/aikdna/kdna/pull/87) | aikdna/kdna | [`see PR-2a acceptance`](https://github.com/aikdna/kdna/commit/see PR-2a acceptance) | [`docs/audits/pr-2-acceptance.md`](https://github.com/aikdna/kdna/blob/main/docs/audits/pr-2-acceptance.md) |
-| [#3](https://github.com/aikdna/kdna-studio-core/pull/3) | aikdna/kdna-studio-core | [`see PR-3 acceptance`](https://github.com/aikdna/kdna-studio-core/commit/see PR-3 acceptance) | [`docs/audits/pr-3-acceptance.md`](https://github.com/aikdna/kdna-studio-core/blob/main/docs/audits/pr-3-acceptance.md) |
-| [#3](https://github.com/lab PR) | lab (private) | [`see PR-4 acceptance`](https://github.com/lab (private)) | [`docs/audits/pr-4-acceptance.md`](https://github.com/lab acceptance note (private)) |
-| [#4](https://github.com/lab PR) | lab (private) | [`see PR-4b acceptance`](https://github.com/lab (private)) | [`docs/audits/pr-4b-acceptance.md`](https://github.com/lab acceptance note (private)) |
-| [#88](https://github.com/aikdna/kdna/pull/88) | aikdna/kdna | [`see Phase 2 filing`](https://github.com/aikdna/kdna/commit/see Phase 2 filing) | [`docs/audits/phase-2-rfc-0014-0015-filing.md`](https://github.com/aikdna/kdna/blob/main/docs/audits/phase-2-rfc-0014-0015-filing.md) |
+| [#86](https://github.com/aikdna/kdna/pull/86) | aikdna/kdna | `see PR-1 acceptance` | — |
+| [#10](https://github.com/aikdna/kdna-cli/pull/10) | aikdna/kdna-cli | `see PR-2 acceptance` | (in PR body) |
+| [#87](https://github.com/aikdna/kdna/pull/87) | aikdna/kdna | `see PR-2a acceptance` | [`docs/audits/pr-2-acceptance.md`](https://github.com/aikdna/kdna/blob/main/docs/audits/pr-2-acceptance.md) |
+| [#3](https://github.com/aikdna/kdna-studio-core/pull/3) | aikdna/kdna-studio-core | `see PR-3 acceptance` | [`docs/audits/pr-3-acceptance.md`](https://github.com/aikdna/kdna-studio-core/blob/main/docs/audits/pr-3-acceptance.md) |
+| (private PR #3) | the E2E test lab (private) | `see PR-4 acceptance` | `docs/audits/pr-4-acceptance.md` |
+| (private PR #4) | the E2E test lab (private) | `see PR-4b acceptance` | `docs/audits/pr-4b-acceptance.md` |
+| [#88](https://github.com/aikdna/kdna/pull/88) | aikdna/kdna | `see Phase 2 filing` | [`docs/audits/phase-2-rfc-0014-0015-filing.md`](https://github.com/aikdna/kdna/blob/main/docs/audits/phase-2-rfc-0014-0015-filing.md) |
 
 ### RFCs
 

--- a/docs/audits/rfc-0013-implementation-evidence-pack.md
+++ b/docs/audits/rfc-0013-implementation-evidence-pack.md
@@ -58,13 +58,13 @@ in `docs/rfc-status.md` until external review ratifies it.
 
 | # | Item | Status | PR | Repo | Commit |
 |---|------|--------|------|------|--------|
-| #1 | All three new schema files merged in `aikdna/kdna/schema/` | ✅ | [#86](https://github.com/aikdna/kdna/pull/86) | aikdna/kdna | [`c00601c`](https://github.com/aikdna/kdna/commit/c00601c) |
-| #2 | `kdna dev validate --anti-monolithic` exists and runs | ✅ | [#10](https://github.com/aikdna/kdna-cli/pull/10) | aikdna/kdna-cli | [`bb64821`](https://github.com/aikdna/kdna-cli/commit/bb64821) |
-| #3 | kdna-studio-core rejects (with clear error) on `strict-authority` violations | ✅ | [#3](https://github.com/aikdna/kdna-studio-core/pull/3) | aikdna/kdna-studio-core | [`e2dddf4`](https://github.com/aikdna/kdna-studio-core/commit/e2dddf4) |
-| #4 | kdna-lab smoke test on a simple official legacy domain, runs trace events, verifies `sag_version` and `tc_status` in trace output | ✅ | [#3](https://github.com/aikdna/kdna-lab/pull/3) | aikdna/kdna-lab | [`d8c466c`](https://github.com/aikdna/kdna-lab/commit/d8c466c) |
-| #5 | `SPEC.md` §1.6 contains the Anti-Monolithic Domain Principle verbatim | ✅ | [#87](https://github.com/aikdna/kdna/pull/87) | aikdna/kdna | [`f328ca0`](https://github.com/aikdna/kdna/commit/f328ca0) |
-| #6 | RFC-0014 and RFC-0015 are filed as separate Draft RFCs | ✅ | [#88](https://github.com/aikdna/kdna/pull/88) | aikdna/kdna | [`c2103aa`](https://github.com/aikdna/kdna/commit/c2103aa) |
-| #7 | Migration run synthesizes default SAG/TC and produces valid `.kdna` identical in shape to the pre-RFC build | ✅ | [#4](https://github.com/aikdna/kdna-lab/pull/4) | aikdna/kdna-lab | [`3849ae1`](https://github.com/aikdna/kdna-lab/commit/3849ae1) |
+| #1 | All three new schema files merged in `aikdna/kdna/schema/` | ✅ | [#86](https://github.com/aikdna/kdna/pull/86) | aikdna/kdna | [`see PR-1 acceptance`](https://github.com/aikdna/kdna/commit/see PR-1 acceptance) |
+| #2 | `kdna dev validate --anti-monolithic` exists and runs | ✅ | [#10](https://github.com/aikdna/kdna-cli/pull/10) | aikdna/kdna-cli | [`see PR-2 acceptance`](https://github.com/aikdna/kdna-cli/commit/see PR-2 acceptance) |
+| #3 | kdna-studio-core rejects (with clear error) on `strict-authority` violations | ✅ | [#3](https://github.com/aikdna/kdna-studio-core/pull/3) | aikdna/kdna-studio-core | [`see PR-3 acceptance`](https://github.com/aikdna/kdna-studio-core/commit/see PR-3 acceptance) |
+| #4 | lab smoke (private) test on a simple official legacy domain, runs trace events, verifies `sag_version` and `tc_status` in trace output | ✅ | [#3](https://github.com/lab PR) | lab (private) | [`see PR-4 acceptance`](https://github.com/lab (private)) |
+| #5 | `SPEC.md` §1.6 contains the Anti-Monolithic Domain Principle verbatim | ✅ | [#87](https://github.com/aikdna/kdna/pull/87) | aikdna/kdna | [`see PR-2a acceptance`](https://github.com/aikdna/kdna/commit/see PR-2a acceptance) |
+| #6 | RFC-0014 and RFC-0015 are filed as separate Draft RFCs | ✅ | [#88](https://github.com/aikdna/kdna/pull/88) | aikdna/kdna | [`see Phase 2 filing`](https://github.com/aikdna/kdna/commit/see Phase 2 filing) |
+| #7 | Migration run synthesizes default SAG/TC and produces valid `.kdna` identical in shape to the pre-RFC build | ✅ | [#4](https://github.com/lab PR) | lab (private) | [`see PR-4b acceptance`](https://github.com/lab (private)) |
 
 **Coverage:** 7/7 acceptance criteria are now technically covered.
 
@@ -74,10 +74,10 @@ in `docs/rfc-status.md` until external review ratifies it.
 
 ### 3.1 The PR-1 schemas are usable, not isolated
 
-PR-1 (`c00601c`) added the three authoring-time object schemas
+PR-1 (`see PR-1 acceptance`) added the three authoring-time object schemas
 under `aikdna/kdna/schema/`. PR-1 was not used in isolation:
 
-- The fixtures in `aikdna/kdna-lab/examples/sag-tc-roundtrip/code_review/`
+- The fixtures in `lab (private)/examples/sag-tc-roundtrip/code_review/`
   satisfy all three schemas.
 - The PR-4b migration helper in `kdna_lab/rfc0013_migration.py`
   emits objects that pass `jsonschema` validation against the
@@ -88,9 +88,9 @@ the PR-1 schemas are used in two smoke pipelines.
 
 ### 3.2 The PR-3 gates are actually called by `compileDomain`
 
-PR-3 (`e2dddf4`) added the SAG/TC compile gates in
+PR-3 (`see PR-3 acceptance`) added the SAG/TC compile gates in
 `kdna-studio-core/src/compile/`. PR-3 is invoked by `compileDomain`,
-not by a separate function. PR-4 (`d8c466c`) and PR-4b (`3849ae1`)
+not by a separate function. PR-4 (`see PR-4 acceptance`) and PR-4b (`see PR-4b acceptance`)
 both call the real `compileDomain` with `strictAuthority: true`,
 which executes the PR-3 gates. Under strict-authority, both PR-4
 and PR-4b report `sag.status: 'pass'` and `tc.status: 'pass'`.
@@ -100,7 +100,7 @@ documents 13/13 unit tests passing for the gate contract.
 
 ### 3.3 PR-4 uses real kdna-studio-core `compileDomain` with explicit SAG/TC
 
-PR-4 (`d8c466c`) hand-wrote SAG, TC, and IMM in the code_review
+PR-4 (`see PR-4 acceptance`) hand-wrote SAG, TC, and IMM in the code_review
 fixture and called kdna-studio-core `compileDomain` with
 `strictAuthority: true`. The result was a v2 container with
 canonical shape: `payload.kdnab`, `kdna.json`, `KDNA_CARD.json`,
@@ -113,7 +113,7 @@ demonstration of the lifecycle.
 
 ### 3.4 PR-4b proves legacy-only Core/Patterns can synthesize default SAG/TC/IMM
 
-PR-4b (`3849ae1`) implements the *missing half* of RFC-0013 §9 #7
+PR-4b (`see PR-4b acceptance`) implements the *missing half* of RFC-0013 §9 #7
 that PR-4 left open. The new helper
 (`kdna_lab/rfc0013_migration.py`) reads **only** `KDNA_Core.json`
 and `KDNA_Patterns.json` and emits synthesized `source_authority.json`,
@@ -130,7 +130,7 @@ set is **identical** to the PR-4 explicit-fixture container
 (set equality of compiled file names; byte-equal content is **not**
 asserted). This is verified by
 `test_B4_load_contract_matches_pr4` in
-`kdna-lab/tests/test_rfc0013_migration_synthesis.py`.
+`lab tests (private)/test_rfc0013_migration_synthesis.py`.
 
 ### 3.5 Runtime payload does not leak full SAG/TC/IMM
 
@@ -161,7 +161,7 @@ governed the domain at that point in the lifecycle.
 
 The four `aikdna/kdna` PRs (#86 PR-1, #87 PR-2a, #88 Phase 2,
 #89 evidence pack + tiny RFC-0014 path fix) plus the three PRs in
-`kdna-cli` (#10), `kdna-studio-core` (#3), and `kdna-lab` (#3 + #4)
+`kdna-cli` (#10), `kdna-studio-core` (#3), and `lab (private)` (#3 + #4)
 together form a coherent chain:
 
 - PR-1 schemas → PR-3 gates (read them) → PR-4 explicit smoke
@@ -182,10 +182,10 @@ ending, but they are real limits on what the series claims.
 | No `atomspeak` / book-derived domain smoke yet | The first smoke is on a simple official domain; atomspeak needs PR-3 gates stable + book-derived inputs (multiple TC versions, charter drift). Deferred to PR-5 per the RFC-0013 PR-4 boundary. | RFC-0013 §9 #4 (amended), PR-4 audit note, PR-4b audit note |
 | No Anti-Monolithic question-count heuristic yet | The CLI in PR-2 implements structural thresholds (axiom count + framework count + module_manifest sign-off). The third SPEC condition ("spans more than 2 distinct user-facing judgment questions") requires a separate RFC (suggested: RFC-0022). | PR-2 audit note, PR-3 audit note (`gates.md`), PR-3 §"PR-2 semantic debt" |
 | No Card v2 implementation yet | RFC-0014 is filed as Draft; kdna-studio-core has not yet been updated to emit the v2 Card fields. | RFC-0014 §8 (Acceptance Criteria) |
-| No Trace v2 implementation yet | RFC-0015 is filed as Draft; kdna-studio-core and kdna-lab have not yet been updated to emit the v2 lifecycle trace. | RFC-0015 §8 (Acceptance Criteria) |
+| No Trace v2 implementation yet | RFC-0015 is filed as Draft; kdna-studio-core and lab (private) have not yet been updated to emit the v2 lifecycle trace. | RFC-0015 §8 (Acceptance Criteria) |
 | No marketplace / enterprise / privacy / WorkPack implementation | All four are RFC-0013 §10 Non-Goals. WorkPack lives in `kdna-workpack`; marketplace / enterprise / privacy are explicit `out_of_scope` per RFC-0013 §10. | RFC-0013 §10 |
 | No independent review submissions on any of the 7 PRs | All 7 PRs were admin-merged by a single maintainer. Review submissions are empty. This is consistent with the public-facing status policy (complex book-derived domain testing is deferred to a follow-up PR) and the recommended external wording, but it is a real limit. | This audit pack §5 |
-| No remote CI workflow runs on most repos | `aikdna/kdna-cli` and `aikdna/kdna-lab` have no CI workflow configured for the relevant branches. `aikdna/kdna-studio-core` and `aikdna/kdna` have workflows but they did not run on the implementation PRs as expected. The validation signal is **local-only** (pytest, node --test, ajv schema validation). | This audit pack §5 |
+| No remote CI workflow runs on most repos | `aikdna/kdna-cli` and `lab (private)` have no CI workflow configured for the relevant branches. `aikdna/kdna-studio-core` and `aikdna/kdna` have workflows but they did not run on the implementation PRs as expected. The validation signal is **local-only** (pytest, node --test, ajv schema validation). | This audit pack §5 |
 | `kdna-studio-core` 11 pre-existing test failures remain out of scope | The 11 failures in `core.test.js`, `e2e.test.js`, `milestone3.test.js` are about `KDNA_Core.json` vs `payload.kdnab` test expectations and predate PR-3. Fixing them is a separate test-suite migration PR. | PR-3 audit note, PR-4b audit note |
 
 A reviewer can decide whether any of these gaps should block
@@ -244,7 +244,7 @@ before any further status promotion.
 | aikdna/kdna | Yes, but did not run on PR-1 / PR-2a / Phase 2 PRs as expected. Local `grep` checks are the only signal. |
 | aikdna/kdna-cli | No CI workflow configured for the relevant branch. Local `node --test` is the only signal. |
 | aikdna/kdna-studio-core | Workflow exists; the PR-3 commit was admin-merged. The 11 pre-existing test failures in this repo are out of scope (see §4). |
-| aikdna/kdna-lab | No CI workflow configured for the relevant branch. Local `pytest` + Node smoke is the only signal. |
+| lab (private) | No CI workflow configured for the relevant branch. Local `pytest` + Node smoke is the only signal. |
 
 The PR descriptions explicitly state
 `no workflow runs; local validation only` where applicable. The
@@ -252,8 +252,8 @@ authoritative validation for each PR is documented in its
 respective audit note (PR-1: docs/audits/pr-1-acceptance.md; PR-2:
 kdna-cli docstring; PR-2a: docs/audits/pr-2-acceptance.md;
 PR-3: kdna-studio-core/docs/audits/pr-3-acceptance.md; PR-4:
-kdna-lab/docs/audits/pr-4-acceptance.md; PR-4b:
-kdna-lab/docs/audits/pr-4b-acceptance.md; Phase 2:
+lab acceptance note (private); PR-4b:
+lab acceptance note (private); Phase 2:
 docs/audits/phase-2-rfc-0014-0015-filing.md).
 
 ---
@@ -293,7 +293,7 @@ are real follow-up work.
    emits Card v2 fields. RFC-0014 is filed as Draft; acceptance
    criteria for the implementation RFC are in RFC-0014 §8.
 
-6. **RFC-0015 implementation** — kdna-studio-core and kdna-lab
+6. **RFC-0015 implementation** — kdna-studio-core and lab (private)
    releases that emit and consume the v2 lifecycle trace. RFC-0015
    is filed as Draft; acceptance criteria are in RFC-0015 §8.
 
@@ -361,13 +361,13 @@ Specifically:
 
 | PR | Repo | Commit | Audit note |
 |----|------|--------|-------------|
-| [#86](https://github.com/aikdna/kdna/pull/86) | aikdna/kdna | [`c00601c`](https://github.com/aikdna/kdna/commit/c00601c) | — |
-| [#10](https://github.com/aikdna/kdna-cli/pull/10) | aikdna/kdna-cli | [`bb64821`](https://github.com/aikdna/kdna-cli/commit/bb64821) | (in PR body) |
-| [#87](https://github.com/aikdna/kdna/pull/87) | aikdna/kdna | [`f328ca0`](https://github.com/aikdna/kdna/commit/f328ca0) | [`docs/audits/pr-2-acceptance.md`](https://github.com/aikdna/kdna/blob/main/docs/audits/pr-2-acceptance.md) |
-| [#3](https://github.com/aikdna/kdna-studio-core/pull/3) | aikdna/kdna-studio-core | [`e2dddf4`](https://github.com/aikdna/kdna-studio-core/commit/e2dddf4) | [`docs/audits/pr-3-acceptance.md`](https://github.com/aikdna/kdna-studio-core/blob/main/docs/audits/pr-3-acceptance.md) |
-| [#3](https://github.com/aikdna/kdna-lab/pull/3) | aikdna/kdna-lab | [`d8c466c`](https://github.com/aikdna/kdna-lab/commit/d8c466c) | [`docs/audits/pr-4-acceptance.md`](https://github.com/aikdna/kdna-lab/blob/main/docs/audits/pr-4-acceptance.md) |
-| [#4](https://github.com/aikdna/kdna-lab/pull/4) | aikdna/kdna-lab | [`3849ae1`](https://github.com/aikdna/kdna-lab/commit/3849ae1) | [`docs/audits/pr-4b-acceptance.md`](https://github.com/aikdna/kdna-lab/blob/main/docs/audits/pr-4b-acceptance.md) |
-| [#88](https://github.com/aikdna/kdna/pull/88) | aikdna/kdna | [`c2103aa`](https://github.com/aikdna/kdna/commit/c2103aa) | [`docs/audits/phase-2-rfc-0014-0015-filing.md`](https://github.com/aikdna/kdna/blob/main/docs/audits/phase-2-rfc-0014-0015-filing.md) |
+| [#86](https://github.com/aikdna/kdna/pull/86) | aikdna/kdna | [`see PR-1 acceptance`](https://github.com/aikdna/kdna/commit/see PR-1 acceptance) | — |
+| [#10](https://github.com/aikdna/kdna-cli/pull/10) | aikdna/kdna-cli | [`see PR-2 acceptance`](https://github.com/aikdna/kdna-cli/commit/see PR-2 acceptance) | (in PR body) |
+| [#87](https://github.com/aikdna/kdna/pull/87) | aikdna/kdna | [`see PR-2a acceptance`](https://github.com/aikdna/kdna/commit/see PR-2a acceptance) | [`docs/audits/pr-2-acceptance.md`](https://github.com/aikdna/kdna/blob/main/docs/audits/pr-2-acceptance.md) |
+| [#3](https://github.com/aikdna/kdna-studio-core/pull/3) | aikdna/kdna-studio-core | [`see PR-3 acceptance`](https://github.com/aikdna/kdna-studio-core/commit/see PR-3 acceptance) | [`docs/audits/pr-3-acceptance.md`](https://github.com/aikdna/kdna-studio-core/blob/main/docs/audits/pr-3-acceptance.md) |
+| [#3](https://github.com/lab PR) | lab (private) | [`see PR-4 acceptance`](https://github.com/lab (private)) | [`docs/audits/pr-4-acceptance.md`](https://github.com/lab acceptance note (private)) |
+| [#4](https://github.com/lab PR) | lab (private) | [`see PR-4b acceptance`](https://github.com/lab (private)) | [`docs/audits/pr-4b-acceptance.md`](https://github.com/lab acceptance note (private)) |
+| [#88](https://github.com/aikdna/kdna/pull/88) | aikdna/kdna | [`see Phase 2 filing`](https://github.com/aikdna/kdna/commit/see Phase 2 filing) | [`docs/audits/phase-2-rfc-0014-0015-filing.md`](https://github.com/aikdna/kdna/blob/main/docs/audits/phase-2-rfc-0014-0015-filing.md) |
 
 ### RFCs
 

--- a/docs/audits/toolchain-5-minute-usability.md
+++ b/docs/audits/toolchain-5-minute-usability.md
@@ -7,7 +7,7 @@ Status: CONDITIONAL PASS (kdnACLI install works; v1 route requires monorepo)
 
 - macOS, Node.js v22
 - Global `kdna` at `/opt/homebrew/bin/kdna` → @aikdna/kdna-cli v0.21.1
-- Local monorepo at `/Users/AI/K/OPEN/kdna`
+- Local monorepo at `<workdir>/kdna`
 
 ## Command-by-command
 

--- a/docs/creator-workflow.md
+++ b/docs/creator-workflow.md
@@ -24,7 +24,7 @@
 | 这个域帮助 AI 判断什么？ | 必须是一个具体的判断问题，不是泛领域。例："判断会议是否真的形成了决策" ✅；"管理" ❌ |
 | 谁需要这个判断？ | 必须能说出具体人群。例："用 Obsidian 但发现笔记越存越多的知识工作者" ✅；"所有人" ❌ |
 | 错误判断的代价是什么？ | AI 在这个域里最常见的错误是什么？错了会怎样？ |
-| 和现有域是否有重叠？ | 检查 kdna-x 资产库。如果是同一判断问题的新角度，标注关系。如果是已有域的弱化版，不要建。 |
+| 和现有域是否有重叠？ | 检查官方资产库。如果是同一判断问题的新角度，标注关系。如果是已有域的弱化版，不要建。 |
 
 ### 0.2 Scope / Out-of-Scope 模板
 
@@ -275,7 +275,7 @@ kdna validate ./your-domain.kdna
 ```
 
 Share the `.kdna` file directly, or publish to a GitHub Release. For curated
-public assets, see [kdna-x](https://github.com/aikdna/kdna-x).
+public assets, see the official asset library (release notes).
 
 ### 5.5 更新网站 Domains 页
 

--- a/docs/phase2-walkthrough.md
+++ b/docs/phase2-walkthrough.md
@@ -30,8 +30,8 @@ Every step produces **schema-valid JSON** that you can inspect, validate, and bu
 
 ```bash
 npm install -g @aikdna/kdna-cli
-git clone https://github.com/the E2E test lab
-cd lab (private)/examples/e2e-coaching
+git clone (private)
+cd the E2E test lab (private)/examples/e2e-coaching
 node demo.mjs
 ```
 

--- a/docs/phase2-walkthrough.md
+++ b/docs/phase2-walkthrough.md
@@ -30,8 +30,8 @@ Every step produces **schema-valid JSON** that you can inspect, validate, and bu
 
 ```bash
 npm install -g @aikdna/kdna-cli
-git clone https://github.com/aikdna/kdna-lab
-cd kdna-lab/examples/e2e-coaching
+git clone https://github.com/the E2E test lab
+cd lab (private)/examples/e2e-coaching
 node demo.mjs
 ```
 

--- a/docs/quality-thresholds.md
+++ b/docs/quality-thresholds.md
@@ -1,7 +1,7 @@
 # KDNA Quality Thresholds
 
 > **Status: Historical.** This document describes pre-Core quality evaluation processes.
-> For current asset creation, see [kdna-x](https://github.com/aikdna/kdna-x).
+> For current asset creation, see the official asset library (release notes).
 
 Not every structurally valid KDNA domain deserves publication. This document defines what quality means at each level — and what evidence is required to advance.
 

--- a/docs/reference-domain-benchmark-runbook.md
+++ b/docs/reference-domain-benchmark-runbook.md
@@ -8,7 +8,7 @@
 - Node.js 22+
 - kdna CLI installed globally: `npm install -g @aikdna/kdna-cli`
 - Domain installed: `kdna install @aikdna/<domain> --yes`
-- API key in `../.env` (relative to lab (private) root):
+- API key in `../.env` (relative to the E2E test lab (private) root):
   ```
   OPENROUTER_API_KEY=sk-or-v1-...
   ```
@@ -17,7 +17,7 @@
 ## Quick Start
 
 ```bash
-cd lab (private)
+cd the E2E test lab (private)
 
 # Dry run (validate everything, no API calls)
 node runners/run_domain_benchmark.mjs --domain "@aikdna/writing" --dry-run
@@ -93,7 +93,7 @@ After running benchmarks for a domain:
 4. [ ] Add to domain's `kdna.json`:
    ```json
    "evals_url": "https://github.com/aikdna/kdna-<domain>/tree/main/evals",
-   "benchmark_report_url": "https://github.com/the E2E test lab/blob/main/outputs/benchmarks/<domain>/benchmark-report.md",
+   "benchmark_report_url": "(private)
    "known_limitations_url": "https://github.com/aikdna/kdna-<domain>/blob/main/docs/known-limitations.md"
    ```
 5. [ ] Republish domain with: `kdna publish @aikdna/<domain>`

--- a/docs/reference-domain-benchmark-runbook.md
+++ b/docs/reference-domain-benchmark-runbook.md
@@ -8,7 +8,7 @@
 - Node.js 22+
 - kdna CLI installed globally: `npm install -g @aikdna/kdna-cli`
 - Domain installed: `kdna install @aikdna/<domain> --yes`
-- API key in `../.env` (relative to kdna-lab root):
+- API key in `../.env` (relative to lab (private) root):
   ```
   OPENROUTER_API_KEY=sk-or-v1-...
   ```
@@ -17,7 +17,7 @@
 ## Quick Start
 
 ```bash
-cd kdna-lab
+cd lab (private)
 
 # Dry run (validate everything, no API calls)
 node runners/run_domain_benchmark.mjs --domain "@aikdna/writing" --dry-run
@@ -93,7 +93,7 @@ After running benchmarks for a domain:
 4. [ ] Add to domain's `kdna.json`:
    ```json
    "evals_url": "https://github.com/aikdna/kdna-<domain>/tree/main/evals",
-   "benchmark_report_url": "https://github.com/aikdna/kdna-lab/blob/main/outputs/benchmarks/<domain>/benchmark-report.md",
+   "benchmark_report_url": "https://github.com/the E2E test lab/blob/main/outputs/benchmarks/<domain>/benchmark-report.md",
    "known_limitations_url": "https://github.com/aikdna/kdna-<domain>/blob/main/docs/known-limitations.md"
    ```
 5. [ ] Republish domain with: `kdna publish @aikdna/<domain>`

--- a/docs/rfc-status.md
+++ b/docs/rfc-status.md
@@ -18,7 +18,7 @@
 | RFC-0010 | Fidelity Protocol | **Implemented** | `specs/fidelity-result.schema.json`, `@aikdna/kdna-fidelity-core` |
 | RFC-0011 | Product Runtime | **Accepted** | `specs/product-runtime.schema.json`, `examples/product-runtime/` |
 | RFC-0012 | Artifact Envelope (output artifact) | **Draft** | `specs/RFC-0012-artifact-contract.md` (companion to RFC-0009; output-side envelope) |
-| RFC-0013 | Judgment Asset Lifecycle | **Implemented** | `schema/source_authority.schema.json` + `schema/truth_charter.schema.json` + `schema/module_manifest.schema.json` (PR-1, aikdna/kdna #86); `SPEC.md` §1.6.3 Anti-Monolithic (PR-2a, aikdna/kdna #87); `aikdna/kdna-cli` Anti-Monolithic CLI lint (PR-2, #10); `aikdna/kdna-studio-core` SAG/TC compile gates (PR-3, #3); `aikdna/kdna-lab` lifecycle smoke (PR-4, #3) + default-synthesis migration smoke (PR-4b, #4); companion Drafts `specs/RFC-0014-kdna-card-v2.md` + `specs/RFC-0015-runtime-trace-v2.md` (Phase 2, aikdna/kdna #88); evidence pack `docs/audits/rfc-0013-implementation-evidence-pack.md` |
+| RFC-0013 | Judgment Asset Lifecycle | **Implemented** | `schema/source_authority.schema.json` + `schema/truth_charter.schema.json` + `schema/module_manifest.schema.json` (PR-1, aikdna/kdna #86); `SPEC.md` §1.6.3 Anti-Monolithic (PR-2a, aikdna/kdna #87); `aikdna/kdna-cli` Anti-Monolithic CLI lint (PR-2, #10); `aikdna/kdna-studio-core` SAG/TC compile gates (PR-3, #3); `the E2E test lab` lifecycle smoke (PR-4, #3) + default-synthesis migration smoke (PR-4b, #4); companion Drafts `specs/RFC-0014-kdna-card-v2.md` + `specs/RFC-0015-runtime-trace-v2.md` (Phase 2, aikdna/kdna #88); evidence pack `docs/audits/rfc-0013-implementation-evidence-pack.md` |
 | RFC-0014 | KDNA Card Spec v2 | **Draft** | `specs/RFC-0014-kdna-card-v2.md` (companion to RFC-0013; field-level extension, not implementation) |
 | RFC-0015 | Runtime Trace Spec v2 | **Draft** | `specs/RFC-0015-runtime-trace-v2.md` (companion to RFC-0013; field-level extension, not implementation) |
 
@@ -46,7 +46,7 @@ RFC-0015 Trace v2              █░░░░░░░░░░░░░░░ 
 > **Implemented** based on technical acceptance coverage and
 > remote audit; not yet `Stable`. The reference implementation is
 > shipped across four repositories (kdna, kdna-cli,
-> kdna-studio-core, kdna-lab); §9 acceptance criteria are 7/7
+> kdna-studio-core, lab (private)); §9 acceptance criteria are 7/7
 > technically covered; the evidence pack and governance rule
 > are in place. Follow-up work remains for atomspeak
 > (PR-5), Card v2 implementation (RFC-0014), Trace v2

--- a/docs/rfc-status.md
+++ b/docs/rfc-status.md
@@ -46,7 +46,7 @@ RFC-0015 Trace v2              █░░░░░░░░░░░░░░░ 
 > **Implemented** based on technical acceptance coverage and
 > remote audit; not yet `Stable`. The reference implementation is
 > shipped across four repositories (kdna, kdna-cli,
-> kdna-studio-core, lab (private)); §9 acceptance criteria are 7/7
+> kdna-studio-core, the E2E test lab (private)); §9 acceptance criteria are 7/7
 > technically covered; the evidence pack and governance rule
 > are in place. Follow-up work remains for atomspeak
 > (PR-5), Card v2 implementation (RFC-0014), Trace v2

--- a/docs/status.md
+++ b/docs/status.md
@@ -87,7 +87,7 @@ These were removed from the Core GA CLI. Future systems such as distribution, si
 - **kdna-vscode** — VS Code extension (legacy workspace tools); not yet updated for Core GA
 - **kdna-loader** — agent adapter skill; functional for supported agents, UX hardening deferred
 - **kdna-core-swift** — Swift runtime; beta until parity proven against fixed Core v1 conformance fixtures
-- **kdna-lab** — pressure-test infrastructure; experimental
+- **lab (private)** — pressure-test infrastructure; experimental
 
 ## Deferred (future RFCs)
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -87,7 +87,7 @@ These were removed from the Core GA CLI. Future systems such as distribution, si
 - **kdna-vscode** — VS Code extension (legacy workspace tools); not yet updated for Core GA
 - **kdna-loader** — agent adapter skill; functional for supported agents, UX hardening deferred
 - **kdna-core-swift** — Swift runtime; beta until parity proven against fixed Core v1 conformance fixtures
-- **lab (private)** — pressure-test infrastructure; experimental
+- **the E2E test lab (private)** — pressure-test infrastructure; experimental
 
 ## Deferred (future RFCs)
 

--- a/ecosystem-manifest.json
+++ b/ecosystem-manifest.json
@@ -167,57 +167,60 @@
       "local_path": null,
       "npm_package": null,
       "package_json": null,
-      "current_version": "0.7.3",
+      "current_version": null,
       "lifecycle": "Removed",
       "supported_kdna_version": "1.0",
       "supported_access_modes": [
         "public"
       ],
       "supported_entitlement_profiles": [],
-      "conformance_commit": "814aa266328f5fa18f3894080bc0d0f4cc5673ee",
+      "conformance_commit": null,
       "known_limitations": [
-        "Repository deleted. No packaged public replacement is released yet. Future replacement must be a .kdna file with release card and checksum."
+        "Pre-v1 entry; removed/legacy as of 2026-06-25. See release notes for current runtime baseline."
       ],
-      "recommended_entrypoint": "Use the local demo path until an approved packaged .kdna release card exists",
-      "legacy_replacement": "packaged .kdna example release"
+      "recommended_entrypoint": "See current Core v1 release notes",
+      "legacy_replacement": null,
+      "_historical": true
     },
     {
       "repository": "aikdna/kdna-prompt_diagnosis",
       "local_path": null,
       "npm_package": null,
       "package_json": null,
-      "current_version": "0.7.6",
+      "current_version": null,
       "lifecycle": "Removed",
       "supported_kdna_version": "1.0",
       "supported_access_modes": [
         "public"
       ],
       "supported_entitlement_profiles": [],
-      "conformance_commit": "57764bdf97d574f8a986c2bd14f5f70f1ea82f7c",
+      "conformance_commit": null,
       "known_limitations": [
-        "Repository deleted. No packaged public replacement is released yet. Future replacement must be a .kdna file with release card and checksum."
+        "Pre-v1 entry; removed/legacy as of 2026-06-25. See release notes for current runtime baseline."
       ],
-      "recommended_entrypoint": "Use the local demo path until an approved packaged .kdna release card exists",
-      "legacy_replacement": "packaged .kdna example release"
+      "recommended_entrypoint": "See current Core v1 release notes",
+      "legacy_replacement": null,
+      "_historical": true
     },
     {
       "repository": "aikdna/kdna-agent_safety",
       "local_path": null,
       "npm_package": null,
       "package_json": null,
-      "current_version": "0.7.6",
+      "current_version": null,
       "lifecycle": "Removed",
       "supported_kdna_version": "1.0",
       "supported_access_modes": [
         "public"
       ],
       "supported_entitlement_profiles": [],
-      "conformance_commit": "86f02f16ef9c167b415609dad1da6723b1448ed6",
+      "conformance_commit": null,
       "known_limitations": [
-        "Repository deleted. No packaged public replacement is released yet. Future replacement must be a .kdna file with release card and checksum."
+        "Pre-v1 entry; removed/legacy as of 2026-06-25. See release notes for current runtime baseline."
       ],
-      "recommended_entrypoint": "Use the local demo path until an approved packaged .kdna release card exists",
-       "legacy_replacement": "packaged .kdna example release"
+      "recommended_entrypoint": "See current Core v1 release notes",
+      "legacy_replacement": null,
+      "_historical": true
     },
     {
       "repository": "aikdna/kdna-registry",
@@ -231,10 +234,11 @@
       "supported_entitlement_profiles": [],
       "conformance_commit": null,
       "known_limitations": [
-        "not part of the current stable public runtime baseline"
+        "Pre-v1 entry; removed/legacy as of 2026-06-25. See release notes for current runtime baseline."
       ],
-      "recommended_entrypoint": "local public .kdna assets through Core/CLI",
-      "legacy_replacement": "local public asset workflow"
+      "recommended_entrypoint": "See current Core v1 release notes",
+      "legacy_replacement": null,
+      "_historical": true
     }
   ],
   "repositories": []

--- a/ecosystem-manifest.json
+++ b/ecosystem-manifest.json
@@ -141,7 +141,9 @@
         "depends on old @aikdna/kdna-core and is not part of the shipped v1 runtime baseline"
       ],
       "recommended_entrypoint": "Use CLI and Studio CLI for current v1 workflows",
-      "legacy_replacement": "@aikdna/kdna-cli"
+      "legacy_replacement": "@aikdna/kdna-cli",
+      "_deprecated_at": "2026-06-25",
+      "_deprecation_note": "Never published to VS Code Marketplace. Repository archived."
     },
     {
       "repository": "aikdna/kdna-website",

--- a/specs/RFC-0013-judgment-asset-lifecycle.md
+++ b/specs/RFC-0013-judgment-asset-lifecycle.md
@@ -455,7 +455,7 @@ These companion RFCs are scoped to **detail schema only**. They do not re-litiga
 | Provenance report | `aikdna/kdna` (meta) | `specs/evidence-trace.schema.json` | Extend with optional `sag_summary` and `tc_summary` blocks |
 | Registry | `aikdna/kdna-registry` | RFC-0002 / `specs/kdna-registry.md` | **No change.** Registry continues to accept `.kdna` files; provenance summaries are advisory |
 | Trace v2 | `aikdna/kdna-cli` | `docs/kdna-trace.md` | `kdna trace` v2 emits `sag_version` and `tc_status` per loaded asset (companion RFC-0015) |
-| Lab | `aikdna/kdna-lab` | E2E demo, benchmark runner | Add `kdna-lab` smoke test: "compile a domain with explicit SAG/TC; verify lint passes; load and trace records TC version" |
+| Lab | `the E2E test lab` | E2E demo, benchmark runner | Add `lab (private)` smoke test: "compile a domain with explicit SAG/TC; verify lint passes; load and trace records TC version" |
 | WorkPack | `aikdna/kdna-workpack` | (separate) | **No change.** Application protocol family. |
 
 **The boundary at LAYER C is enforceable in CI.** A new `kdna ci` check (in kdna-cli) verifies, for any `.kdna` produced by `kdna build`:
@@ -483,10 +483,10 @@ schema/module_manifest.schema.json
 | `kdna build --auto-migrate` (synthesize SAG/TC for legacy domains) | kdna-cli | No (default off) | S |
 | `kdna inspect <file>` surfaces SAG/TC summary from provenance | kdna-cli | No | S |
 | `kdna-studio-core` compile() verifies TC locked + SAG `current_highest` | kdna-studio-core | No (gates existing compile) | M |
-| `kdna-lab` smoke test for SAG/TC round-trip | kdna-lab | No | S |
+| `lab (private)` smoke test for SAG/TC round-trip | lab (private) | No | S |
 | `kdna-trace` v2 records `sag_version` + `tc_status` (companion RFC-0015) | kdna-cli | No (additive) | M |
 
-**S = 1 day, M = 1 week.** Total estimated effort for this RFC and its companions: 1 maintainer-week of focused work, distributed over kdna-cli, kdna-studio-core, kdna-lab, and the meta repo. Schema and docs are the bulk.
+**S = 1 day, M = 1 week.** Total estimated effort for this RFC and its companions: 1 maintainer-week of focused work, distributed over kdna-cli, kdna-studio-core, lab (private), and the meta repo. Schema and docs are the bulk.
 
 ### 8.4 Spec Updates to Existing Documents
 
@@ -559,7 +559,7 @@ MODIFIED FILES
   CHANGELOG.md
 ```
 
-**`aikdna/kdna-lab`:**
+**`the E2E test lab`:**
 
 ```
 NEW FILES
@@ -592,7 +592,7 @@ This RFC is considered **Accepted → Implemented** when all of the following ar
 1. All three new schema files (`source_authority`, `truth_charter`, `module_manifest`) are merged in `aikdna/kdna/schema/`.
 2. `kdna dev validate --anti-monolithic` exists and passes CI on the meta repo's own example domains.
 3. `kdna-studio-core` rejects (with a clear error) any `compile()` call where the source workspace has a TC with `tc_status: "synthesized"` and a SAG with no `current_highest` source **and** the caller passes `--strict-authority`.
-4. `kdna-lab` smoke test compiles a **simple official legacy domain** (e.g., `@aikdna/code_review` or `@aikdna/prompt_diagnosis`) with synthesized or explicit SAG/TC, runs 5 trace events, and verifies `sag_version` and `tc_status` appear in the trace output. A book-derived atomspeak smoke test is **deferred to a follow-up PR (proposed: PR-5 after PR-1~4 stable)**.
+4. `lab (private)` smoke test compiles a **simple official legacy domain** (e.g., `@aikdna/code_review` or `@aikdna/prompt_diagnosis`) with synthesized or explicit SAG/TC, runs 5 trace events, and verifies `sag_version` and `tc_status` appear in the trace output. A book-derived atomspeak smoke test is **deferred to a follow-up PR (proposed: PR-5 after PR-1~4 stable)**.
 5. `SPEC.md` §1.6 contains the Anti-Monolithic Domain Principle verbatim.
 6. RFC-0014 and RFC-0015 are filed as separate Draft RFCs.
 7. A migration run on a real legacy domain (e.g., `@aikdna/code_review`) successfully synthesizes default SAG/TC and produces a valid `.kdna` identical in shape to the pre-RFC build.

--- a/specs/RFC-0013-judgment-asset-lifecycle.md
+++ b/specs/RFC-0013-judgment-asset-lifecycle.md
@@ -455,7 +455,7 @@ These companion RFCs are scoped to **detail schema only**. They do not re-litiga
 | Provenance report | `aikdna/kdna` (meta) | `specs/evidence-trace.schema.json` | Extend with optional `sag_summary` and `tc_summary` blocks |
 | Registry | `aikdna/kdna-registry` | RFC-0002 / `specs/kdna-registry.md` | **No change.** Registry continues to accept `.kdna` files; provenance summaries are advisory |
 | Trace v2 | `aikdna/kdna-cli` | `docs/kdna-trace.md` | `kdna trace` v2 emits `sag_version` and `tc_status` per loaded asset (companion RFC-0015) |
-| Lab | `the E2E test lab` | E2E demo, benchmark runner | Add `lab (private)` smoke test: "compile a domain with explicit SAG/TC; verify lint passes; load and trace records TC version" |
+| Lab | `the E2E test lab` | E2E demo, benchmark runner | Add `the E2E test lab (private)` smoke test: "compile a domain with explicit SAG/TC; verify lint passes; load and trace records TC version" |
 | WorkPack | `aikdna/kdna-workpack` | (separate) | **No change.** Application protocol family. |
 
 **The boundary at LAYER C is enforceable in CI.** A new `kdna ci` check (in kdna-cli) verifies, for any `.kdna` produced by `kdna build`:
@@ -483,10 +483,10 @@ schema/module_manifest.schema.json
 | `kdna build --auto-migrate` (synthesize SAG/TC for legacy domains) | kdna-cli | No (default off) | S |
 | `kdna inspect <file>` surfaces SAG/TC summary from provenance | kdna-cli | No | S |
 | `kdna-studio-core` compile() verifies TC locked + SAG `current_highest` | kdna-studio-core | No (gates existing compile) | M |
-| `lab (private)` smoke test for SAG/TC round-trip | lab (private) | No | S |
+| `the E2E test lab (private)` smoke test for SAG/TC round-trip | the E2E test lab (private) | No | S |
 | `kdna-trace` v2 records `sag_version` + `tc_status` (companion RFC-0015) | kdna-cli | No (additive) | M |
 
-**S = 1 day, M = 1 week.** Total estimated effort for this RFC and its companions: 1 maintainer-week of focused work, distributed over kdna-cli, kdna-studio-core, lab (private), and the meta repo. Schema and docs are the bulk.
+**S = 1 day, M = 1 week.** Total estimated effort for this RFC and its companions: 1 maintainer-week of focused work, distributed over kdna-cli, kdna-studio-core, the E2E test lab (private), and the meta repo. Schema and docs are the bulk.
 
 ### 8.4 Spec Updates to Existing Documents
 
@@ -592,7 +592,7 @@ This RFC is considered **Accepted → Implemented** when all of the following ar
 1. All three new schema files (`source_authority`, `truth_charter`, `module_manifest`) are merged in `aikdna/kdna/schema/`.
 2. `kdna dev validate --anti-monolithic` exists and passes CI on the meta repo's own example domains.
 3. `kdna-studio-core` rejects (with a clear error) any `compile()` call where the source workspace has a TC with `tc_status: "synthesized"` and a SAG with no `current_highest` source **and** the caller passes `--strict-authority`.
-4. `lab (private)` smoke test compiles a **simple official legacy domain** (e.g., `@aikdna/code_review` or `@aikdna/prompt_diagnosis`) with synthesized or explicit SAG/TC, runs 5 trace events, and verifies `sag_version` and `tc_status` appear in the trace output. A book-derived atomspeak smoke test is **deferred to a follow-up PR (proposed: PR-5 after PR-1~4 stable)**.
+4. `the E2E test lab (private)` smoke test compiles a **simple official legacy domain** (e.g., `@aikdna/code_review` or `@aikdna/prompt_diagnosis`) with synthesized or explicit SAG/TC, runs 5 trace events, and verifies `sag_version` and `tc_status` appear in the trace output. A book-derived atomspeak smoke test is **deferred to a follow-up PR (proposed: PR-5 after PR-1~4 stable)**.
 5. `SPEC.md` §1.6 contains the Anti-Monolithic Domain Principle verbatim.
 6. RFC-0014 and RFC-0015 are filed as separate Draft RFCs.
 7. A migration run on a real legacy domain (e.g., `@aikdna/code_review`) successfully synthesizes default SAG/TC and produces a valid `.kdna` identical in shape to the pre-RFC build.

--- a/specs/RFC-0014-kdna-card-v2.md
+++ b/specs/RFC-0014-kdna-card-v2.md
@@ -10,8 +10,8 @@
 - `schema/source_authority.schema.json` (PR-1, aikdna/kdna #86)
 - `schema/truth_charter.schema.json` (PR-1)
 - `schema/module_manifest.schema.json` (PR-1)
-- the E2E test lab PR (PR-4 lifecycle smoke)
-- the E2E test lab PR (PR-4b default synthesis migration)
+- the E2E test the E2E test the E2E test the E2E test lab (private) PR (PR-4 lifecycle smoke)
+- the E2E test the E2E test the E2E test the E2E test lab (private) PR (PR-4b default synthesis migration)
 
 ---
 
@@ -362,7 +362,7 @@ This RFC is considered **Accepted → Implemented** when:
 - v1 Card Spec: `docs/KDNA_CARD_SPEC.md`
 - PR-1 (schemas): aikdna/kdna #86
 - PR-3 (gates): aikdna/kdna-studio-core #3
-- PR-4 (lifecycle smoke): the E2E test lab PR
-- PR-4b (default synthesis): the E2E test lab PR
-- the E2E test lab PR-4 audit note: `see the corresponding acceptance note (private)`
-- the E2E test lab PR-4b audit note: `see the corresponding acceptance note (private)`
+- PR-4 (lifecycle smoke): the E2E test the E2E test the E2E test the E2E test lab (private) PR
+- PR-4b (default synthesis): the E2E test the E2E test the E2E test the E2E test lab (private) PR
+- the E2E test the E2E test the E2E test the E2E test lab (private) PR-4 audit note: `see the corresponding acceptance note (private)`
+- the E2E test the E2E test the E2E test the E2E test lab (private) PR-4b audit note: `see the corresponding acceptance note (private)`

--- a/specs/RFC-0014-kdna-card-v2.md
+++ b/specs/RFC-0014-kdna-card-v2.md
@@ -10,8 +10,8 @@
 - `schema/source_authority.schema.json` (PR-1, aikdna/kdna #86)
 - `schema/truth_charter.schema.json` (PR-1)
 - `schema/module_manifest.schema.json` (PR-1)
-- aikdna/kdna-lab PR #3 (PR-4 lifecycle smoke)
-- aikdna/kdna-lab PR #4 (PR-4b default synthesis migration)
+- the E2E test lab PR (PR-4 lifecycle smoke)
+- the E2E test lab PR (PR-4b default synthesis migration)
 
 ---
 
@@ -297,7 +297,7 @@ fields are required when their authoring-time objects exist.
 
 ## 6. Relationship to PR-4b
 
-PR-4b (`docs/audits/pr-4b-acceptance.md`) is the closing piece of
+PR-4b (`see the corresponding acceptance note (private)`) is the closing piece of
 RFC-0013 §9 #7. RFC-0014 builds on PR-4b's findings:
 
 - The `migration_status: "synthesized_then_human_locked"` value is
@@ -347,7 +347,7 @@ This RFC is considered **Accepted → Implemented** when:
 2. The v2 fields are documented in `docs/KDNA_CARD_SPEC.md` (or its
    successor).
 3. The `migration_status: "synthesized_then_human_locked"` value
-   is exercised by a kdna-lab smoke (PR-4b already produces it).
+   is exercised by a lab smoke (PR-4b already produces it).
 4. The Card schema validates against a JSON Schema Draft 2020-12
    document.
 5. A consumer reading only the v2 fields can answer the questions
@@ -362,7 +362,7 @@ This RFC is considered **Accepted → Implemented** when:
 - v1 Card Spec: `docs/KDNA_CARD_SPEC.md`
 - PR-1 (schemas): aikdna/kdna #86
 - PR-3 (gates): aikdna/kdna-studio-core #3
-- PR-4 (lifecycle smoke): aikdna/kdna-lab #3
-- PR-4b (default synthesis): aikdna/kdna-lab #4
-- aikdna/kdna-lab PR-4 audit note: `docs/audits/pr-4-acceptance.md`
-- aikdna/kdna-lab PR-4b audit note: `docs/audits/pr-4b-acceptance.md`
+- PR-4 (lifecycle smoke): the E2E test lab PR
+- PR-4b (default synthesis): the E2E test lab PR
+- the E2E test lab PR-4 audit note: `see the corresponding acceptance note (private)`
+- the E2E test lab PR-4b audit note: `see the corresponding acceptance note (private)`

--- a/specs/RFC-0014-kdna-card-v2.md
+++ b/specs/RFC-0014-kdna-card-v2.md
@@ -10,8 +10,8 @@
 - `schema/source_authority.schema.json` (PR-1, aikdna/kdna #86)
 - `schema/truth_charter.schema.json` (PR-1)
 - `schema/module_manifest.schema.json` (PR-1)
-- the E2E test the E2E test the E2E test the E2E test lab (private) PR (PR-4 lifecycle smoke)
-- the E2E test the E2E test the E2E test the E2E test lab (private) PR (PR-4b default synthesis migration)
+- the E2E test lab (private) PR (PR-4 lifecycle smoke)
+- the E2E test lab (private) PR (PR-4b default synthesis migration)
 
 ---
 
@@ -362,7 +362,7 @@ This RFC is considered **Accepted → Implemented** when:
 - v1 Card Spec: `docs/KDNA_CARD_SPEC.md`
 - PR-1 (schemas): aikdna/kdna #86
 - PR-3 (gates): aikdna/kdna-studio-core #3
-- PR-4 (lifecycle smoke): the E2E test the E2E test the E2E test the E2E test lab (private) PR
-- PR-4b (default synthesis): the E2E test the E2E test the E2E test the E2E test lab (private) PR
-- the E2E test the E2E test the E2E test the E2E test lab (private) PR-4 audit note: `see the corresponding acceptance note (private)`
-- the E2E test the E2E test the E2E test the E2E test lab (private) PR-4b audit note: `see the corresponding acceptance note (private)`
+- PR-4 (lifecycle smoke): the E2E test lab (private) PR
+- PR-4b (default synthesis): the E2E test lab (private) PR
+- the E2E test lab (private) PR-4 audit note: `see the corresponding acceptance note (private)`
+- the E2E test lab (private) PR-4b audit note: `see the corresponding acceptance note (private)`

--- a/specs/RFC-0015-runtime-trace-v2.md
+++ b/specs/RFC-0015-runtime-trace-v2.md
@@ -13,8 +13,8 @@
   replaced** by this RFC)
 - `specs/judgment-trace-schema.json` (existing)
 - `specs/evidence-trace.schema.json` (existing)
-- the E2E test lab PR (PR-4 lifecycle smoke)
-- the E2E test lab PR (PR-4b default synthesis migration)
+- the E2E test the E2E test the E2E test the E2E test lab (private) PR (PR-4 lifecycle smoke)
+- the E2E test the E2E test the E2E test the E2E test lab (private) PR (PR-4b default synthesis migration)
 
 ---
 
@@ -267,7 +267,7 @@ This RFC explicitly does **not**:
 - ❌ Modify `docs/kdna-trace.md` (v1). v1 remains valid.
 - ❌ Modify `specs/judgment-trace-schema.json`. v1 judgment-call
   trace schema remains valid.
-- ❌ Modify the lab (private) trace checker (`lab_trace_check.py (private)`).
+- ❌ Modify the the E2E test lab (private) trace checker (`lab_trace_check.py (private)`).
   The checker is for v1 traces; v2 checker is a follow-up.
 - ❌ Define an enterprise audit log. Enterprise audit is
   Governance track; v2 only adds per-event status fields.
@@ -289,7 +289,7 @@ This RFC is considered **Accepted → Implemented** when:
 2. A consumer (follow-up PR) can read the v2 events using only
    the v2 minimum field set.
 3. The `migration_mode` / `synthesis_status` / `lock_status` /
-   `runtime_payload_leaked` fields are exercised by a lab (private)
+   `runtime_payload_leaked` fields are exercised by a the E2E test lab (private)
    smoke (PR-4b already produces them).
 4. v1 trace command (`docs/kdna-trace.md`) and v1 judgment-trace
    schema (`specs/judgment-trace-schema.json`) are **unchanged**
@@ -308,7 +308,7 @@ This RFC is considered **Accepted → Implemented** when:
 - v1 evidence-trace schema: `specs/evidence-trace.schema.json`
 - PR-1 (schemas): aikdna/kdna #86
 - PR-3 (gates): aikdna/kdna-studio-core #3
-- PR-4 (lifecycle smoke): the E2E test lab PR
-- PR-4b (default synthesis): the E2E test lab PR
-- the E2E test lab PR-4 audit note: `see the corresponding acceptance note (private)`
-- the E2E test lab PR-4b audit note: `see the corresponding acceptance note (private)`
+- PR-4 (lifecycle smoke): the E2E test the E2E test the E2E test the E2E test lab (private) PR
+- PR-4b (default synthesis): the E2E test the E2E test the E2E test the E2E test lab (private) PR
+- the E2E test the E2E test the E2E test the E2E test lab (private) PR-4 audit note: `see the corresponding acceptance note (private)`
+- the E2E test the E2E test the E2E test the E2E test lab (private) PR-4b audit note: `see the corresponding acceptance note (private)`

--- a/specs/RFC-0015-runtime-trace-v2.md
+++ b/specs/RFC-0015-runtime-trace-v2.md
@@ -13,8 +13,8 @@
   replaced** by this RFC)
 - `specs/judgment-trace-schema.json` (existing)
 - `specs/evidence-trace.schema.json` (existing)
-- aikdna/kdna-lab PR #3 (PR-4 lifecycle smoke)
-- aikdna/kdna-lab PR #4 (PR-4b default synthesis migration)
+- the E2E test lab PR (PR-4 lifecycle smoke)
+- the E2E test lab PR (PR-4b default synthesis migration)
 
 ---
 
@@ -214,7 +214,7 @@ able to:
 
 The existing `docs/kdna-trace.md` v1 reader does not need to
 change to support v2. v2 readers are a separate concern (a
-follow-up RFC will likely propose a `kdna-lab-trace` reader that
+follow-up RFC will likely propose a `lab-trace` reader that
 emits v2 lifecycle events).
 
 ---
@@ -228,7 +228,7 @@ toolchain:
   `docs/kdna-trace.md`). Records which KDNA domains were loaded by
   which agent for which task.
 - v2: the compile / load / lifecycle pipeline (kdna-studio-core
-  compile, kdna-lab smoke). Records which lifecycle stages
+  compile, lab smoke). Records which lifecycle stages
   occurred and which SAG/TC version was governing each.
 
 The two streams are **independent**: a domain can have v1 events
@@ -251,7 +251,7 @@ specific fields (`migration_mode`, `synthesis_status`,
 formalized in this RFC.
 
 A future kdna-studio-core release that adopts this RFC will emit
-the same v2 fields. A future kdna-lab smoke that adopts this RFC
+the same v2 fields. A future lab smoke that adopts this RFC
 will assert the same v2 fields. Until those future releases
 land, PR-4 and PR-4b remain the only producers and consumers of
 v2 events.
@@ -267,7 +267,7 @@ This RFC explicitly does **not**:
 - ❌ Modify `docs/kdna-trace.md` (v1). v1 remains valid.
 - ❌ Modify `specs/judgment-trace-schema.json`. v1 judgment-call
   trace schema remains valid.
-- ❌ Modify the kdna-lab trace checker (`kdna_lab/trace_check.py`).
+- ❌ Modify the lab (private) trace checker (`lab_trace_check.py (private)`).
   The checker is for v1 traces; v2 checker is a follow-up.
 - ❌ Define an enterprise audit log. Enterprise audit is
   Governance track; v2 only adds per-event status fields.
@@ -289,7 +289,7 @@ This RFC is considered **Accepted → Implemented** when:
 2. A consumer (follow-up PR) can read the v2 events using only
    the v2 minimum field set.
 3. The `migration_mode` / `synthesis_status` / `lock_status` /
-   `runtime_payload_leaked` fields are exercised by a kdna-lab
+   `runtime_payload_leaked` fields are exercised by a lab (private)
    smoke (PR-4b already produces them).
 4. v1 trace command (`docs/kdna-trace.md`) and v1 judgment-trace
    schema (`specs/judgment-trace-schema.json`) are **unchanged**
@@ -308,7 +308,7 @@ This RFC is considered **Accepted → Implemented** when:
 - v1 evidence-trace schema: `specs/evidence-trace.schema.json`
 - PR-1 (schemas): aikdna/kdna #86
 - PR-3 (gates): aikdna/kdna-studio-core #3
-- PR-4 (lifecycle smoke): aikdna/kdna-lab #3
-- PR-4b (default synthesis): aikdna/kdna-lab #4
-- aikdna/kdna-lab PR-4 audit note: `docs/audits/pr-4-acceptance.md`
-- aikdna/kdna-lab PR-4b audit note: `docs/audits/pr-4b-acceptance.md`
+- PR-4 (lifecycle smoke): the E2E test lab PR
+- PR-4b (default synthesis): the E2E test lab PR
+- the E2E test lab PR-4 audit note: `see the corresponding acceptance note (private)`
+- the E2E test lab PR-4b audit note: `see the corresponding acceptance note (private)`

--- a/specs/RFC-0015-runtime-trace-v2.md
+++ b/specs/RFC-0015-runtime-trace-v2.md
@@ -13,8 +13,8 @@
   replaced** by this RFC)
 - `specs/judgment-trace-schema.json` (existing)
 - `specs/evidence-trace.schema.json` (existing)
-- the E2E test the E2E test the E2E test the E2E test lab (private) PR (PR-4 lifecycle smoke)
-- the E2E test the E2E test the E2E test the E2E test lab (private) PR (PR-4b default synthesis migration)
+- the E2E test lab (private) PR (PR-4 lifecycle smoke)
+- the E2E test lab (private) PR (PR-4b default synthesis migration)
 
 ---
 
@@ -308,7 +308,7 @@ This RFC is considered **Accepted → Implemented** when:
 - v1 evidence-trace schema: `specs/evidence-trace.schema.json`
 - PR-1 (schemas): aikdna/kdna #86
 - PR-3 (gates): aikdna/kdna-studio-core #3
-- PR-4 (lifecycle smoke): the E2E test the E2E test the E2E test the E2E test lab (private) PR
-- PR-4b (default synthesis): the E2E test the E2E test the E2E test the E2E test lab (private) PR
-- the E2E test the E2E test the E2E test the E2E test lab (private) PR-4 audit note: `see the corresponding acceptance note (private)`
-- the E2E test the E2E test the E2E test the E2E test lab (private) PR-4b audit note: `see the corresponding acceptance note (private)`
+- PR-4 (lifecycle smoke): the E2E test lab (private) PR
+- PR-4b (default synthesis): the E2E test lab (private) PR
+- the E2E test lab (private) PR-4 audit note: `see the corresponding acceptance note (private)`
+- the E2E test lab (private) PR-4b audit note: `see the corresponding acceptance note (private)`

--- a/specs/archive/kdna-registry.md
+++ b/specs/archive/kdna-registry.md
@@ -61,7 +61,7 @@ registered KDNA domains.
     {
       "name": "@aikdna/writing",
       "version": "0.1.0",
-      "repo": "https://github.com/aikdna/<historical>",
+      "repo": "(private)
       "spec_version": "1.0-rc",
       "status": "experimental",
       "access": "public",
@@ -229,7 +229,7 @@ License:     CC-BY-4.0
 Description: Domain cognition for high-trust writing judgment.
 Core:        Price objections are certainty deficits, not price problems.
 Files:       6 (KDNA_Core, KDNA_Patterns, Scenarios, Cases, Reasoning, Evolution)
-Repo:        https://github.com/aikdna/<historical>
+Repo:        (private)
 ```
 
 ### 5.3 List

--- a/specs/archive/kdna-registry.md
+++ b/specs/archive/kdna-registry.md
@@ -61,7 +61,7 @@ registered KDNA domains.
     {
       "name": "@aikdna/writing",
       "version": "0.1.0",
-      "repo": "https://github.com/aikdna/kdna-writing",
+      "repo": "https://github.com/aikdna/<historical>",
       "spec_version": "1.0-rc",
       "status": "experimental",
       "access": "public",
@@ -229,7 +229,7 @@ License:     CC-BY-4.0
 Description: Domain cognition for high-trust writing judgment.
 Core:        Price objections are certainty deficits, not price problems.
 Files:       6 (KDNA_Core, KDNA_Patterns, Scenarios, Cases, Reasoning, Evolution)
-Repo:        https://github.com/aikdna/kdna-writing
+Repo:        https://github.com/aikdna/<historical>
 ```
 
 ### 5.3 List


### PR DESCRIPTION
One-shot cleanup of all private references and deprecated entries from public-facing docs, specs, and the ecosystem manifest. Followup hardening (a public-surface CI check) is tracked separately in `pr-5-guardrail`.

## T1 — Private repo references (kdna-x, kdna-lab)

Replaced across docs/REGISTRY_IS_OPTIONAL.md, docs/quality-thresholds.md, docs/creator-workflow.md, .github/workflows/publish.yml, specs/RFC-0013/0014/0015, docs/rfc-status.md, docs/phase2-walkthrough.md, docs/reference-domain-benchmark-runbook.md, docs/status.md, and 6 audit docs.

## T2 — Local filesystem paths

5 audit docs (flagship-* and toolchain-5-minute-usability.md):
- `/Users/AI/K/OPEN/kdna-*/` → `<workdir>/kdna-*`
- `/private/tmp/kdna-*/` → `/tmp/kdna-*`

## T3 — Manifest historical entries

4 historical entries in ecosystem-manifest.json (kdna-writing, kdna-prompt_diagnosis, kdna-agent_safety, kdna-registry) now carry `_historical: true`, null current_version and conformance_commit, and a single short note pointing to release notes. Stops giving external readers a roadmap of removed/Legacy repos with version numbers.

## T7 — Short commit hashes

4 audit docs: 7-char hex commit hashes (f328ca0, c2103aa, d8c466c, 3849ae1, e2dddf4, etc.) replaced with cross-references to the relevant acceptance notes.

## T9 (manifest side) — Mark kdna-vscode as deprecated

The kdna-vscode repository is deprecated (PR-4 adds the user-facing banner in kdna-vscode repo). Marked here in the manifest with `_deprecated_at: 2026-06-25` and a note pointing to the active CLI tools.

## T-followup — Public-surface check caught a missed URL

When the public-surface script landed in `pr-5-guardrail`, it caught one remaining kdna-writing URL in specs/archive/kdna-registry.md. That followup is included here (3rd commit).

Companion PR: aikdna/kdna-assets#pr-3-public-scrub (scrub kdna-assets showcase + assets.json)