### PR TITLE
chore: bump kdna-core to 0.14.0

### DIFF
--- a/packages/kdna-core/package.json
+++ b/packages/kdna-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aikdna/kdna-core",
-  "version": "0.13.3",
+  "version": "0.14.0",
   "description": "KDNA Core library for validating, planning, and loading local .kdna judgment assets.",
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
Version bump to 0.14.0 to publish B1+B4+B8+W4 from #129.

Includes:
- B1: unified container dispatcher
- B4: loadAuthorized decryption orchestration
- B8: golden vectors (8/8)
- Wave 4: canonical conformance (13/13)

Needed to unblock kdna-cli #47 (e2e tests need decryptProtectedEntry in published core).