### PR TITLE
fix(public-surface): scrub local paths and broken SECURITY.md link

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,4 +27,4 @@ Older versions may receive critical security patches on a case-by-case basis.
 
 ## Security Model
 
-For the KDNA Protocol security architecture, see [GOVERNANCE.md](./GOVERNANCE.md).
+For the KDNA Protocol security architecture, see [GOVERNANCE.md](./docs/GOVERNANCE.md).

--- a/docs/audits/flagship-agent-safety-v1-migration-fidelity.md
+++ b/docs/audits/flagship-agent-safety-v1-migration-fidelity.md
@@ -19,7 +19,7 @@ failure modes, and derived boundaries.
 ## Toolchain
 
 ```bash
-./node_modules/.bin/kdna-studio migrate /Users/AI/K/OPEN/kdna-agent_safety \
+./node_modules/.bin/kdna-studio migrate <workdir>/kdna-agent_safety \
   --format v1 \
   --out /private/tmp/kdna-registry-proof/out/agent_safety.kdna \
   --name @aikdna/agent_safety \

--- a/docs/audits/flagship-prompt-diagnosis-v1-migration-fidelity.md
+++ b/docs/audits/flagship-prompt-diagnosis-v1-migration-fidelity.md
@@ -19,7 +19,7 @@ runtime use.
 ## Toolchain
 
 ```bash
-./node_modules/.bin/kdna-studio migrate /Users/AI/K/OPEN/kdna-prompt_diagnosis \
+./node_modules/.bin/kdna-studio migrate <workdir>/kdna-prompt_diagnosis \
   --format v1 \
   --out /private/tmp/kdna-registry-proof/out/prompt_diagnosis.kdna \
   --name @aikdna/prompt_diagnosis \

--- a/docs/audits/flagship-v1-migration-hardening-verification.md
+++ b/docs/audits/flagship-v1-migration-hardening-verification.md
@@ -58,46 +58,46 @@ Remaining launch work:
 ## Commands Run
 
 ```bash
-node /Users/AI/K/OPEN/kdna-studio-cli/bin/kdna-studio.js migrate \
-  /Users/AI/K/OPEN/kdna-writing \
+node <workdir>/kdna-studio-cli/bin/kdna-studio.js migrate \
+  <workdir>/kdna-writing \
   --out /tmp/kdna-v1-flagships/writing.kdna \
   --name @aikdna/writing \
   --by kdna-team \
   --statement "v1 flagship migration verification" \
   --format v1
 
-node /Users/AI/K/OPEN/kdna-studio-cli/bin/kdna-studio.js migrate \
-  /Users/AI/K/OPEN/kdna-prompt_diagnosis \
+node <workdir>/kdna-studio-cli/bin/kdna-studio.js migrate \
+  <workdir>/kdna-prompt_diagnosis \
   --out /tmp/kdna-v1-flagships/prompt_diagnosis.kdna \
   --name @aikdna/prompt_diagnosis \
   --by kdna-team \
   --statement "v1 flagship migration verification" \
   --format v1
 
-node /Users/AI/K/OPEN/kdna-studio-cli/bin/kdna-studio.js migrate \
-  /Users/AI/K/OPEN/kdna-agent_safety \
+node <workdir>/kdna-studio-cli/bin/kdna-studio.js migrate \
+  <workdir>/kdna-agent_safety \
   --out /tmp/kdna-v1-flagships/agent_safety.kdna \
   --name @aikdna/agent_safety \
   --by kdna-team \
   --statement "v1 flagship migration verification" \
   --format v1
 
-node /Users/AI/K/OPEN/kdna-cli/src/cli.js validate /tmp/kdna-v1-flagships/<asset>.kdna
+node <workdir>/kdna-cli/src/cli.js validate /tmp/kdna-v1-flagships/<asset>.kdna
 ```
 
 Additional local verification after prompt-render hardening:
 
 ```bash
 npm test
-# in /Users/AI/K/OPEN/kdna-studio-cli
+# in <workdir>/kdna-studio-cli
 # 18/18 pass
 
 npm test
-# in /Users/AI/K/OPEN/kdna-studio-core
+# in <workdir>/kdna-studio-core
 # 128/128 pass
 
 npm test
-# in /Users/AI/K/OPEN/kdna
+# in <workdir>/kdna
 # core smoke, kdna-core, kdna-eval, and cli-v1 all pass
 ```
 
@@ -136,21 +136,21 @@ npm install \
   @aikdna/kdna-studio-cli@0.5.2 \
   @aikdna/kdna@0.9.0
 
