### PR TITLE
feat: add canonical conformance script (0.28.0 threshold #8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "validate:rfc0013-schemas": "node scripts/validate-rfc0013-schemas.js",
     "test": "npm --workspace @aikdna/kdna-core test && npm --workspace @aikdna/kdna-eval test && node scripts/run-node-tests.js tests/cli-v1/*.test.js",
     "conformance": "node conformance/run.mjs",
+    "conformance:canonical": "node --test conformance/canonical-conformance.mjs",
     "conformance:phase2": "node conformance/run.mjs --profile phase2-protocol",
     "conformance:authorization:update": "node scripts/generate-authorization-conformance.mjs",
     "certify:asset-loader": "node conformance/run.mjs --profile asset-loader",

--- a/packages/kdna-core/package.json
+++ b/packages/kdna-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aikdna/kdna-core",
-  "version": "0.13.3",
+  "version": "0.14.0",
   "description": "KDNA Core library for validating, planning, and loading local .kdna judgment assets.",
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
Wave 4 delivered 13/13 canonical conformance tests in conformance/canonical-conformance.mjs. This PR adds the `conformance:canonical` npm script to run them alongside the legacy run.mjs.

`npm run conformance:canonical` → 13/13 (protocol + access + negative + integration)