### PR TITLE
fix(scrub): replace /Users/AI/K/OPEN/ and /private/tmp/ paths in audit docs

### DIFF
--- a/docs/audits/flagship-agent-safety-v1-migration-fidelity.md
+++ b/docs/audits/flagship-agent-safety-v1-migration-fidelity.md
@@ -14,14 +14,14 @@ failure modes, and derived boundaries.
 - Source repo: `kdna-agent_safety`
 - Source package name: `@aikdna/agent_safety`
 - v1 asset ID: `kdna:aikdna:agent_safety`
-- Output container: `/private/tmp/kdna-registry-proof/out/agent_safety.kdna`
+- Output container: `/tmp/kdna-registry-proof/out/agent_safety.kdna`
 
 ## Toolchain
 
 ```bash
-./node_modules/.bin/kdna-studio migrate /Users/AI/K/OPEN/kdna-agent_safety \
+./node_modules/.bin/kdna-studio migrate <workdir>/kdna-agent_safety \
   --format v1 \
-  --out /private/tmp/kdna-registry-proof/out/agent_safety.kdna \
+  --out /tmp/kdna-registry-proof/out/agent_safety.kdna \
   --name @aikdna/agent_safety \
   --by aikdna-maintainers \
   --statement registry-clean-install-proof
@@ -37,7 +37,7 @@ Public npm packages used:
 
 ## Validation
 
-`kdna validate /private/tmp/kdna-registry-proof/out/agent_safety.kdna` returned:
+`kdna validate /tmp/kdna-registry-proof/out/agent_safety.kdna` returned:
 
 ```json
 {

--- a/docs/audits/flagship-prompt-diagnosis-v1-migration-fidelity.md
+++ b/docs/audits/flagship-prompt-diagnosis-v1-migration-fidelity.md
@@ -14,14 +14,14 @@ runtime use.
 - Source repo: `kdna-prompt_diagnosis`
 - Source package name: `@aikdna/prompt_diagnosis`
 - v1 asset ID: `kdna:aikdna:prompt_diagnosis`
-- Output container: `/private/tmp/kdna-registry-proof/out/prompt_diagnosis.kdna`
+- Output container: `/tmp/kdna-registry-proof/out/prompt_diagnosis.kdna`
 
 ## Toolchain
 
 ```bash
-./node_modules/.bin/kdna-studio migrate /Users/AI/K/OPEN/kdna-prompt_diagnosis \
+./node_modules/.bin/kdna-studio migrate <workdir>/kdna-prompt_diagnosis \
   --format v1 \
-  --out /private/tmp/kdna-registry-proof/out/prompt_diagnosis.kdna \
+  --out /tmp/kdna-registry-proof/out/prompt_diagnosis.kdna \
   --name @aikdna/prompt_diagnosis \
   --by aikdna-maintainers \
   --statement registry-clean-install-proof
@@ -37,7 +37,7 @@ Public npm packages used:
 
 ## Validation
 
-`kdna validate /private/tmp/kdna-registry-proof/out/prompt_diagnosis.kdna`
+`kdna validate /tmp/kdna-registry-proof/out/prompt_diagnosis.kdna`
 returned:
 
 ```json

--- a/docs/audits/flagship-v1-migration-blocker-summary.md
+++ b/docs/audits/flagship-v1-migration-blocker-summary.md
@@ -25,7 +25,7 @@ Studio v1 export path, but they are no longer the current launch verdict.
 - `@aikdna/kdna-studio-cli@0.5.2`
 - `@aikdna/kdna@0.9.0`
 
-Proof directory: `/private/tmp/kdna-registry-proof`
+Proof directory: `/tmp/kdna-registry-proof`
 
 ## Current Flagship Results
 

--- a/docs/audits/flagship-v1-migration-hardening-verification.md
+++ b/docs/audits/flagship-v1-migration-hardening-verification.md
@@ -41,8 +41,8 @@ with:
   `[object Object]`
 
 This is now backed by source-tree verification, a local tarball clean-install
-proof from `/private/tmp/kdna-clean-proof-2`, and an npm-registry clean-install
-proof from `/private/tmp/kdna-registry-proof`.
+proof from `/tmp/kdna-clean-proof-2`, and an npm-registry clean-install
+proof from `/tmp/kdna-registry-proof`.
 
 It is still **not final public-launch proof** until final per-asset PASS reports,
 README/release artifacts, MCP package evidence, website/docs reconciliation, and
@@ -58,61 +58,61 @@ Remaining launch work:
 ## Commands Run
 
 ```bash
-node /Users/AI/K/OPEN/kdna-studio-cli/bin/kdna-studio.js migrate \
-  /Users/AI/K/OPEN/kdna-writing \
+node <workdir>/kdna-studio-cli/bin/kdna-studio.js migrate \
+  <workdir>/kdna-writing \
   --out /tmp/kdna-v1-flagships/writing.kdna \
   --name @aikdna/writing \
   --by kdna-team \
   --statement "v1 flagship migration verification" \
   --format v1
 
-node /Users/AI/K/OPEN/kdna-studio-cli/bin/kdna-studio.js migrate \
-  /Users/AI/K/OPEN/kdna-prompt_diagnosis \
+node <workdir>/kdna-studio-cli/bin/kdna-studio.js migrate \
+  <workdir>/kdna-prompt_diagnosis \
   --out /tmp/kdna-v1-flagships/prompt_diagnosis.kdna \
   --name @aikdna/prompt_diagnosis \
   --by kdna-team \
   --statement "v1 flagship migration verification" \
   --format v1
 
-node /Users/AI/K/OPEN/kdna-studio-cli/bin/kdna-studio.js migrate \
-  /Users/AI/K/OPEN/kdna-agent_safety \
+node <workdir>/kdna-studio-cli/bin/kdna-studio.js migrate \
+  <workdir>/kdna-agent_safety \
   --out /tmp/kdna-v1-flagships/agent_safety.kdna \
   --name @aikdna/agent_safety \
   --by kdna-team \
   --statement "v1 flagship migration verification" \
   --format v1
 
-node /Users/AI/K/OPEN/kdna-cli/src/cli.js validate /tmp/kdna-v1-flagships/<asset>.kdna
+node <workdir>/kdna-cli/src/cli.js validate /tmp/kdna-v1-flagships/<asset>.kdna
 ```
 
 Additional local verification after prompt-render hardening:
 
 ```bash
 npm test
-# in /Users/AI/K/OPEN/kdna-studio-cli
+# in <workdir>/kdna-studio-cli
 # 18/18 pass
 
 npm test
-# in /Users/AI/K/OPEN/kdna-studio-core
+# in <workdir>/kdna-studio-core
 # 128/128 pass
 
 npm test
-# in /Users/AI/K/OPEN/kdna
+# in <workdir>/kdna
 # core smoke, kdna-core, kdna-eval, and cli-v1 all pass
 ```
 
 Local tarball clean-install proof:
 
 ```bash
-npm pack --pack-destination /private/tmp/kdna-pack-proof-2
+npm pack --pack-destination /tmp/kdna-pack-proof-2
 # @aikdna/kdna-core@0.11.1
 # @aikdna/kdna-studio-core@1.5.3
 # @aikdna/kdna-studio-cli@0.5.2
 
 npm install \
-  /private/tmp/kdna-pack-proof-2/aikdna-kdna-core-0.11.1.tgz \
-  /private/tmp/kdna-pack-proof-2/aikdna-kdna-studio-core-1.5.3.tgz \
-  /private/tmp/kdna-pack-proof-2/aikdna-kdna-studio-cli-0.5.2.tgz \
+  /tmp/kdna-pack-proof-2/aikdna-kdna-core-0.11.1.tgz \
+  /tmp/kdna-pack-proof-2/aikdna-kdna-studio-core-1.5.3.tgz \
+  /tmp/kdna-pack-proof-2/aikdna-kdna-studio-cli-0.5.2.tgz \
   @aikdna/kdna-cli@0.25.0
 
 ./node_modules/.bin/kdna-studio migrate <flagship-source> --format v1 --out <asset.kdna>
@@ -127,7 +127,7 @@ as readable compact prompts, and exposed non-empty `core.boundaries`.
 Npm registry clean-install proof:
 
 ```bash
-cd /private/tmp/kdna-registry-proof
+cd /tmp/kdna-registry-proof
 npm init -y
 npm install \
   @aikdna/kdna-core@0.11.1 \
@@ -136,30 +136,30 @@ npm install \
   @aikdna/kdna-studio-cli@0.5.2 \
   @aikdna/kdna@0.9.0
 
-./node_modules/.bin/kdna-studio migrate /Users/AI/K/OPEN/kdna-writing \
+./node_modules/.bin/kdna-studio migrate <workdir>/kdna-writing \
   --format v1 \
-  --out /private/tmp/kdna-registry-proof/out/writing.kdna \
+  --out /tmp/kdna-registry-proof/out/writing.kdna \
   --name @aikdna/writing \
   --by aikdna-maintainers \
   --statement registry-clean-install-proof
 
-./node_modules/.bin/kdna-studio migrate /Users/AI/K/OPEN/kdna-agent_safety \
+./node_modules/.bin/kdna-studio migrate <workdir>/kdna-agent_safety \
   --format v1 \
-  --out /private/tmp/kdna-registry-proof/out/agent_safety.kdna \
+  --out /tmp/kdna-registry-proof/out/agent_safety.kdna \
   --name @aikdna/agent_safety \
   --by aikdna-maintainers \
   --statement registry-clean-install-proof
 
-./node_modules/.bin/kdna-studio migrate /Users/AI/K/OPEN/kdna-prompt_diagnosis \
+./node_modules/.bin/kdna-studio migrate <workdir>/kdna-prompt_diagnosis \
   --format v1 \
-  --out /private/tmp/kdna-registry-proof/out/prompt_diagnosis.kdna \
+  --out /tmp/kdna-registry-proof/out/prompt_diagnosis.kdna \
   --name @aikdna/prompt_diagnosis \
   --by aikdna-maintainers \
   --statement registry-clean-install-proof
 
-./node_modules/.bin/kdna validate /private/tmp/kdna-registry-proof/out/<asset>.kdna
-./node_modules/.bin/kdna load /private/tmp/kdna-registry-proof/out/<asset>.kdna --profile=compact --as=prompt
-./node_modules/.bin/kdna load /private/tmp/kdna-registry-proof/out/<asset>.kdna --profile=full --as=json
+./node_modules/.bin/kdna validate /tmp/kdna-registry-proof/out/<asset>.kdna
+./node_modules/.bin/kdna load /tmp/kdna-registry-proof/out/<asset>.kdna --profile=compact --as=prompt
+./node_modules/.bin/kdna load /tmp/kdna-registry-proof/out/<asset>.kdna --profile=full --as=json
 ```
 
 Result: `writing`, `agent_safety`, and `prompt_diagnosis` all exported from

--- a/docs/audits/flagship-writing-v1-migration-fidelity.md
+++ b/docs/audits/flagship-writing-v1-migration-fidelity.md
@@ -6,14 +6,14 @@
 
 This report supersedes the pre-hardening failure report that recorded the old
 Studio v1 export retaining only axiom one-liners. Current evidence comes from
-public npm packages installed in `/private/tmp/kdna-registry-proof`.
+public npm packages installed in `/tmp/kdna-registry-proof`.
 
 ## Asset
 
 - Source repo: `kdna-writing`
 - Source package name: `@aikdna/writing`
 - v1 asset ID: `kdna:aikdna:writing`
-- Output container: `/private/tmp/kdna-registry-proof/out/writing.kdna`
+- Output container: `/tmp/kdna-registry-proof/out/writing.kdna`
 
 ## Toolchain
 
@@ -25,9 +25,9 @@ npm install \
   @aikdna/kdna-studio-cli@0.5.2 \
   @aikdna/kdna@0.9.0
 
-./node_modules/.bin/kdna-studio migrate /Users/AI/K/OPEN/kdna-writing \
+./node_modules/.bin/kdna-studio migrate <workdir>/kdna-writing \
   --format v1 \
-  --out /private/tmp/kdna-registry-proof/out/writing.kdna \
+  --out /tmp/kdna-registry-proof/out/writing.kdna \
   --name @aikdna/writing \
   --by aikdna-maintainers \
   --statement registry-clean-install-proof
@@ -35,7 +35,7 @@ npm install \
 
 ## Validation
 
-`kdna validate /private/tmp/kdna-registry-proof/out/writing.kdna` returned:
+`kdna validate /tmp/kdna-registry-proof/out/writing.kdna` returned:
 
 ```json
 {

--- a/docs/audits/studio-export-e2e-status.md
+++ b/docs/audits/studio-export-e2e-status.md
@@ -54,9 +54,9 @@ kdna load asset.kdna --profile=compact --as=prompt
 - `kdna-studio-cli npm test`: 18/18 pass.
 - `kdna-studio-core npm test`: 128/128 pass.
 - `kdna npm test`: pass.
-- Local tarball clean install in `/private/tmp/kdna-clean-proof-2` passes for:
+- Local tarball clean install in `/tmp/kdna-clean-proof-2` passes for:
   `writing`, `agent_safety`, and `prompt_diagnosis`.
-- npm registry clean install in `/private/tmp/kdna-registry-proof` passes with:
+- npm registry clean install in `/tmp/kdna-registry-proof` passes with:
   - `@aikdna/kdna-core@0.11.1`
   - `@aikdna/kdna-cli@0.25.0`
   - `@aikdna/kdna-studio-core@1.5.3`

--- a/docs/audits/toolchain-5-minute-usability.md
+++ b/docs/audits/toolchain-5-minute-usability.md
@@ -7,7 +7,7 @@ Status: CONDITIONAL PASS (kdnACLI install works; v1 route requires monorepo)
 
 - macOS, Node.js v22
 - Global `kdna` at `/opt/homebrew/bin/kdna` → @aikdna/kdna-cli v0.21.1
-- Local monorepo at `/Users/AI/K/OPEN/kdna`
+- Local monorepo at `<workdir>/kdna`
 
 ## Command-by-command
 

--- a/docs/releases/kdna-core-v1-official-pipeline-baseline.md
+++ b/docs/releases/kdna-core-v1-official-pipeline-baseline.md
@@ -49,7 +49,7 @@ Current hardening proof shows:
   - `@aikdna/kdna-studio-core@1.5.3`
   - `@aikdna/kdna-studio-cli@0.5.3`
   - `@aikdna/kdna-cli@0.25.1`
-- npm registry clean-install proof passes in `/private/tmp/kdna-registry-proof`
+- npm registry clean-install proof passes in `/tmp/kdna-registry-proof`
   with:
   - `@aikdna/kdna-core@0.11.1`
   - `@aikdna/kdna-cli@0.25.1`


### PR DESCRIPTION
附录 I L8/L9 from 17号: 7 audit/release docs contained real internal paths (developer's macOS machine name 'AI', work directory 'K/OPEN', and macOS default TMPDIR).

Replaces:
- /Users/AI/K/OPEN/<x> → <workdir>/<x>
- /private/tmp/kdna-* → /tmp/kdna-*

No semantic change — these paths are only cited in audit methodology footnotes.