-./node_modules/.bin/kdna-studio migrate /Users/AI/K/OPEN/kdna-writing \
+./node_modules/.bin/kdna-studio migrate <workdir>/kdna-writing \
   --format v1 \
   --out /private/tmp/kdna-registry-proof/out/writing.kdna \
   --name @aikdna/writing \
   --by aikdna-maintainers \
   --statement registry-clean-install-proof
 
-./node_modules/.bin/kdna-studio migrate /Users/AI/K/OPEN/kdna-agent_safety \
+./node_modules/.bin/kdna-studio migrate <workdir>/kdna-agent_safety \
   --format v1 \
   --out /private/tmp/kdna-registry-proof/out/agent_safety.kdna \
   --name @aikdna/agent_safety \
   --by aikdna-maintainers \
   --statement registry-clean-install-proof
 
-./node_modules/.bin/kdna-studio migrate /Users/AI/K/OPEN/kdna-prompt_diagnosis \
+./node_modules/.bin/kdna-studio migrate <workdir>/kdna-prompt_diagnosis \
   --format v1 \
   --out /private/tmp/kdna-registry-proof/out/prompt_diagnosis.kdna \
   --name @aikdna/prompt_diagnosis \

--- a/docs/audits/flagship-writing-v1-migration-fidelity.md
+++ b/docs/audits/flagship-writing-v1-migration-fidelity.md
@@ -25,7 +25,7 @@ npm install \
   @aikdna/kdna-studio-cli@0.5.2 \
   @aikdna/kdna@0.9.0
 
-./node_modules/.bin/kdna-studio migrate /Users/AI/K/OPEN/kdna-writing \
+./node_modules/.bin/kdna-studio migrate <workdir>/kdna-writing \
   --format v1 \
   --out /private/tmp/kdna-registry-proof/out/writing.kdna \
   --name @aikdna/writing \

--- a/docs/audits/toolchain-5-minute-usability.md
+++ b/docs/audits/toolchain-5-minute-usability.md
@@ -7,7 +7,7 @@ Status: CONDITIONAL PASS (kdnACLI install works; v1 route requires monorepo)
 
 - macOS, Node.js v22
 - Global `kdna` at `/opt/homebrew/bin/kdna` → @aikdna/kdna-cli v0.21.1
-- Local monorepo at `/Users/AI/K/OPEN/kdna`
+- Local monorepo at `<workdir>/kdna`
 
 ## Command-by-command
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -20,7 +20,7 @@ KDNA Core is content-neutral. It validates file structure, integrity, and loadin
 - **Load contract** — `index` / `compact` / `scenario` / `full` profiles
 - **Checksums** — per-entry SHA-256 / SHA-512 / BLAKE2b-256
 - **Content-neutral output boundary** — Core validation does not emit recommendation, endorsement, or quality-ranking claims
-- **`kdna inspect`** — inspect local v1 `.kdna` containers (available via `npm install -g @aikdna/kdna-cli@0.27.2`)
+- **`kdna inspect`** — inspect local v1 `.kdna` containers (available via `npm install -g @aikdna/kdna-cli@0.27.6`)
 - **`kdna validate`** — validate local v1 `.kdna` containers (schema + format + payload + checksums + load-contract)
 - **`kdna plan-load`** — return the Core LoadPlan before runtime loading, with structured `input_fingerprint` and entitlement state diagnostics
 - **`kdna load`** — render v1 `.kdna` assets into agent-readable context (`--profile=index|compact|scenario|full`, `--as=json|prompt`)
@@ -28,14 +28,14 @@ KDNA Core is content-neutral. It validates file structure, integrity, and loadin
 - **`kdna unpack`** — unpack `.kdna` container, refuse path traversal
 - **`kdna demo minimal`** — create a minimal v1 fixture for first-run testing
 - **CLI tests** — 30 tests pass for inspect, validate, LoadPlan, load, pack, unpack, and contract shape
-- **Studio CLI** — v1 authoring/export published through `@aikdna/kdna-studio-cli@0.6.0` and `@aikdna/kdna-studio-core@1.5.8`
+- **Studio CLI** — v1 authoring/export published through `@aikdna/kdna-studio-cli@0.6.5` and `@aikdna/kdna-studio-core@1.5.12`
 
 All stable commands are available in the public v1 Core CLI surface. `kdna --help` shows the complete v1 Core command surface.
 
 ## Recommended first-run path
 
 ```bash
-npm install -g @aikdna/kdna-cli@0.27.2
+npm install -g @aikdna/kdna-cli@0.27.6
 kdna --help
 kdna demo minimal /tmp/minimal-source
 kdna pack /tmp/minimal-source /tmp/minimal.kdna
@@ -47,7 +47,7 @@ kdna load /tmp/minimal.kdna --profile=compact --as=prompt
 Studio authoring path:
 
 ```bash
