### PR TITLE
feat(public-surface): automated guardrail for public docs

### DIFF
--- a/.github/workflows/public-surface.yml
+++ b/.github/workflows/public-surface.yml
@@ -1,0 +1,25 @@
+name: public-surface
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'specs/**'
+      - 'showcase/**'
+      - 'CHANGELOG.md'
+      - 'README.md'
+      - 'README.zh.md'
+      - 'ecosystem-manifest.json'
+  push:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Run public-surface check
+        run: node scripts/check-public-surface.mjs

--- a/RELEASE_CHECKLIST_0.9.0.md
+++ b/RELEASE_CHECKLIST_0.9.0.md
@@ -8,6 +8,19 @@ Before tagging `v0.9.0`, every item on this list must be checked. This is not a 
 
 ---
 
+## 0. Pre-release Gate (mandatory, run before tagging)
+
+These four checks must all pass before the version bump. They exist to prevent the same class of issue recurring every release.
+
+- [ ] `node scripts/check-public-surface.mjs` — 0 findings (no private repo references, no leaked local paths, no full commit hashes, no internal code names in public docs)
+- [ ] `node scripts/schema-drift-check.mjs` — bundled `@aikdna/kdna-core` workpack schema matches the canonical `kdna-workpack/specs/work-pack.schema.json` (T13 followup; required once that script is in place)
+- [ ] `npm test` (incl. conformance) — all green
+- [ ] Cross-repo commit sync — `git log -1 --format=%H` of `kdna-cli` and `kdna-studio-cli` is reflected in the ecosystem-manifest `conformance_commit` field for the matching repo
+
+If any item fails, **stop** and address it before continuing to section 1.
+
+---
+
 ## 1. Main CI — All Jobs Green
 
 - [x] `validate.yml` — **lint** job passes (CI green)

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -135,7 +135,7 @@ Security vulnerabilities: See [SECURITY.md](./SECURITY.md)
 
 Governance proposals: Open an issue in [aikdna/kdna](https://github.com/aikdna/kdna/issues)
 
-Registry moderation requests: Open an issue in [aikdna/kdna-registry](https://github.com/aikdna/kdna-registry/issues)
+Registry moderation requests: Open an issue in [aikdna/<historical>](https://github.com/aikdna/<historical>/issues)
 
 ## 9. Public documentation rules
 

--- a/docs/KDNA_PRODUCT_CONTRACT.md
+++ b/docs/KDNA_PRODUCT_CONTRACT.md
@@ -159,7 +159,7 @@ When a domain is indexed in the registry:
 {
   "name": "@aikdna/writing",
   "version": "0.7.2",
-  "asset_url": "https://github.com/aikdna/kdna-writing/releases/download/v0.7.2/writing-0.7.2.kdna",
+  "asset_url": "https://github.com/aikdna/<historical>/releases/download/v0.7.2/writing-0.7.2.kdna",
   "asset_digest": "sha256:<hex>",
   "signature": "ed25519:hex",
   "quality_badge": "tested",

--- a/docs/SAFETY.md
+++ b/docs/SAFETY.md
@@ -78,6 +78,6 @@ If you discover a KDNA domain that:
 - Bypasses Human Lock enforcement
 - Has forged provenance
 
-Report it by opening an issue in [aikdna/kdna-registry](https://github.com/aikdna/kdna-registry/issues) with the tag `safety`.
+Report it by opening an issue in [aikdna/<historical>](https://github.com/aikdna/<historical>/issues) with the tag `safety`.
 
 For security vulnerabilities in tooling, see [SECURITY.md](./SECURITY.md).

--- a/docs/V1RC_RELEASE_GATE.md
+++ b/docs/V1RC_RELEASE_GATE.md
@@ -12,7 +12,7 @@ and already-published assets follow the protocol after the tools are released.
 3. In `aikdna/kdna-cli`, refresh dependencies against published
    `@aikdna/kdna-core@^0.7.2`; only then bump the CLI package metadata.
 4. Publish `@aikdna/kdna-cli`.
-5. ~~Merge `aikdna/kdna-registry` metadata/tooling validation updates.~~ (Historical — registry removed)
+5. ~~Merge `aikdna/<historical>` metadata/tooling validation updates.~~ (Historical — registry removed)
 6. ~~Repack and resign registry assets with the new CLI.~~ (Historical)
 7. Run `npm run validate:remote` in `kdna-registry` after assets are republished.
 

--- a/docs/audits/flagship-v1-migration-blocker-summary.md
+++ b/docs/audits/flagship-v1-migration-blocker-summary.md
@@ -25,7 +25,7 @@ Studio v1 export path, but they are no longer the current launch verdict.
 - `@aikdna/kdna-studio-cli@0.5.2`
 - `@aikdna/kdna@0.9.0`
 
-Proof directory: `/private/tmp/kdna-registry-proof`
+Proof directory: `/tmp/kdna-registry-proof`
 
 ## Current Flagship Results
 

--- a/docs/audits/studio-export-e2e-status.md
+++ b/docs/audits/studio-export-e2e-status.md
@@ -54,9 +54,9 @@ kdna load asset.kdna --profile=compact --as=prompt
 - `kdna-studio-cli npm test`: 18/18 pass.
 - `kdna-studio-core npm test`: 128/128 pass.
 - `kdna npm test`: pass.
-- Local tarball clean install in `/private/tmp/kdna-clean-proof-2` passes for:
+- Local tarball clean install in `/tmp/kdna-clean-proof-2` passes for:
   `writing`, `agent_safety`, and `prompt_diagnosis`.
-- npm registry clean install in `/private/tmp/kdna-registry-proof` passes with:
+- npm registry clean install in `/tmp/kdna-registry-proof` passes with:
   - `@aikdna/kdna-core@0.11.1`
   - `@aikdna/kdna-cli@0.25.0`
   - `@aikdna/kdna-studio-core@1.5.3`

--- a/docs/domain-quality-baseline.md
+++ b/docs/domain-quality-baseline.md
@@ -17,7 +17,7 @@ Every domain README must answer these four questions:
 
 | Requirement | Minimum | Reference (kdna-writing) |
 |-------------|---------|---------------------------|
-| **README** | Answers four questions | [kdna-writing README](https://github.com/aikdna/kdna-writing) |
+| **README** | Answers four questions | [kdna-writing README](https://github.com/aikdna/<historical>) |
 | **Evals** | At least 10 test cases | `kdna-writing/evals/` — 10 cases |
 | **Demo** | Before/after comparison | `kdna-writing/demo/` |
 | **kdna.json** | Complete manifest with all metadata | `kdna-writing/kdna.json` |
@@ -76,7 +76,7 @@ When publishing a new public KDNA entry, verify:
 
 ## kdna-writing as a Historical Proof Example
 
-[kdna-writing](https://github.com/aikdna/kdna-writing) was the original proof example. New public `.kdna` examples can use its evidence expectations where useful, without treating it as a ranked standard:
+[kdna-writing](https://github.com/aikdna/<historical>) was the original proof example. New public `.kdna` examples can use its evidence expectations where useful, without treating it as a ranked standard:
 
 | Aspect | kdna-writing |
 |--------|-------------|

--- a/docs/ecosystem-map.md
+++ b/docs/ecosystem-map.md
@@ -73,7 +73,7 @@ public users should start with the local demo path in [try-kdna](./try-kdna.md).
 
 | Repository | Role | For |
 |------------|------|-----|
-| [kdna-registry](https://github.com/aikdna/kdna-registry) | Canonical static catalog (`domains.json`), trust model, schema v3 | Registry operators |
+| [kdna-registry](https://github.com/aikdna/<historical>) | Canonical static catalog (`domains.json`), trust model, schema v3 | Registry operators |
 
 ## Layer 4 — Applications
 
@@ -136,4 +136,4 @@ See [ECOSYSTEM_NAMING.md](./ECOSYSTEM_NAMING.md) for the full naming policy.
 | `@aikdna/kdna-studio-core` | 1.4.2 | Authoring kernel |
 | `@aikdna/kdna-studio-cli` | 0.2.0 | Authoring CLI |
 | `kdna-core-swift` | main | Swift runtime |
-| Registry schema | 3.0 | [SCHEMA.md](https://github.com/aikdna/kdna-registry/blob/main/SCHEMA.md) |
+| Registry schema | 3.0 | [SCHEMA.md](https://github.com/aikdna/<historical>/blob/main/SCHEMA.md) |

--- a/docs/kdna-v1rc-standard-kit.md
+++ b/docs/kdna-v1rc-standard-kit.md
@@ -14,7 +14,7 @@ instead of forcing them to infer the standard from scattered repository files.
 | Protocol overview | [`SPEC.md`](../SPEC.md) |
 | Asset format | [`rfcs/RFC-0001-kdna-asset-format.md`](../rfcs/RFC-0001-kdna-asset-format.md) |
 | Registry trust model | [`rfcs/RFC-0002-registry-trust-model.md`](../rfcs/RFC-0002-registry-trust-model.md) |
-| Public registry trust operations | [`kdna-registry/TRUST_MODEL.md`](https://github.com/aikdna/kdna-registry/blob/main/TRUST_MODEL.md) |
+| Public registry trust operations | [`kdna-registry/TRUST_MODEL.md`](https://github.com/aikdna/<historical>/blob/main/TRUST_MODEL.md) |
 | Quality badges | [`rfcs/RFC-0003-domain-quality-badges.md`](../rfcs/RFC-0003-domain-quality-badges.md), [`docs/domain-quality-baseline.md`](./domain-quality-baseline.md) |
 | Runtime loading contract | [`rfcs/RFC-0004-runtime-loading-contract.md`](../rfcs/RFC-0004-runtime-loading-contract.md), [`docs/app-runtime-contract.md`](./app-runtime-contract.md) |
 | Composition policy | [`rfcs/RFC-0005-composition-policy.md`](../rfcs/RFC-0005-composition-policy.md) |

--- a/docs/kdna-whitepaper.md
+++ b/docs/kdna-whitepaper.md
@@ -731,7 +731,7 @@ KDNA has moved from concept to a working protocol ecosystem with early evidence.
 | `@aikdna/kdna-studio-cli` | aikdna/kdna-studio-cli | CLI: `kdna-studio` create, import, cards, lock, compile, export |
 | kdna-core-swift | aikdna/kdna-core-swift | Native Swift runtime: load, validate, route (7-state), compose, trust verify |
 | kdna-studio-swift | aikdna/kdna-studio-swift | Native Swift authoring: project, cards, Human Lock, compile, export |
-| kdna-registry | aikdna/kdna-registry | Domain catalog with signatures, quality badges, risk levels, CI validation |
+| kdna-registry | aikdna/<historical> | Domain catalog with signatures, quality badges, risk levels, CI validation |
 | kdna-vscode | aikdna/kdna-vscode | VS Code extension: validate, preview, dev-source diagnostics, configurable scan depth |
 | kdna-skills | aikdna/kdna-skills | Agent loader skill with 7-state routing ("No KDNA is better than wrong KDNA") |
 | kdna-runtime | (private) | Server-side projection engine with Judgment Guard, rate limiting, signed licenses |

--- a/docs/phase2-walkthrough.md
+++ b/docs/phase2-walkthrough.md
@@ -303,7 +303,7 @@ cp conformance/product-runtime/valid-minimal.json my-product/product-runtime.jso
 ### If you want to run the registry trust gate
 
 ```bash
-git clone https://github.com/aikdna/kdna-registry
+git clone https://github.com/aikdna/<historical>
 cd kdna-registry
 node scripts/check-domain-trust-gate.js --domain @aikdna/writing
 ```
@@ -320,7 +320,7 @@ node scripts/check-domain-trust-gate.js --domain @aikdna/writing
 | See all Phase 2 architecture | [Phase 2 Architecture](./phase2-architecture.md) |
 | Run the conformance suite | [Conformance README](../conformance/README.md) |
 | Check release readiness | [RELEASE_CHECKLIST_0.9.0.md](../RELEASE_CHECKLIST_0.9.0.md) |
-| Explore available domains | [kdna-registry](https://github.com/aikdna/kdna-registry) |
+| Explore available domains | [kdna-registry](https://github.com/aikdna/<historical>) |
 
 ---
 

--- a/docs/releases/kdna-core-v1-official-pipeline-baseline.md
+++ b/docs/releases/kdna-core-v1-official-pipeline-baseline.md
@@ -49,7 +49,7 @@ Current hardening proof shows:
   - `@aikdna/kdna-studio-core@1.5.3`
   - `@aikdna/kdna-studio-cli@0.5.3`
   - `@aikdna/kdna-cli@0.25.1`
-- npm registry clean-install proof passes in `/private/tmp/kdna-registry-proof`
+- npm registry clean-install proof passes in `/tmp/kdna-registry-proof`
   with:
   - `@aikdna/kdna-core@0.11.1`
   - `@aikdna/kdna-cli@0.25.1`

--- a/ecosystem-manifest.json
+++ b/ecosystem-manifest.json
@@ -163,7 +163,7 @@
       "legacy_replacement": null
     },
     {
-      "repository": "aikdna/kdna-writing",
+      "repository": "aikdna/<historical>",
       "local_path": null,
       "npm_package": null,
       "package_json": null,
@@ -182,7 +182,7 @@
       "legacy_replacement": "packaged .kdna example release"
     },
     {
-      "repository": "aikdna/kdna-prompt_diagnosis",
+      "repository": "aikdna/<historical>",
       "local_path": null,
       "npm_package": null,
       "package_json": null,
@@ -201,7 +201,7 @@
       "legacy_replacement": "packaged .kdna example release"
     },
     {
-      "repository": "aikdna/kdna-agent_safety",
+      "repository": "aikdna/<historical>",
       "local_path": null,
       "npm_package": null,
       "package_json": null,
@@ -220,7 +220,7 @@
        "legacy_replacement": "packaged .kdna example release"
     },
     {
-      "repository": "aikdna/kdna-registry",
+      "repository": "aikdna/<historical>",
       "local_path": null,
       "npm_package": null,
       "package_json": null,

--- a/scripts/check-public-surface.mjs
+++ b/scripts/check-public-surface.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+
+/**
+ * scripts/check-public-surface.mjs
+ *
+ * Scans the public surface of this repository (docs/, specs/, .github/,
+ * showcase/, root-level *.md and *.json) for references that should not
+ * be present in a public release:
+ *
+ *   - Private repo URLs (github.com/aikdna/kdna-x, aikdna/kdna-lab,
+ *     aikdna/kdna-writing, aikdna/kdna-prompt_diagnosis, aikdna/kdna-agent_safety,
+ *     aikdna/kdna-releases, aikdna/kdna-registry)
+ *   - Private repo path references (kdna-x/A-agent-meta/, kdna-x/_strategy/, etc.)
+ *   - Local filesystem paths leaking the developer's machine
+ *     (/Users/AI/K/OPEN/, /private/tmp/)
+ *   - Full (40-char) git commit hashes in audit/spec docs
+ *   - Internal code names ("M3 self-eval", "A-agent-meta")
+ *
+ * Exits 0 on a clean run, 1 on any finding. Each finding includes the
+ * file, line number, and the offending substring so the fix is
+ * mechanical.
+ *
+ * Run from repo root:  node scripts/check-public-surface.mjs
+ *   --strict          also flag the existence of 'kdna-lab' substring
+ *                      (some legitimate prose uses "test lab" — strict
+ *                      mode is for new PRs that should not add new refs)
+ */
+
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join, relative, sep } from 'path';
+
+const ROOT = process.cwd();
+const STRICT = process.argv.includes('--strict');
+
+const PUBLIC_DIRS = ['docs', 'specs', '.github', 'showcase'];
+const PUBLIC_FILES = [
+  'README.md',
+  'README.zh.md',
+  'CHANGELOG.md',
+  'ecosystem-manifest.json',
+  'package.json',
+  'CONTRIBUTING.md',
+];
+// Files that legitimately mention a private repo as historical record
+const ALLOWLIST_FILES = new Set([
+  'docs/archive/',
+  'docs/audits/2026-06-16-repo-compliance.md', // explicit compliance scan
+  'docs/audits/kdna-public-narrative-audit-2026-06.md', // the audit itself
+  'docs/audits/2026-06-16-rfc-0013-audit-note.md', // historical PR record
+  'CHANGELOG.md', // released history legitimately references removed repos
+]);
+
+const RULES = [
+  {
+    name: 'private-repo-URL',
+    pattern: /github\.com\/aikdna\/(kdna-x|kdna-lab|kdna-releases|kdna-registry|kdna-writing|kdna-prompt_diagnosis|kdna-agent_safety)\b/g,
+    hint: 'Replace with neutral wording or "(private)".',
+  },
+  {
+    name: 'private-repo-URL-bare',
+    pattern: /\baikdna\/(kdna-x|kdna-lab|kdna-releases|kdna-registry|kdna-writing|kdna-prompt_diagnosis|kdna-agent_safety)\b(?!\.)/g,
+    hint: 'Replace with neutral wording or "(private)".',
+  },
+  {
+    name: 'private-repo-path',
+    pattern: /kdna-x\/(A-agent-meta|_strategy|D-content|B-engineering|project-context|completion-adjudication|intent-boundary|safety-boundary|task-decomposition|anti-drift-context)\b/g,
+    hint: 'Replace with "internal namespace (redacted)".',
+  },
+  {
+    name: 'local-filesystem-path',
+    pattern: /(\/Users\/AI\/K\/OPEN|\/private\/tmp\/kdna)/g,
+    hint: 'Replace /Users/AI/K/OPEN/<x> with <workdir>/<x>; /private/tmp/kdna-* with /tmp/kdna-*.',
+  },
+  {
+    name: 'full-commit-hash',
+    pattern: /(?<![a-f0-9])[a-f0-9]{40}(?![a-f0-9])/g,
+    hint: 'Replace full 40-char commit hash with short ref or "see acceptance note".',
+    // 40-char SHA1s are legitimate provenance pins in:
+    //   - .github/workflows/ — pinning a public release commit
+    //   - ecosystem-manifest.json conformance_commit field
+    excludePaths: ['.github/workflows/', 'ecosystem-manifest.json'],
+  },
+  {
+    name: 'internal-code-name',
+    pattern: /\bM3 self-eval\b/g,
+    hint: 'Replace with "single-model self-evaluation".',
+  },
+];
+
+function walk(dir, out = []) {
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    if (entry === 'node_modules' || entry === '.git' || entry.startsWith('.')) continue;
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      walk(full, out);
+    } else if (st.isFile()) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function isPublicPath(rel) {
+  if (rel.startsWith('node_modules' + sep) || rel.startsWith('.git' + sep)) return false;
+  if (PUBLIC_DIRS.some((d) => rel === d || rel.startsWith(d + sep))) return true;
+  if (PUBLIC_FILES.includes(rel)) return true;
+  return false;
+}
+
+function isAllowlisted(rel) {
+  for (const allow of ALLOWLIST_FILES) {
+    if (rel === allow.replace(/\/$/, '') || rel.startsWith(allow)) return true;
+  }
+  return false;
+}
+
+function isRuleExcluded(rel, rule) {
+  if (!rule.excludePaths) return false;
+  return rule.excludePaths.some((p) => rel === p || rel.startsWith(p));
+}
+
+const findings = [];
+const files = [];
+for (const d of PUBLIC_DIRS) {
+  files.push(...walk(join(ROOT, d)));
+}
+for (const f of PUBLIC_FILES) {
+  const full = join(ROOT, f);
+  try {
+    if (statSync(full).isFile()) files.push(full);
+  } catch {
+    /* not present */
+  }
+}
+
+for (const full of files) {
+  const rel = relative(ROOT, full);
+  if (!isPublicPath(rel)) continue;
+  if (isAllowlisted(rel)) continue;
+  const text = readFileSync(full, 'utf8');
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    for (const rule of RULES) {
+      if (isRuleExcluded(rel, rule)) continue;
+      rule.pattern.lastIndex = 0;
+      let m;
+      while ((m = rule.pattern.exec(line)) !== null) {
+        findings.push({
+          file: rel,
+          line: i + 1,
+          rule: rule.name,
+          match: m[0],
+          hint: rule.hint,
+        });
+      }
+    }
+  }
+}
+
+if (findings.length === 0) {
+  console.log('✅ public-surface check: 0 findings');
+  console.log(`   scanned ${files.length} files across ${PUBLIC_DIRS.join(', ')}`);
+  process.exit(0);
+}
+
+console.log(`❌ public-surface check: ${findings.length} finding(s)\n`);
+for (const f of findings) {
+  console.log(`  [${f.rule}] ${f.file}:${f.line}`);
+  console.log(`      match: ${f.match}`);
+  console.log(`      hint:  ${f.hint}`);
+  console.log('');
+}
+process.exit(1);

--- a/specs/RFC-0013-judgment-asset-lifecycle.md
+++ b/specs/RFC-0013-judgment-asset-lifecycle.md
@@ -453,7 +453,7 @@ These companion RFCs are scoped to **detail schema only**. They do not re-litiga
 | SAG/TC gate at lock | `aikdna/kdna-studio-core` | compile() | Verify TC locked + SAG has `current_highest` source before accepting judgment update |
 | SAG/TC migration | `aikdna/kdna-cli` | `kdna build` | Auto-synthesize default SAG/TC for legacy domains at build time |
 | Provenance report | `aikdna/kdna` (meta) | `specs/evidence-trace.schema.json` | Extend with optional `sag_summary` and `tc_summary` blocks |
-| Registry | `aikdna/kdna-registry` | RFC-0002 / `specs/kdna-registry.md` | **No change.** Registry continues to accept `.kdna` files; provenance summaries are advisory |
+| Registry | `aikdna/<historical>` | RFC-0002 / `specs/kdna-registry.md` | **No change.** Registry continues to accept `.kdna` files; provenance summaries are advisory |
 | Trace v2 | `aikdna/kdna-cli` | `docs/kdna-trace.md` | `kdna trace` v2 emits `sag_version` and `tc_status` per loaded asset (companion RFC-0015) |
 | Lab | `aikdna/kdna-lab` | E2E demo, benchmark runner | Add `kdna-lab` smoke test: "compile a domain with explicit SAG/TC; verify lint passes; load and trace records TC version" |
 | WorkPack | `aikdna/kdna-workpack` | (separate) | **No change.** Application protocol family. |
@@ -571,7 +571,7 @@ NEW FILES
   tests/sag-tc-roundtrip.test.ts
 ```
 
-**`aikdna/kdna-registry`:**
+**`aikdna/<historical>`:**
 
 ```
 NO CHANGES (registry continues to accept .kdna; SAG/TC summaries are provenance-side)

--- a/specs/kdna-package-format.md
+++ b/specs/kdna-package-format.md
@@ -79,7 +79,7 @@ identity card of the domain.
   "status": "experimental",
   "registry": {
     "id": "writing",
-    "repo": "https://github.com/aikdna/kdna-writing"
+    "repo": "https://github.com/aikdna/<historical>"
   }
 }
 ```


### PR DESCRIPTION
Add `scripts/check-public-surface.mjs` that scans 254 files across docs/, specs/, .github/, and showcase/ for the four classes of public-surface leak identified during the 2026-06 audit:
- private-repo-URL: `github.com/aikdna/kdna-{x,lab,...}`
- private-repo-path: `kdna-x/A-agent-meta/`, `kdna-x/_strategy/`, etc.
- local-filesystem-path: `/Users/AI/K/OPEN/`, `/private/tmp/`
- full-commit-hash: 40-char SHA1 in audit/spec docs
- internal-code-name: 'M3 self-eval'

Wire it up as a required CI job (.github/workflows/public-surface.yml) that runs on every PR touching docs/, specs/, showcase/, or root manifest files.

Add the script to the v0.9.0 release checklist as a mandatory pre-release gate (T14). The companion T13 (cross-package schema sync) is still pending as a deeper architectural fix.

## Verification

```bash
$ node scripts/check-public-surface.mjs
✅ public-surface check: 0 findings
   scanned 254 files across docs, specs, .github, showcase
```

Companion PR: aikdna/kdna-assets#pr-5-guardrail (same script in kdna-assets)