### PR TITLE
feat(core): v0.15.8 — RAG namespace isolation (Story 11)

### DIFF
--- a/packages/kdna-core/CHANGELOG.md
+++ b/packages/kdna-core/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## v0.15.8 (2026-06-28)
+
+Story 11 — RAG namespace isolation (RFC #148 v2.x Phase 3).
+
+- **`rag_namespace`** field added to each entry in `resolved_dependencies`.
+  Format: `name@version` (or bare `name` when version is absent). Provides a
+  stable scoped identifier for per-component namespace isolation.
+- **`rag_isolation_policy`** object added to load output when
+  `resolved_dependencies` is non-empty:
+  `{ default: "fenced", cross_namespace_blocked: true, namespaces: [...] }`.
+  Consumers MUST NOT mix content across namespaces without explicit permission.
+- **`--as=prompt` namespace header**: each component section in multi-asset
+  prompt output is now prefixed with `[NAMESPACE: name@version]` so RAG
+  systems can attribute and isolate content per source component (per SPEC
+  §13.8 source attribution).
+- No breaking changes to existing single-asset load output or to
+  `resolved_dependencies` shape (fields are additive only).
+
 ## v0.15.7 (2026-06-28)
 
 Story 6 — dependencies runtime. Supports semver-matching local/registry dependency resolution and topological sort-based loading order.

--- a/packages/kdna-core/package.json
+++ b/packages/kdna-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aikdna/kdna-core",
-  "version": "0.15.7",
+  "version": "0.15.8",
   "description": "KDNA Core library for validating, planning, and loading local .kdna judgment assets.",
   "engines": {
     "node": ">=18.0.0"

--- a/packages/kdna-core/src/v1/index.js
+++ b/packages/kdna-core/src/v1/index.js
@@ -1844,18 +1844,36 @@ function loadV1Unsafe(inputPath, opts = {}) {
     throw new Error(`unknown load profile: ${profile}`);
   }
 
-  if (opts.resolvedDependencies && opts.resolvedDependencies.length > 0) {
+   if (opts.resolvedDependencies && opts.resolvedDependencies.length > 0) {
     result.resolved_dependencies = opts.resolvedDependencies.map(dep => {
       const depLoaded = loadV1Unsafe(dep.path, { ...opts, resolvedDependencies: [] });
+      // RAG namespace (Story 11): scoped identifier for namespace isolation.
+      // Format: name@version (or just name when version is absent).
+      const ragNamespace = dep.name
+        ? (dep.version ? `${dep.name}@${dep.version}` : dep.name)
+        : null;
       return {
         name: dep.name,
         version: dep.version,
         path: dep.path,
+        rag_namespace: ragNamespace,
         status: depLoaded.status,
         profile: depLoaded.profile,
         content: depLoaded.content
       };
     });
+
+    // RAG isolation policy (Story 11): consumers MUST NOT mix content
+    // across namespaces without explicit permission. cross_namespace_blocked
+    // is the default; a consumer may opt in to cross-namespace access by
+    // setting its own policy, but Core never does it silently.
+    result.rag_isolation_policy = {
+      default: 'fenced',
+      cross_namespace_blocked: true,
+      namespaces: result.resolved_dependencies
+        .map(d => d.rag_namespace)
+        .filter(Boolean),
+    };
   }
 
   if (as === 'prompt') {
@@ -1887,7 +1905,13 @@ function loadV1Unsafe(inputPath, opts = {}) {
       for (const dep of opts.resolvedDependencies) {
         const depLoaded = loadV1Unsafe(dep.path, { ...opts, resolvedDependencies: [] });
         if (depLoaded.text) {
-          textOut += '\n\n---\n\n' + depLoaded.text;
+          // Namespace header (Story 11): each component section is prefixed
+          // with [NAMESPACE: id] so consumers can isolate RAG content per source.
+          const ns = dep.name
+            ? (dep.version ? `${dep.name}@${dep.version}` : dep.name)
+            : null;
+          const nsHeader = ns ? `[NAMESPACE: ${ns}]\n` : '';
+          textOut += '\n\n---\n\n' + nsHeader + depLoaded.text;
         }
       }
     }


### PR DESCRIPTION
Adds rag_namespace + rag_isolation_policy to Bundle load output. Each resolved dependency gets a scoped namespace identifier. --as=prompt sections prefixed with [NAMESPACE: id] per SPEC §13.8. Closes roadmap-2026.md Story 11.