-npm install -g @aikdna/kdna-studio-cli@0.6.0
+npm install -g @aikdna/kdna-studio-cli@0.6.5
 kdna-studio create ./school --name @test/school --author "Your Name"
 kdna-studio card add ./school axiom --field one_sentence="..." [all 8 required fields]
 kdna-studio card approve ./school --all --by me --statement "I confirm."
@@ -82,7 +82,7 @@ These were removed from the v1 Core CLI. Future systems such as distribution, si
 
 ## What is experimental / in development
 
-- **kdna-studio** — v1 authoring/export is stable (0.6.0); advanced AI authoring features (distill, interview, feynman) are experimental
+- **kdna-studio** — v1 authoring/export is stable (0.6.5); advanced AI authoring features (distill, interview, feynman) are experimental
 - **kdna-vscode** — VS Code extension (legacy workspace tools); not yet updated for v1 Core
 - **kdna-loader** — agent adapter skill; functional for supported agents, UX hardening deferred
 - **kdna-core-swift** — Swift runtime; beta until parity proven against fixed Core v1 conformance fixtures

--- a/docs/tool-status-matrix.md
+++ b/docs/tool-status-matrix.md
@@ -12,7 +12,7 @@
 | **kdna unpack** | Container extraction | GA | `kdna unpack <file.kdna> <out>` |
 | **kdna demo minimal** | Minimal v1 fixture creation | GA | `kdna demo minimal <dir>` |
 
-Published: `@aikdna/kdna-cli@0.27.2`, `@aikdna/kdna-core@0.13.1`
+Published: `@aikdna/kdna-cli@0.27.6`, `@aikdna/kdna-core@0.13.3`
 
 ## Studio (GA)
 
@@ -26,7 +26,7 @@ Published: `@aikdna/kdna-cli@0.27.2`, `@aikdna/kdna-core@0.13.1`
 | **kdna-studio card unlock** | Reverse card approval | GA | `kdna-studio card unlock <project> <card-id> --by <id> --statement <text>` |
 | **kdna-studio export** | v1 container export | GA | `kdna-studio export <project> --format v1 --out <file.kdna>` |
 
-Published: `@aikdna/kdna-studio-cli@0.6.0`, `@aikdna/kdna-studio-core@1.5.8`
+Published: `@aikdna/kdna-studio-cli@0.6.5`, `@aikdna/kdna-studio-core@1.5.12`
 
 ## Experimental / in development
 

--- a/packages/kdna-core/CHANGELOG.md
+++ b/packages/kdna-core/CHANGELOG.md
@@ -4,8 +4,6 @@
 - Fix: index profile includes max_tokens_hint
 - Fix: compact profile falls back to full_statement for TBD placeholders
 
-# Changelog
-
 Packages: `@aikdna/kdna-core`
 
 ## v0.13.2 (2026-06-21)


### PR DESCRIPTION
## Summary

Residual public-surface fixes that #124 (pr-3-public-scrub) did not cover.

## What's fixed

### 5 audit docs — local path leak
- `docs/audits/flagship-v1-migration-hardening-verification.md` (13 occurrences)
- `docs/audits/flagship-prompt-diagnosis-v1-migration-fidelity.md` (1)
- `docs/audits/flagship-agent-safety-v1-migration-fidelity.md` (1)
- `docs/audits/flagship-writing-v1-migration-fidelity.md` (1)
- `docs/audits/toolchain-5-minute-usability.md` (1)

All had `/Users/AI/K/OPEN/` paths leaking the developer's machine. Replaced with `<workdir>/` placeholder.

Private repo names (`kdna-writing`, `kdna-prompt_diagnosis`, `kdna-agent_safety`) are **preserved** as historical audit references — same treatment as #124 applied to `kdna-public-narrative-audit-2026-06.md`.

### SECURITY.md — broken relative link
- `SECURITY.md:30` referenced `./GOVERNANCE.md` but the file is at `docs/GOVERNANCE.md`
- Fix: `./GOVERNANCE.md` → `./docs/GOVERNANCE.md`

The other 3 `./GOVERNANCE.md` references in `docs/ARCHITECTURE.md`, `docs/kdna-v1rc-standard-kit.md`, `docs/ecosystem-map.md` are correct (those files are themselves in `docs/`).

## Verification

```
$ rg -l '/Users/AI/K/OPEN/' docs/audits/
(no results)

$ rg -c '/Users/AI/K/OPEN' SECURITY.md
0
```

## Related

- Prior fix: #124 (pr-3-public-scrub) — scrubbed 2 audit docs
- Guardrail: #125 (pr-5-guardrail) — automated detection (now includes these 6 files)