### PR TITLE
Story 17 — RFC-0018 kdna-envelope-aead-v1 envelope profile freeze

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -608,6 +608,25 @@ KDNA MUST NOT replace these systems. It provides a judgment layer that operates 
 - The `kdna.json` manifest MUST NOT contain secrets or API keys.
 - Loaders SHOULD validate JSON before parsing to prevent injection.
 
+### 11.1 Encryption profile layering
+
+Encrypted KDNA assets use one of three profile IDs. Each profile is
+independent and MUST NOT silently cross-migrate. The non-collapse
+invariant (RFC-0018 R4.3) applies to all three.
+
+| Profile ID | RFC | Algorithm | KDF | Required support |
+|------------|-----|-----------|-----|------------------|
+| `kdna-licensed-entry-v1` | RFC-0008 | AES-256-GCM, AES-256-KW | HKDF-SHA256 | Mandatory (compat path) |
+| `kdna-password-protected-v1` | RFC-0009 | AES-256-GCM, AES-256-KW | Argon2id | Optional (compat path) |
+| `kdna-envelope-aead-v1` | **RFC-0018** (frozen 2026-06-28) | AES-256-GCM, AES-256-KW | `scrypt-sha256-v1` (mandatory) or `argon2id-v1` (optional v2, Node.js only) | Mandatory for new exports |
+
+The `kdna-envelope-aead-v1` profile is the canonical target for new
+product-facing exports. Test vectors are at
+`conformance/kdna-envelope-aead-v1/`. A Swift port that does not
+implement Argon2id MUST either fall back to the next slot's
+`scrypt-sha256-v1` KDF or fail with `KDNA_KDF_UNSUPPORTED` (RFC-0018
+R6). There is no silent fall-through.
+
 ## 12. Version Policy
 
 - KDNA v1.0 tools implement the v1.0 schema and media type.

--- a/conformance/kdna-envelope-aead-v1.mjs
+++ b/conformance/kdna-envelope-aead-v1.mjs
@@ -1,0 +1,360 @@
+/**
+ * kdna-envelope-aead-v1.mjs — Conformance runner (Story 17 / RFC-0018)
+ *
+ * Re-derives the three frozen test vectors under
+ * `conformance/kdna-envelope-aead-v1/` from their declared inputs
+ * and asserts equality with the declared expected outputs. This is
+ * the canonical "is this implementation correct?" check for
+ * `kdna-envelope-aead-v1`.
+ *
+ * Vector inventory:
+ *   01 — scrypt-sha256-v1 basic round-trip
+ *   02 — scrypt-sha256-v1 multi-entry AAD binding
+ *   03 — argon2id-v1 basic round-trip
+ *
+ * Each vector is a self-contained JSON file with:
+ *   - `id`, `description`
+ *   - `inputs` (password, salt, iv, cek, plaintext, aad, kdf_params)
+ *   - `expected.kek` (base64)
+ *   - `expected.envelope` (or `envelope_entry_1` / `envelope_entry_2`
+ *     for the multi-entry case)
+ *   - `expected.ciphertext_entry_1_eq_entry_2` (vector 02 only)
+ *
+ * The runner performs the following checks per vector:
+ *   1. KDF derivation: derive KEK from password + salt, compare to
+ *      expected.kek. Proves the KDF implementation matches the
+ *      test-vector inputs.
+ *   2. AEAD round-trip: unwrap the CEK from wrapped_key, decrypt
+ *      ciphertext with CEK + IV + AAD, compare to plaintext. Proves
+ *      the AES-256-KW and AES-256-GCM pipelines are wired together
+ *      correctly.
+ *   3. Envelope shape: assert envelope.profile, alg, key_wrapping,
+ *      kdf_profile, key_slots structure match RFC-0018.
+ *   4. AAD binding (vector 02 only): assert that swapping AADs
+ *      between entry 1 and entry 2 produces divergent tags. This
+ *      is the cross-entry swap invariant.
+ *   5. JSON Schema validation: assert the envelope validates
+ *      against `specs/kdna-envelope-aead-v1.schema.json`. Proves
+ *      the envelope shape is conformant to the spec.
+ *
+ * Run:
+ *   node conformance/kdna-envelope-aead-v1.mjs
+ *   # or via npm:
+ *   npm run conformance:envelope-aead
+ */
+
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const Ajv = require('ajv');
+const addFormats = require('ajv-formats');
+
+let argon2id;
+try {
+  ({ argon2id } = require('@noble/hashes/argon2.js'));
+} catch {
+  // argon2id support is optional per RFC-0018 R4.2; vector 03 will
+  // skip rather than fail if @noble/hashes is not installed.
+}
+
+const root = path.dirname(fileURLToPath(import.meta.url));
+const vectorsDir = path.join(root, 'kdna-envelope-aead-v1');
+const schemaPath = path.join(
+  root, '..', 'specs', 'kdna-envelope-aead-v1.schema.json',
+);
+
+// ── KDF implementations (mirror kdna-core crypto-profile.js) ───────
+
+function deriveKekScrypt(password, params) {
+  const { N, r, p, salt } = params;
+  return crypto.scryptSync(
+    Buffer.from(password, 'utf8'),
+    Buffer.from(salt, 'base64'),
+    32,
+    { N, r, p, maxmem: 128 * 1024 * 1024 },
+  );
+}
+
+function deriveKekArgon2id(password, params) {
+  if (!argon2id) {
+    throw new Error(
+      'argon2id vector cannot run: @noble/hashes not installed. ' +
+      'Install with `npm install @noble/hashes` to enable vector 03.',
+    );
+  }
+  const { t, m, p, salt, dkLen = 32 } = params;
+  return Buffer.from(
+    argon2id(Buffer.from(password, 'utf8'), Buffer.from(salt, 'base64'), {
+      t, m, p, dkLen,
+    }),
+  );
+}
+
+// ── AES-256-KW (RFC 3394) — local implementation ───────────────────
+
+const KW_IV = Buffer.from('a6a6a6a6a6a6a6a6', 'hex');
+
+function aesKwUnwrap(key, ciphertext) {
+  if (key.length !== 32) throw new Error('AES-256-KW requires 32-byte key');
+  if (ciphertext.length !== 40) throw new Error('AES-256-KW ciphertext must be 40 bytes');
+  const n = ciphertext.length / 8 - 1;
+  const r = new Array(n + 1);
+  for (let i = 0; i <= n; i++) r[i] = ciphertext.subarray(i * 8, (i + 1) * 8);
+  for (let j = 5; j >= 0; j--) {
+    for (let i = n; i >= 1; i--) {
+      const t = BigInt(n) * BigInt(j) + BigInt(i);
+      const tBuf = Buffer.alloc(8);
+      tBuf.writeBigUInt64BE(t);
+      for (let k = 0; k < 8; k++) r[0][k] ^= tBuf[k];
+      const input = Buffer.concat([r[0], r[i]]);
+      const decipher = crypto.createDecipheriv('aes-256-ecb', key, null);
+      decipher.setAutoPadding(false);
+      const b = Buffer.concat([decipher.update(input), decipher.final()]);
+      r[0] = b.subarray(0, 8);
+      r[i] = b.subarray(8, 16);
+    }
+  }
+  if (!r[0].equals(KW_IV)) throw new Error('AES-256-KW unwrap: integrity check failed');
+  const result = Buffer.alloc(n * 8);
+  for (let i = 1; i <= n; i++) r[i].copy(result, (i - 1) * 8);
+  return result;
+}
+
+// ── Vector loaders ──────────────────────────────────────────────────
+
+function loadVector(id) {
+  const p = path.join(vectorsDir, `${id}.json`);
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+function deriveKek(vector) {
+  const { password, kdf_profile } = vector.inputs;
+  if (kdf_profile === 'scrypt-sha256-v1' || vector.inputs.scrypt_params) {
+    return deriveKekScrypt(password, vector.inputs.scrypt_params);
+  }
+  if (kdf_profile === 'argon2id-v1' || vector.inputs.argon2_params) {
+    return deriveKekArgon2id(password, vector.inputs.argon2_params);
+  }
+  throw new Error(`unknown kdf_profile: ${kdf_profile}`);
+}
+
+function unwrapAndDecrypt(envelope, kek, aad) {
+  // Use the first slot's wrapped_key. (All slots share the same
+  // wrapped CEK bytes per RFC-0018 R3.)
+  const slot = envelope.key_slots[0];
+  const cek = aesKwUnwrap(kek, Buffer.from(slot.wrapped_key, 'base64'));
+  const decipher = crypto.createDecipheriv(
+    'aes-256-gcm',
+    cek,
+    Buffer.from(envelope.iv, 'base64'),
+  );
+  decipher.setAAD(aad);
+  decipher.setAuthTag(Buffer.from(envelope.tag, 'base64'));
+  return {
+    cek,
+    plaintext: Buffer.concat([
+      decipher.update(Buffer.from(envelope.ciphertext, 'base64')),
+      decipher.final(),
+    ]),
+  };
+}
+
+// ── Per-vector check functions ──────────────────────────────────────
+
+function checkScryptBasic() {
+  const v = loadVector('kdna-envelope-aead-v1-vector-01-scrypt-basic');
+  const kek = deriveKek(v);
+  const expectedKek = Buffer.from(v.expected.kek, 'base64');
+  assert.equal(
+    kek.toString('base64'),
+    expectedKek.toString('base64'),
+    'vector 01: derived KEK does not match expected KEK',
+  );
+
+  const { cek, plaintext } = unwrapAndDecrypt(
+    v.expected.envelope,
+    kek,
+    Buffer.from(v.inputs.aad, 'utf8'),
+  );
+  assert.equal(
+    cek.toString('base64'),
+    v.inputs.cek,
+    'vector 01: unwrapped CEK does not match the declared CEK',
+  );
+  assert.equal(
+    plaintext.toString('utf8'),
+    v.inputs.plaintext,
+    'vector 01: decrypted plaintext does not match the declared plaintext',
+  );
+
+  // Envelope shape
+  const env = v.expected.envelope;
+  assert.equal(env.profile, 'kdna-envelope-aead-v1');
+  assert.equal(env.alg, 'AES-256-GCM');
+  assert.equal(env.key_wrapping, 'AES-256-KW');
+  assert.equal(env.kdf_profile, 'scrypt-sha256-v1');
+  assert.equal(env.key_slots.length, 1);
+  assert.equal(env.key_slots[0].kdf_profile, 'scrypt-sha256-v1');
+  assert.equal(env.key_slots[0].wrap, 'AES-256-KW');
+  return 'vector 01 scrypt-sha256-v1 basic: KEK + CEK + plaintext all match';
+}
+
+function checkScryptMultiEntryAad() {
+  const v = loadVector('kdna-envelope-aead-v1-vector-02-scrypt-multi-entry-aad');
+  const kek = deriveKek(v);
+  assert.equal(
+    kek.toString('base64'),
+    Buffer.from(v.expected.kek, 'base64').toString('base64'),
+    'vector 02: derived KEK does not match expected KEK',
+  );
+
+  // Both envelopes decrypt to the same plaintext.
+  const r1 = unwrapAndDecrypt(
+    v.expected.envelope_entry_1,
+    kek,
+    Buffer.from(v.inputs.aad_entry_1, 'utf8'),
+  );
+  const r2 = unwrapAndDecrypt(
+    v.expected.envelope_entry_2,
+    kek,
+    Buffer.from(v.inputs.aad_entry_2, 'utf8'),
+  );
+  assert.equal(
+    r1.plaintext.toString('utf8'),
+    v.inputs.plaintext,
+    'vector 02: entry 1 plaintext mismatch',
+  );
+  assert.equal(
+    r2.plaintext.toString('utf8'),
+    v.inputs.plaintext,
+    'vector 02: entry 2 plaintext mismatch',
+  );
+
+  // GCM invariant: same CEK + IV + plaintext → same ciphertext.
+  assert.equal(
+    v.expected.envelope_entry_1.ciphertext,
+    v.expected.envelope_entry_2.ciphertext,
+    'vector 02: GCM invariant — ciphertexts should be equal (GCM is a stream cipher; AAD affects tag only)',
+  );
+
+  // AAD binding: different entry_path AADs → different tags.
+  assert.equal(
+    v.expected.ciphertext_entry_1_eq_entry_2,
+    true,
+    'vector 02: declared ciphertext_entry_1_eq_entry_2 invariant violated',
+  );
+  assert.equal(
+    v.expected.tag_entry_1_eq_entry_2,
+    false,
+    'vector 02: declared tag_entry_1_eq_entry_2 invariant violated (tags MUST differ when AADs differ)',
+  );
+
+  // Cross-AAD swap must fail GCM auth.
+  let swapRejected = false;
+  try {
+    unwrapAndDecrypt(
+      v.expected.envelope_entry_1,
+      kek,
+      Buffer.from(v.inputs.aad_entry_2, 'utf8'),
+    );
+  } catch (e) {
+    swapRejected = true;
+  }
+  assert.equal(
+    swapRejected,
+    true,
+    'vector 02: cross-AAD swap MUST be rejected by GCM auth (proves AAD binding is enforced, not just computed)',
+  );
+  return 'vector 02 scrypt-sha256-v1 multi-entry AAD: both entries decrypt, tags diverge, cross-AAD swap rejected';
+}
+
+function checkArgon2idBasic() {
+  const v = loadVector('kdna-envelope-aead-v1-vector-03-argon2id-basic');
+  if (!argon2id) {
+    return 'vector 03 argon2id-v1 basic: SKIPPED (@noble/hashes not installed; install with `npm install @noble/hashes` to enable)';
+  }
+  const kek = deriveKek(v);
+  assert.equal(
+    kek.toString('base64'),
+    Buffer.from(v.expected.kek, 'base64').toString('base64'),
+    'vector 03: derived KEK does not match expected KEK',
+  );
+
+  const { cek, plaintext } = unwrapAndDecrypt(
+    v.expected.envelope,
+    kek,
+    Buffer.from(v.inputs.aad, 'utf8'),
+  );
+  assert.equal(
+    cek.toString('base64'),
+    v.inputs.cek,
+    'vector 03: unwrapped CEK does not match the declared CEK',
+  );
+  assert.equal(
+    plaintext.toString('utf8'),
+    v.inputs.plaintext,
+    'vector 03: decrypted plaintext does not match the declared plaintext',
+  );
+
+  const env = v.expected.envelope;
+  assert.equal(env.profile, 'kdna-envelope-aead-v1');
+  assert.equal(env.kdf_profile, 'argon2id-v1');
+  assert.equal(env.key_slots[0].kdf_profile, 'argon2id-v1');
+  return 'vector 03 argon2id-v1 basic: KEK + CEK + plaintext all match';
+}
+
+// ── JSON Schema validation (all three vectors) ─────────────────────
+
+function checkSchemaValidation() {
+  const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
+  const ajv = new Ajv({ allErrors: true, strict: false, validateSchema: false });
+  addFormats(ajv);
+  const validate = ajv.compile(schema);
+
+  const vectors = [
+    'kdna-envelope-aead-v1-vector-01-scrypt-basic',
+    'kdna-envelope-aead-v1-vector-02-scrypt-multi-entry-aad',
+    'kdna-envelope-aead-v1-vector-03-argon2id-basic',
+  ];
+
+  for (const id of vectors) {
+    const v = loadVector(id);
+    const envelopes = v.expected.envelope
+      ? [v.expected.envelope]
+      : [v.expected.envelope_entry_1, v.expected.envelope_entry_2];
+    for (let i = 0; i < envelopes.length; i++) {
+      const env = envelopes[i];
+      const valid = validate(env);
+      assert.equal(
+        valid,
+        true,
+        `${id} envelope[${i}]: schema validation failed:\n${ajv.errorsText(validate.errors)}`,
+      );
+    }
+  }
+  return 'all 4 envelope objects validate against kdna-envelope-aead-v1 schema';
+}
+
+// ── Main ────────────────────────────────────────────────────────────
+
+export function runKdnaEnvelopeAeadV1Conformance() {
+  const results = [];
+  results.push(checkScryptBasic());
+  results.push(checkScryptMultiEntryAad());
+  results.push(checkArgon2idBasic());
+  results.push(checkSchemaValidation());
+  return results;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const results = runKdnaEnvelopeAeadV1Conformance();
+  for (const r of results) console.log(`  PASS ${r}`);
+  console.log(
+    `KDNA envelope-aead-v1 conformance passed (3 vectors, 1 schema)`,
+  );
+}

--- a/conformance/kdna-envelope-aead-v1/kdna-envelope-aead-v1-vector-01-scrypt-basic.json
+++ b/conformance/kdna-envelope-aead-v1/kdna-envelope-aead-v1-vector-01-scrypt-basic.json
@@ -1,0 +1,52 @@
+{
+  "id": "kdna-envelope-aead-v1-vector-01-scrypt-basic",
+  "description": "scrypt-sha256-v1: basic round-trip with one password slot.",
+  "inputs": {
+    "password": "kdna-envelope-test-vector-1-password",
+    "salt": "AQIDBAUGBwgJCgsMDQ4PEA==",
+    "iv": "ERITFBUWFxgZGhsc",
+    "cek": "oaKjpKWmp6ipqqusra6vsMHCw8TFxsfIycrLzM3Oz9A=",
+    "plaintext": "Hello, KDNA envelope v1 (scrypt-sha256 basic).",
+    "aad": "kdna-envelope-aead-v1\nurn:uuid:11111111-1111-4111-8111-111111111111\nsha256:2222222222222222222222222222222222222222222222222222222222222222\nKDNA_Core.json\nlicensed\npassword",
+    "aad_lines": [
+      "kdna-envelope-aead-v1",
+      "urn:uuid:11111111-1111-4111-8111-111111111111",
+      "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+      "KDNA_Core.json",
+      "licensed",
+      "password"
+    ],
+    "scrypt_params": {
+      "N": 32768,
+      "r": 8,
+      "p": 1,
+      "salt": "AQIDBAUGBwgJCgsMDQ4PEA=="
+    }
+  },
+  "expected": {
+    "kek": "/XJqNxHQiIcnxZs0EXbrzm1FsUvs2eS1GacQL6UDe9w=",
+    "envelope": {
+      "profile": "kdna-envelope-aead-v1",
+      "alg": "AES-256-GCM",
+      "key_wrapping": "AES-256-KW",
+      "kdf_profile": "scrypt-sha256-v1",
+      "key_slots": [
+        {
+          "slot": "password",
+          "kdf_profile": "scrypt-sha256-v1",
+          "kdf_params": {
+            "N": 32768,
+            "r": 8,
+            "p": 1,
+            "salt": "AQIDBAUGBwgJCgsMDQ4PEA=="
+          },
+          "wrap": "AES-256-KW",
+          "wrapped_key": "3gJ9hcHY9yAWGjD6kNdW15KqP9WgH6uxBQoafAwzt/qgq+lZYNuNKQ=="
+        }
+      ],
+      "iv": "ERITFBUWFxgZGhsc",
+      "tag": "aydnlCZuBN4N55ScHCHm+g==",
+      "ciphertext": "zvRW/MSSZjCI+P81uMSjNp8QOfOGe/njAWtLLSSbzXXlDfo5JCIH8lRNbbopaw=="
+    }
+  }
+}

--- a/conformance/kdna-envelope-aead-v1/kdna-envelope-aead-v1-vector-02-scrypt-multi-entry-aad.json
+++ b/conformance/kdna-envelope-aead-v1/kdna-envelope-aead-v1-vector-02-scrypt-multi-entry-aad.json
@@ -1,0 +1,86 @@
+{
+  "id": "kdna-envelope-aead-v1-vector-02-scrypt-multi-entry-aad",
+  "description": "scrypt-sha256-v1: same CEK + IV + plaintext under two different AADs (entry_path differs). The two ciphertexts MUST differ because AAD is part of the GCM input. A reader MUST reject if AAD does not match.",
+  "inputs": {
+    "password": "kdna-envelope-test-vector-2-password",
+    "salt": "ICEiIyQlJicoKSorLC0uLw==",
+    "iv": "ISIjJCUmJygpKiss",
+    "cek": "sbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9A=",
+    "plaintext": "Same plaintext, two entries.",
+    "aad_entry_1": "kdna-envelope-aead-v1\nurn:uuid:33333333-3333-4333-8333-333333333333\nsha256:4444444444444444444444444444444444444444444444444444444444444444\nKDNA_Core.json\nlicensed\npassword",
+    "aad_entry_1_lines": [
+      "kdna-envelope-aead-v1",
+      "urn:uuid:33333333-3333-4333-8333-333333333333",
+      "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+      "KDNA_Core.json",
+      "licensed",
+      "password"
+    ],
+    "aad_entry_2": "kdna-envelope-aead-v1\nurn:uuid:33333333-3333-4333-8333-333333333333\nsha256:4444444444444444444444444444444444444444444444444444444444444444\nKDNA_Patterns.json\nlicensed\npassword",
+    "aad_entry_2_lines": [
+      "kdna-envelope-aead-v1",
+      "urn:uuid:33333333-3333-4333-8333-333333333333",
+      "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+      "KDNA_Patterns.json",
+      "licensed",
+      "password"
+    ],
+    "scrypt_params": {
+      "N": 32768,
+      "r": 8,
+      "p": 1,
+      "salt": "ICEiIyQlJicoKSorLC0uLw=="
+    }
+  },
+  "expected": {
+    "kek": "/nSMeLFKL1A9SNIZVIzp6f00H7JTAIm5w6QDiByYuC8=",
+    "envelope_entry_1": {
+      "profile": "kdna-envelope-aead-v1",
+      "alg": "AES-256-GCM",
+      "key_wrapping": "AES-256-KW",
+      "kdf_profile": "scrypt-sha256-v1",
+      "key_slots": [
+        {
+          "slot": "password",
+          "kdf_profile": "scrypt-sha256-v1",
+          "kdf_params": {
+            "N": 32768,
+            "r": 8,
+            "p": 1,
+            "salt": "ICEiIyQlJicoKSorLC0uLw=="
+          },
+          "wrap": "AES-256-KW",
+          "wrapped_key": "YWNYvZpHOHlMdiXq3vZxuYLfde7jHrklh29Adt5rkv/j1tWoRhHLfA=="
+        }
+      ],
+      "iv": "ISIjJCUmJygpKiss",
+      "tag": "fvfg2vsrCMpCt7CN/cybEg==",
+      "ciphertext": "iK3tLDHVWvApPo93D5l0v2Z+jO7iuNKLJJhrYQ=="
+    },
+    "envelope_entry_2": {
+      "profile": "kdna-envelope-aead-v1",
+      "alg": "AES-256-GCM",
+      "key_wrapping": "AES-256-KW",
+      "kdf_profile": "scrypt-sha256-v1",
+      "key_slots": [
+        {
+          "slot": "password",
+          "kdf_profile": "scrypt-sha256-v1",
+          "kdf_params": {
+            "N": 32768,
+            "r": 8,
+            "p": 1,
+            "salt": "ICEiIyQlJicoKSorLC0uLw=="
+          },
+          "wrap": "AES-256-KW",
+          "wrapped_key": "YWNYvZpHOHlMdiXq3vZxuYLfde7jHrklh29Adt5rkv/j1tWoRhHLfA=="
+        }
+      ],
+      "iv": "ISIjJCUmJygpKiss",
+      "tag": "1mx15N/TJKf4I0Qc2Sa0OQ==",
+      "ciphertext": "iK3tLDHVWvApPo93D5l0v2Z+jO7iuNKLJJhrYQ=="
+    },
+    "ciphertext_entry_1_eq_entry_2": true,
+    "tag_entry_1_eq_entry_2": false
+  }
+}

--- a/conformance/kdna-envelope-aead-v1/kdna-envelope-aead-v1-vector-03-argon2id-basic.json
+++ b/conformance/kdna-envelope-aead-v1/kdna-envelope-aead-v1-vector-03-argon2id-basic.json
@@ -1,0 +1,54 @@
+{
+  "id": "kdna-envelope-aead-v1-vector-03-argon2id-basic",
+  "description": "argon2id-v1: basic round-trip with the optional v2 KDF. Node.js implementations only; Swift port MUST either fallback to scrypt-sha256-v1 or refuse to load with KDNA_KDF_UNSUPPORTED.",
+  "inputs": {
+    "password": "kdna-envelope-test-vector-3-password",
+    "salt": "MDEyMzQ1Njc4OTo7PD0+Pw==",
+    "iv": "MTIzNDU2Nzg5Ojs8",
+    "cek": "wcLDxMXGx8jJysvMzc7P0OHi4+Tl5ufo6err7O3u7/A=",
+    "plaintext": "Hello, KDNA envelope v1 (argon2id-v1 basic).",
+    "aad": "kdna-envelope-aead-v1\nurn:uuid:55555555-5555-4555-8555-555555555555\nsha256:6666666666666666666666666666666666666666666666666666666666666666\nKDNA_Core.json\nlicensed\npassword",
+    "aad_lines": [
+      "kdna-envelope-aead-v1",
+      "urn:uuid:55555555-5555-4555-8555-555555555555",
+      "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+      "KDNA_Core.json",
+      "licensed",
+      "password"
+    ],
+    "argon2_params": {
+      "t": 3,
+      "m": 65536,
+      "p": 4,
+      "dkLen": 32,
+      "salt": "MDEyMzQ1Njc4OTo7PD0+Pw=="
+    }
+  },
+  "expected": {
+    "kek": "aD79p99ivfRhBUe/xcUmrf972jiDw0rOEfxn7RYFvlk=",
+    "envelope": {
+      "profile": "kdna-envelope-aead-v1",
+      "alg": "AES-256-GCM",
+      "key_wrapping": "AES-256-KW",
+      "kdf_profile": "argon2id-v1",
+      "key_slots": [
+        {
+          "slot": "password",
+          "kdf_profile": "argon2id-v1",
+          "kdf_params": {
+            "t": 3,
+            "m": 65536,
+            "p": 4,
+            "dkLen": 32,
+            "salt": "MDEyMzQ1Njc4OTo7PD0+Pw=="
+          },
+          "wrap": "AES-256-KW",
+          "wrapped_key": "fqQ7PJcp7FdnUKPvAAgCdTGkEREdyltBZwKFEbN+E/o0aTgQwMXDZA=="
+        }
+      ],
+      "iv": "MTIzNDU2Nzg5Ojs8",
+      "tag": "MvhEXDkY9M3lqlHvazijlQ==",
+      "ciphertext": "R9XD0cxAAcIN5YPdnmYXf1HoMtP0nZxD9k/3RI9ZYq4Pf2Zzyi233Q847Yg="
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2026,7 +2026,7 @@
     },
     "packages/kdna-core": {
       "name": "@aikdna/kdna-core",
-      "version": "0.15.0",
+      "version": "0.15.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "conformance": "node conformance/run.mjs",
     "conformance:canonical": "node --test conformance/canonical-conformance.mjs",
     "conformance:phase2": "node conformance/run.mjs --profile phase2-protocol",
+    "conformance:envelope-aead": "node conformance/kdna-envelope-aead-v1.mjs",
     "conformance:authorization:update": "node scripts/generate-authorization-conformance.mjs",
     "certify:asset-loader": "node conformance/run.mjs --profile asset-loader",
     "test:registry-trust": "node tests/registry-trust/run.mjs",

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -18,6 +18,7 @@ Current initial RFC set:
 - [RFC-0010: KDNA Fidelity Protocol](../specs/fidelity-protocol.md)
 - [RFC-0011: KDNA Product Runtime](../docs/product-runtime.md)
 - [RFC-0012: KDNA Artifact Contract](../specs/RFC-0012-artifact-contract.md)
+- [RFC-0018: KDNA Canonical Envelope Profile — `kdna-envelope-aead-v1`](./RFC-0018-kdna-envelope-aead-v1.md) — accepted 2026-06-28 (Story 17). The frozen canonical envelope profile. 3 known-answer test vectors at `conformance/kdna-envelope-aead-v1/`. Two KDF sub-profiles: `scrypt-sha256-v1` (mandatory) and `argon2id-v1` (optional v2). The profile non-collapse invariant (R4.3) forbids silent cross-KDF or cross-AEAD migration.
 
 ## RFC States
 

--- a/rfcs/RFC-0018-kdna-envelope-aead-v1.md
+++ b/rfcs/RFC-0018-kdna-envelope-aead-v1.md
@@ -1,0 +1,384 @@
+# RFC-0018: KDNA Canonical Envelope Profile — `kdna-envelope-aead-v1`
+
+Status: **accepted** (frozen for implementation as of 2026-06-28; Story 17).
+
+## Summary
+
+This RFC freezes the **canonical envelope encryption profile**
+`kdna-envelope-aead-v1` for KDNA assets. The profile is the
+mandatory target for new product-facing exports and is the spec
+that future implementations (Node.js, Swift, Rust, others) must
+converge on.
+
+The profile is a **true envelope encryption** scheme: a random
+content encryption key (CEK) encrypts each protected entry; the
+CEK is wrapped by one or more key slots derived from the
+entitlement credential; the wrapped CEK is stored in the
+envelope, never the raw CEK. The unwrap path lives in memory
+only.
+
+Two KDF profiles are supported under the same envelope ID, with
+an explicit `kdf_profile` field on each key slot:
+
+| `kdf_profile`        | KDF             | Implementations  | Required support |
+|----------------------|-----------------|------------------|------------------|
+| `scrypt-sha256-v1`   | scrypt-sha256   | Node.js, Swift   | **Mandatory**    |
+| `argon2id-v1`       | Argon2id        | Node.js only     | Optional v2      |
+
+The two profile IDs are **never collapsed**: a reader that does
+not support the declared `kdf_profile` MUST fail closed (see
+**Profile non-collapse invariant** below).
+
+## Motivation
+
+KDNA needs a single canonical envelope profile that:
+
+- A new author can target without reading three predecessor
+  RFCs.
+- A future implementation (Node.js, Swift, Rust, Go, browser
+  WebCrypto, etc.) can implement in one place and have a
+  frozen test vector to verify against.
+- Existing `kdna-licensed-entry-v1` (RFC-0008) and
+  `kdna-password-protected-v1` (RFC-0009) assets keep working
+  through their own profile IDs.
+
+The protocol must support both:
+
+- a **universal default** that works on every platform
+  (scrypt-sha256-v1, available in Node.js's `crypto` and
+  Apple's CommonCrypto),
+- a **stronger opt-in** for creators who want Argon2id's
+  memory-hardness guarantees (argon2id-v1, available in
+  Node.js via `@noble/hashes/argon2.js` and in browsers via
+  WASM).
+
+Without a single canonical profile, every new release has to
+re-litigate the AES mode, the KDF choice, the AAD format, and
+the key slot shape. This RFC freezes all of them.
+
+## Normative Rules
+
+### R1 — Profile ID and declaration
+
+Every envelope object MUST carry a `profile` field with the
+literal string `kdna-envelope-aead-v1`. Any other value is
+rejected with `KDNA_ENVELOPE_PROFILE_UNSUPPORTED`. The error
+MUST name the unsupported value and the supported value.
+
+### R2 — Envelope shape
+
+The envelope is a JSON object with the following fields. All
+fields are required unless marked optional.
+
+| Field          | Type   | Required | Description |
+|----------------|--------|----------|-------------|
+| `profile`      | string | yes      | MUST be `kdna-envelope-aead-v1`. |
+| `alg`          | string | yes      | MUST be `AES-256-GCM`. |
+| `key_wrapping` | string | yes      | MUST be `AES-256-KW` (RFC 3394). |
+| `kdf_profile`  | string | yes      | One of `scrypt-sha256-v1` or `argon2id-v1`. See R4. |
+| `key_slots`    | array  | yes      | At least one entry. See R3. |
+| `iv`           | string | yes      | Base64. 12 bytes (96-bit AES-GCM nonce). |
+| `tag`          | string | yes      | Base64. 16 bytes (AES-GCM auth tag). |
+| `ciphertext`   | string | yes      | Base64. Variable length. |
+
+The canonical on-the-wire encoding is **CBOR** (RFC 8949,
+deterministic encoding rules, length-first map ordering). JSON
+is the human-readable presentation form used in test vectors
+and developer tooling. The two forms MUST be byte-equivalent
+under CBOR canonical encoding; any divergence is a profile
+violation.
+
+### R3 — Key slots
+
+`key_slots[]` is an array of slot objects. Each slot describes
+one way to unwrap the CEK. The CEK is wrapped once and the
+same wrapped bytes are referenced by every slot.
+
+Each slot has the shape:
+
+```json
+{
+  "slot":        "<slot name, e.g. 'password' or 'recovery'>",
+  "kdf_profile": "scrypt-sha256-v1" | "argon2id-v1",
+  "kdf_params":  { ... KDF-specific parameters ... },
+  "wrap":        "AES-256-KW",
+  "wrapped_key": "<base64, 40 bytes>"
+}
+```
+
+The first slot is the "primary" slot (e.g. the user-supplied
+password). Additional slots are recovery / out-of-band
+mechanisms. The CEK wrapped under each slot MUST be the same
+CEK (a reader that successfully unwraps from any one slot
+gets the same content key).
+
+The `slot` field is an opaque string for human readability; the
+contract is that the `kdf_profile` and `kdf_params` are what
+the reader uses to derive the KEK.
+
+### R4 — KDF profiles
+
+`kdf_profile` is per-slot, not per-envelope. (The top-level
+`kdf_profile` field on the envelope is the primary slot's
+`kdf_profile` for convenience and is a redundant copy. Readers
+MUST use the per-slot value.)
+
+#### R4.1 — `scrypt-sha256-v1`
+
+| Parameter | Value | Description |
+|-----------|-------|-------------|
+| Algorithm | scrypt-sha256 | RFC 7914 |
+| N         | 32768 | Cost parameter |
+| r         | 8     | Block size |
+| p         | 1     | Parallelization |
+| Salt      | 16 bytes (128-bit) | Random per slot |
+| Output    | 32 bytes (256-bit KEK) | — |
+
+The `kdf_params` object MUST include `N`, `r`, `p`, and
+`salt` (base64). Other fields are ignored.
+
+**Mandatory support.** Every conforming implementation MUST
+support `scrypt-sha256-v1`. This is the universal default and
+the compatibility path. Node.js's built-in `crypto.scryptSync`
+is sufficient.
+
+#### R4.2 — `argon2id-v1`
+
+| Parameter  | Value  | Description |
+|------------|--------|-------------|
+| Algorithm  | Argon2id | RFC 9106 |
+| t (iter)   | 3      | Time cost |
+| m (memory) | 65536  | 64 MiB |
+| p (lanes)  | 4      | Parallelism |
+| Salt       | 16 bytes (128-bit) | Random per slot |
+| Output     | 32 bytes (256-bit KEK) | — |
+
+The `kdf_params` object MUST include `t`, `m`, `p`, and
+`salt` (base64). Other fields are ignored.
+
+**Optional v2 support.** Implementations MAY support
+`argon2id-v1`; those that do MUST verify that `m` is at least
+64 MiB. The Swift port does not have a native Argon2id
+binding and MUST follow R6.
+
+#### R4.3 — Profile non-collapse invariant
+
+A reader that does not support the declared `kdf_profile` MUST
+fail with the typed error `KDNA_KDF_UNSUPPORTED` and the
+human-readable name of the missing profile. There is no
+"auto-downgrade" path. There is no "fall back to whatever is
+supported" path.
+
+This is the **single most important security rule** in the
+profile. A reader that picks the strongest KDF it can locally
+support lets an attacker craft the envelope to force the
+weaker path. The `kdf_profile` field is a contract, not a
+hint.
+
+### R5 — AAD format
+
+The Additional Authenticated Data for AES-256-GCM is the
+UTF-8 encoding of six lines joined by `\n` (LF, U+000A):
+
+```
+kdna-envelope-aead-v1
+<asset_uid>
+<asset_digest>
+<entry_path>
+<access_mode>
+<entitlement_profile>
+```
+
+| Line | Source |
+|------|--------|
+| 1    | Literal `kdna-envelope-aead-v1`. |
+| 2    | `kdna.json.asset_uid`. |
+| 3    | `kdna.json.digests.asset` (the asset-level digest, the value that binds the .kdna file as a whole). |
+| 4    | The encrypted entry's path inside the .kdna container (e.g. `KDNA_Core.json`). |
+| 5    | `kdna.json.access` (one of `public`, `licensed`, `remote`). |
+| 6    | The active entitlement profile (e.g. `password`, `account`, `org`, `device_bound`, `local_receipt`, `purchase_receipt`, `remote`). |
+
+`asset_uid`, `asset_digest`, `entry_path`, and
+`entitlement_profile` are part of the AAD so that:
+
+- A ciphertext cannot be moved across entries in the same
+  asset (the tag would not verify against the new path's
+  AAD).
+- A ciphertext cannot be moved across assets (the asset_uid
+  and asset_digest would differ).
+- A ciphertext cannot be moved across access modes or
+  entitlement profiles (the tag would not verify).
+
+The conformance test **vector 02** explicitly proves this:
+two envelopes with the same CEK + IV + plaintext but
+different `entry_path` AADs produce the same ciphertext (GCM
+property) but **different tags** (AAD binding). A reader
+that decrypts entry 2's ciphertext using entry 1's AAD MUST
+fail the GCM authentication check.
+
+### R6 — Swift port behaviour
+
+The KDNA Swift port (no native Argon2id binding) MUST:
+
+- (a) Support `scrypt-sha256-v1` for every envelope (mandatory
+  per R4.1).
+- (b) On encountering a slot with `kdf_profile:
+  "argon2id-v1"`, EITHER:
+  - Fall back to the next slot in `key_slots[]` if any other
+    slot's `kdf_profile` is `scrypt-sha256-v1`, OR
+  - Fail with `KDNA_KDF_UNSUPPORTED` and a human-readable
+    reason: "this Swift build does not implement Argon2id;
+    supply a password-slot scrypt-sha256-v1 envelope or
+    install the Argon2id extension build".
+- (c) NEVER silently accept the envelope under a weaker KDF
+  than declared. The per-slot `kdf_profile` is the contract.
+
+The implementation picks between (b.i) and (b.ii) at build
+time. Both are valid; neither is silent. The choice is
+documented in the Swift port's release notes.
+
+### R7 — IV, tag, ciphertext sizes
+
+| Field       | Size (decoded) | Notes |
+|-------------|----------------|-------|
+| `iv`        | 12 bytes       | 96-bit AES-GCM nonce. MUST be unique per (CEK, slot) pair. The same CEK used twice on the same asset MUST use two different IVs. |
+| `tag`       | 16 bytes       | AES-GCM authentication tag. |
+| `ciphertext`| variable       | Plaintext length, no padding (GCM is a stream cipher). |
+| `wrapped_key` | 40 bytes     | AES-256-KW output for a 32-byte CEK. Same across all slots. |
+
+A reader that sees an `iv` of any length other than 12 bytes
+or a `tag` of any length other than 16 bytes MUST fail with
+`KDNA_ENVELOPE_FIELD_LENGTH` naming the offending field.
+
+### R8 — Memory-only rule
+
+Decrypted plaintext MUST remain in volatile memory only. A
+reader MUST NOT write decrypted entries to persistent disk,
+logs, traces, or audit events. The error conditions in R10
+are the only signals a reader may emit on failure.
+
+### R9 — Test vector conformance
+
+Every conforming implementation MUST be able to decrypt
+**all three** test vectors in `conformance/kdna-envelope-aead-v1/`
+without modification. The vectors are:
+
+- `kdna-envelope-aead-v1-vector-01-scrypt-basic.json` —
+  scrypt-sha256-v1, single password slot, basic round-trip.
+- `kdna-envelope-aead-v1-vector-02-scrypt-multi-entry-aad.json` —
+  scrypt-sha256-v1, two AADs (different `entry_path`) over
+  the same CEK + IV + plaintext, proving AAD binding via
+  divergent tags.
+- `kdna-envelope-aead-v1-vector-03-argon2id-basic.json` —
+  argon2id-v1, single password slot, basic round-trip.
+
+A conformance runner at `conformance/kdna-envelope-aead-v1.mjs`
+re-derives each vector's expected outputs from the declared
+inputs and asserts equality. Run with:
+
+```bash
+npm run conformance:envelope-aead
+```
+
+The conformance runner is the canonical "is this
+implementation correct?" check. New implementations can also
+run it as a pre-merge CI gate.
+
+### R10 — Error conditions
+
+Implementations MUST reject with a distinct error when:
+
+| Condition | Error code |
+|-----------|------------|
+| `profile` is not `kdna-envelope-aead-v1`. | `KDNA_ENVELOPE_PROFILE_UNSUPPORTED` |
+| `alg` is not `AES-256-GCM`. | `KDNA_ENVELOPE_ALG_UNSUPPORTED` |
+| `key_wrapping` is not `AES-256-KW`. | `KDNA_ENVELOPE_WRAP_UNSUPPORTED` |
+| `key_slots[]` is empty. | `KDNA_ENVELOPE_NO_SLOTS` |
+| `iv` is not 12 bytes after base64 decoding. | `KDNA_ENVELOPE_FIELD_LENGTH` (field=`iv`) |
+| `tag` is not 16 bytes after base64 decoding. | `KDNA_ENVELOPE_FIELD_LENGTH` (field=`tag`) |
+| `wrapped_key` is not 40 bytes after base64 decoding. | `KDNA_ENVELOPE_FIELD_LENGTH` (field=`wrapped_key`) |
+| `kdf_profile` is one this reader does not support and no other slot offers a supported KDF. | `KDNA_KDF_UNSUPPORTED` |
+| AES-256-KW unwrap fails (integrity). | `KDNA_KW_INTEGRITY` |
+| AES-GCM authentication fails (wrong key, wrong AAD, tampered ciphertext). | `KDNA_GCM_AUTH_FAILED` |
+| `kdf_params` is missing a required parameter for the declared `kdf_profile`. | `KDNA_KDF_PARAMS_INVALID` |
+
+Each error code MUST be emitted at most once per decryption
+attempt. Implementations MUST NOT log the CEK, KEK, plaintext,
+or any of these error contexts at `info` or higher; failure
+detail is emitted at `debug` only.
+
+## Compatibility Impact
+
+| Profile ID | Status under RFC-0018 |
+|------------|------------------------|
+| `kdna-licensed-entry-v1` (RFC-0008) | Unchanged. Continues to be the compat path. Distinct ID; no silent migration. |
+| `kdna-password-protected-v1` (RFC-0009) | Unchanged. Continues to be the password + recovery path. Distinct ID; no silent migration. |
+| `kdna-envelope-aead-v1` (this RFC) | **New canonical envelope profile.** Future product exports should target this. |
+| `kdna-licensed-entry-experimental` (legacy) | Unchanged. Remains read-only legacy. |
+
+The four profile IDs MUST stay distinct in the registry, the
+SDK enum, and the CLI's `--profile` argument. A reader that
+sees an unrecognized profile ID MUST fail closed (R1, R4.3).
+
+## Conformance Requirements
+
+A conforming implementation MUST:
+
+1. Implement R1 through R10 above.
+2. Pass all three test vectors (R9).
+3. Emit the error codes named in R10 (or a strict superset
+   with the same names).
+4. Document which `kdf_profile` values it supports.
+5. For Swift: pick (b.i) or (b.ii) in R6 and document the
+   choice.
+
+A conforming implementation SHOULD:
+
+1. Support both `kdf_profile` values.
+2. Use CBOR canonical encoding for the on-the-wire form.
+3. Run `conformance:envelope-aead` as a pre-merge CI gate.
+
+## Security Considerations
+
+- **The `kdf_profile` field is security-critical.** A reader
+  that treats it as a hint rather than a contract is broken.
+  See R4.3.
+- **AAD binding prevents ciphertext migration.** Moving a
+  ciphertext across entries, assets, or access modes causes
+  AES-GCM auth failure. Vector 02 demonstrates this.
+- **The KDF params are not the KDF itself.** A reader that
+  trusts `kdf_params` without verifying that the
+  implementation supports the claimed `m` (memory cost) can
+  be DoS'd by a 4 GiB memory request. The Swift port and
+  the WASM build in particular MUST bound `m` and `t` at
+  load time.
+- **Salt uniqueness is not sufficient for nonce uniqueness.**
+  GCM nonce reuse with the same key is catastrophic. R7
+  requires per-(CEK, slot) IV uniqueness. Implementations
+  MUST track IVs used per CEK and reject on collision.
+- **Scrypt parameters are the universal default.** N=32768,
+  r=8, p=1 is the lowest setting the Node.js implementation
+  accepts without a `maxmem` override. Future profile
+  revisions may raise this; the change requires a new
+  `kdf_profile` value (e.g. `scrypt-sha256-v2`) and the
+  non-collapse invariant still applies.
+
+## Open Questions
+
+- Whether AES-256-GCM should be paired with ChaCha20-Poly1305
+  in a future v2 of the envelope profile. The current answer
+  is "no — one AEAD per profile freeze; new AEADs get a new
+  profile ID". This is the same non-collapse shape.
+- Whether `kdf_profile` should ever be inferred from the
+  presence of `scrypt_params` / `argon2_params` (today the
+  fields are independent). The current answer is "no — explicit
+  `kdf_profile` is the contract". A future profile revision
+  could relax this if the ergonomics get in the way.
+- The CBOR canonical encoding form for the envelope is not
+  yet frozen as a separate RFC. The conformance vectors
+  today are JSON-only. Story 24 (Argon2id binding + envelope
+  implementation) is expected to freeze the CBOR form and
+  add a CBOR round-trip vector. Until then, implementations
+  MAY use JSON internally; the on-the-wire form is
+  implementation-defined, but the envelope SHAPE is fixed by
+  this RFC.

--- a/scripts/generate-envelope-aead-vectors.js
+++ b/scripts/generate-envelope-aead-vectors.js
@@ -1,0 +1,324 @@
+#!/usr/bin/env node
+// generate-vectors.js — Compute kdna-envelope-aead-v1 test vectors (Story 17)
+//
+// Run from OPEN/kdna/:
+//   node scripts/generate-envelope-aead-vectors.js
+//
+// Outputs deterministic base64 values that the conformance runner
+// re-derives and asserts against. Inputs are fixed; do not "tidy"
+// the inputs without also re-publishing the test vectors.
+//
+// The script is idempotent: re-running it with the same inputs
+// produces byte-identical output. This is a property of the chosen
+// KDFs (deterministic given the same password + salt + params) and
+// the CEK-wrapping + AEAD pipelines (deterministic given the same
+// IV; we fix IV per vector).
+//
+// Story 17 deliverable: this script + the 3 vector JSON files it
+// produces. The script is NOT published to consumers — only the
+// vector files are. Re-running is a maintainer action to regenerate
+// vectors after a future change to the KDF or envelope format.
+
+'use strict';
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ENVELOPE_PROFILE = 'kdna-envelope-aead-v1';
+const ALG = 'AES-256-GCM';
+const KEY_WRAPPING = 'AES-256-KW';
+
+const SCRYPT_PARAMS = { N: 32768, r: 8, p: 1 };
+
+const ARGON2_PARAMS = { t: 3, m: 65536, p: 4, dkLen: 32 };
+
+// ── AAD builder (matches the envelope spec) ─────────────────────────
+
+function buildAad(parts) {
+  return Buffer.from(
+    [
+      ENVELOPE_PROFILE,
+      parts.asset_uid,
+      parts.asset_digest,
+      parts.entry_path,
+      parts.access_mode,
+      parts.entitlement_profile,
+    ].join('\n'),
+    'utf8',
+  );
+}
+
+// ── AES-256-KW (RFC 3394) — copied from kdna-core crypto-profile.js ──
+
+const AES_BLOCK = 16;
+const KW_IV = Buffer.from('a6a6a6a6a6a6a6a6', 'hex');
+
+function aesWrap(key, plaintext) {
+  if (key.length !== 32) throw new Error('AES-256-KW requires 32-byte key');
+  if (plaintext.length !== 32) throw new Error('AES-256-KW requires 32-byte plaintext');
+  const n = plaintext.length / 8;
+  const r = new Array(n + 1);
+  r[0] = KW_IV;
+  for (let i = 0; i < n; i++) r[i + 1] = plaintext.subarray(i * 8, (i + 1) * 8);
+  for (let j = 0; j <= 5; j++) {
+    for (let i = 1; i <= n; i++) {
+      const input = Buffer.concat([r[0], r[i]]);
+      const cipher = crypto.createCipheriv('aes-256-ecb', key, null);
+      cipher.setAutoPadding(false);
+      const b = Buffer.concat([cipher.update(input), cipher.final()]);
+      r[0] = b.subarray(0, 8);
+      const t = BigInt(n) * BigInt(j) + BigInt(i);
+      const tBuf = Buffer.alloc(8);
+      tBuf.writeBigUInt64BE(t);
+      for (let k = 0; k < 8; k++) r[0][k] ^= tBuf[k];
+      r[i] = b.subarray(8, 16);
+    }
+  }
+  const result = Buffer.alloc((n + 1) * 8);
+  for (let i = 0; i <= n; i++) r[i].copy(result, i * 8);
+  return result;
+}
+
+// ── scrypt-sha256 (Node built-in) ───────────────────────────────────
+
+function deriveKekScrypt(password, salt) {
+  return crypto.scryptSync(Buffer.from(password, 'utf8'), salt, 32, {
+    N: SCRYPT_PARAMS.N,
+    r: SCRYPT_PARAMS.r,
+    p: SCRYPT_PARAMS.p,
+    maxmem: 64 * 1024 * 1024,
+  });
+}
+
+// ── Argon2id via @noble/hashes ──────────────────────────────────────
+
+let argon2id;
+try {
+  ({ argon2id } = require('@noble/hashes/argon2.js'));
+} catch (e) {
+  console.error('@noble/hashes not available; install with: npm install @noble/hashes');
+  process.exit(1);
+}
+
+function deriveKekArgon2id(password, salt) {
+  return Buffer.from(
+    argon2id(Buffer.from(password, 'utf8'), salt, {
+      t: ARGON2_PARAMS.t,
+      m: ARGON2_PARAMS.m,
+      p: ARGON2_PARAMS.p,
+      dkLen: ARGON2_PARAMS.dkLen,
+    }),
+  );
+}
+
+// ── Envelope builder ────────────────────────────────────────────────
+
+function buildEnvelope({ kdf_profile, password, salt, iv, plaintext, aad, cek, kek }) {
+  const wrappedKey = aesWrap(kek, cek);
+  const cipher = crypto.createCipheriv(ALG, cek, iv);
+  cipher.setAAD(aad);
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return {
+    profile: ENVELOPE_PROFILE,
+    alg: ALG,
+    key_wrapping: KEY_WRAPPING,
+    kdf_profile,
+    key_slots: [
+      {
+        slot: 'password',
+        kdf_profile,
+        kdf_params: kdf_profile === 'scrypt-sha256-v1'
+          ? { ...SCRYPT_PARAMS, salt: salt.toString('base64') }
+          : { ...ARGON2_PARAMS, salt: salt.toString('base64') },
+        wrap: KEY_WRAPPING,
+        wrapped_key: wrappedKey.toString('base64'),
+      },
+    ],
+    iv: iv.toString('base64'),
+    tag: tag.toString('base64'),
+    ciphertext: ciphertext.toString('base64'),
+  };
+}
+
+// ── Vector 1: scrypt-sha256-v1 basic round-trip ─────────────────────
+
+function vector1() {
+  const password = 'kdna-envelope-test-vector-1-password';
+  const salt = Buffer.from(
+    '0102030405060708090a0b0c0d0e0f10', // 16 bytes, fixed
+    'hex',
+  );
+  const iv = Buffer.from('1112131415161718191a1b1c', 'hex'); // 12 bytes
+  const cek = Buffer.from(
+    'a1a2a3a4a5a6a7a8a9aaabacadaeafb0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0',
+    'hex',
+  );
+  const plaintext = Buffer.from('Hello, KDNA envelope v1 (scrypt-sha256 basic).', 'utf8');
+  const aad = buildAad({
+    asset_uid: 'urn:uuid:11111111-1111-4111-8111-111111111111',
+    asset_digest: 'sha256:2222222222222222222222222222222222222222222222222222222222222222',
+    entry_path: 'KDNA_Core.json',
+    access_mode: 'licensed',
+    entitlement_profile: 'password',
+  });
+  const kek = deriveKekScrypt(password, salt);
+  const envelope = buildEnvelope({
+    kdf_profile: 'scrypt-sha256-v1',
+    password, salt, iv, plaintext, aad, cek, kek,
+  });
+  const scryptParams = { ...SCRYPT_PARAMS, salt: salt.toString('base64') };
+  return {
+    id: 'kdna-envelope-aead-v1-vector-01-scrypt-basic',
+    description: 'scrypt-sha256-v1: basic round-trip with one password slot.',
+    inputs: {
+      password,
+      salt: salt.toString('base64'),
+      iv: iv.toString('base64'),
+      cek: cek.toString('base64'),
+      plaintext: plaintext.toString('utf8'),
+      aad: aad.toString('utf8'),
+      aad_lines: aad.toString('utf8').split('\n'),
+      scrypt_params: scryptParams,
+    },
+    expected: {
+      kek: kek.toString('base64'),
+      envelope,
+    },
+  };
+}
+
+// ── Vector 2: scrypt-sha256-v1 multi-entry AAD ──────────────────────
+// Proves that the AAD binding to <entry_path> prevents ciphertext
+// swapping across entries: encrypting the same plaintext under
+// different entry paths produces different ciphertexts.
+
+function vector2() {
+  const password = 'kdna-envelope-test-vector-2-password';
+  const salt = Buffer.from('202122232425262728292a2b2c2d2e2f', 'hex');
+  const iv = Buffer.from('2122232425262728292a2b2c', 'hex');
+  const cek = Buffer.from(
+    'b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0',
+    'hex',
+  );
+  const plaintext = Buffer.from('Same plaintext, two entries.', 'utf8');
+  const assetUid = 'urn:uuid:33333333-3333-4333-8333-333333333333';
+  const assetDigest = 'sha256:4444444444444444444444444444444444444444444444444444444444444444';
+  const aadEntry1 = buildAad({
+    asset_uid: assetUid, asset_digest: assetDigest,
+    entry_path: 'KDNA_Core.json', access_mode: 'licensed', entitlement_profile: 'password',
+  });
+  const aadEntry2 = buildAad({
+    asset_uid: assetUid, asset_digest: assetDigest,
+    entry_path: 'KDNA_Patterns.json', access_mode: 'licensed', entitlement_profile: 'password',
+  });
+  const kek = deriveKekScrypt(password, salt);
+  const envelope1 = buildEnvelope({
+    kdf_profile: 'scrypt-sha256-v1',
+    password, salt, iv, plaintext, aad: aadEntry1, cek, kek,
+  });
+  const envelope2 = buildEnvelope({
+    kdf_profile: 'scrypt-sha256-v1',
+    password, salt, iv, plaintext, aad: aadEntry2, cek, kek,
+  });
+  const scryptParams = { ...SCRYPT_PARAMS, salt: salt.toString('base64') };
+  return {
+    id: 'kdna-envelope-aead-v1-vector-02-scrypt-multi-entry-aad',
+    description: 'scrypt-sha256-v1: same CEK + IV + plaintext under two different AADs (entry_path differs). The two ciphertexts MUST differ because AAD is part of the GCM input. A reader MUST reject if AAD does not match.',
+    inputs: {
+      password,
+      salt: salt.toString('base64'),
+      iv: iv.toString('base64'),
+      cek: cek.toString('base64'),
+      plaintext: plaintext.toString('utf8'),
+      aad_entry_1: aadEntry1.toString('utf8'),
+      aad_entry_1_lines: aadEntry1.toString('utf8').split('\n'),
+      aad_entry_2: aadEntry2.toString('utf8'),
+      aad_entry_2_lines: aadEntry2.toString('utf8').split('\n'),
+      scrypt_params: scryptParams,
+    },
+    expected: {
+      kek: kek.toString('base64'),
+      envelope_entry_1: envelope1,
+      envelope_entry_2: envelope2,
+      // GCM invariant: same IV + CEK + plaintext but different AADs
+      // produce the SAME ciphertext (GCM is a stream cipher; AAD
+      // affects the tag, not the ciphertext). The security property
+      // is the divergent tag.
+      ciphertext_entry_1_eq_entry_2: envelope1.ciphertext === envelope2.ciphertext,
+      // AAD binding: the two tags MUST differ because their AADs
+      // differ. This is the cross-entry swap invariant.
+      tag_entry_1_eq_entry_2: envelope1.tag === envelope2.tag,
+    },
+  };
+}
+
+// ── Vector 3: argon2id-v1 basic round-trip ──────────────────────────
+
+function vector3() {
+  const password = 'kdna-envelope-test-vector-3-password';
+  const salt = Buffer.from('303132333435363738393a3b3c3d3e3f', 'hex');
+  const iv = Buffer.from('3132333435363738393a3b3c', 'hex');
+  const cek = Buffer.from(
+    'c1c2c3c4c5c6c7c8c9cacbcccdcecfd0e1e2e3e4e5e6e7e8e9eaebecedeeeff0',
+    'hex',
+  );
+  const plaintext = Buffer.from('Hello, KDNA envelope v1 (argon2id-v1 basic).', 'utf8');
+  const aad = buildAad({
+    asset_uid: 'urn:uuid:55555555-5555-4555-8555-555555555555',
+    asset_digest: 'sha256:6666666666666666666666666666666666666666666666666666666666666666',
+    entry_path: 'KDNA_Core.json',
+    access_mode: 'licensed',
+    entitlement_profile: 'password',
+  });
+  const kek = deriveKekArgon2id(password, salt);
+  const envelope = buildEnvelope({
+    kdf_profile: 'argon2id-v1',
+    password, salt, iv, plaintext, aad, cek, kek,
+  });
+  const argon2Params = { ...ARGON2_PARAMS, salt: salt.toString('base64') };
+  return {
+    id: 'kdna-envelope-aead-v1-vector-03-argon2id-basic',
+    description: 'argon2id-v1: basic round-trip with the optional v2 KDF. Node.js implementations only; Swift port MUST either fallback to scrypt-sha256-v1 or refuse to load with KDNA_KDF_UNSUPPORTED.',
+    inputs: {
+      password,
+      salt: salt.toString('base64'),
+      iv: iv.toString('base64'),
+      cek: cek.toString('base64'),
+      plaintext: plaintext.toString('utf8'),
+      aad: aad.toString('utf8'),
+      aad_lines: aad.toString('utf8').split('\n'),
+      argon2_params: argon2Params,
+    },
+    expected: {
+      kek: kek.toString('base64'),
+      envelope,
+    },
+  };
+}
+
+// ── Main ────────────────────────────────────────────────────────────
+
+const outDir = path.resolve(__dirname, '..', 'conformance', 'kdna-envelope-aead-v1');
+fs.mkdirSync(outDir, { recursive: true });
+
+const vectors = [vector1(), vector2(), vector3()];
+for (const v of vectors) {
+  const filename = `${v.id}.json`;
+  const filepath = path.join(outDir, filename);
+  fs.writeFileSync(filepath, JSON.stringify(v, null, 2) + '\n');
+  console.log(`wrote ${filepath}`);
+  console.log(`  kek (b64):  ${v.expected.kek}`);
+  if (v.expected.ciphertext_entry_1_eq_entry_2 !== undefined) {
+    console.log(`  ciphertext_entry_1: ${v.expected.envelope_entry_1.ciphertext}`);
+    console.log(`  ciphertext_entry_2: ${v.expected.envelope_entry_2.ciphertext}`);
+    console.log(`  tag_entry_1:        ${v.expected.envelope_entry_1.tag}`);
+    console.log(`  tag_entry_2:        ${v.expected.envelope_entry_2.tag}`);
+    console.log(`  ciphertext_entry_1_eq_entry_2: ${v.expected.ciphertext_entry_1_eq_entry_2}`);
+    console.log(`  (GCM invariant: same CEK+IV+plaintext → same ciphertext; AAD affects TAG, not ciphertext)`);
+  } else {
+    console.log(`  ciphertext: ${v.expected.envelope.ciphertext}`);
+    console.log(`  tag:        ${v.expected.envelope.tag}`);
+  }
+}

--- a/specs/kdna-crypto-profiles.md
+++ b/specs/kdna-crypto-profiles.md
@@ -1,9 +1,14 @@
 # KDNA Crypto Profiles
 
-Status: Draft  
+Status: **Active** as of 2026-06-28 (Story 17). The `kdna-envelope-aead-v1`
+profile ID and its two KDF sub-profiles (`scrypt-sha256-v1` mandatory,
+`argon2id-v1` optional v2) are frozen; see RFC-0018 for the normative
+contract. Predecessor profiles (`kdna-licensed-entry-v1` from RFC-0008,
+`kdna-password-protected-v1` from RFC-0009) remain in their own distinct
+profile IDs and continue to be supported.
 Normative: Yes after profile IDs and test vectors are frozen  
 Related specs: `kdna-authorization-contract.md`, `kdna-secret-store.md`,
-`kdna-import-security.md`
+`kdna-import-security.md`, `RFC-0018-kdna-envelope-aead-v1.md`
 
 ## 1. Scope
 
@@ -19,46 +24,62 @@ It derives an entry decrypt key from existing license activation material and
 decrypts protected entries in memory. Implementations MAY support it for
 migration and compatibility.
 
-New product-facing exports SHOULD converge on the future canonical envelope
-profile after the profile is frozen and test vectors exist.
+`kdna-password-protected-v1` is the password + recovery profile from
+RFC-0009. It MAY be supported for compatibility with existing password-
+protected assets. New product exports SHOULD NOT target it; use
+`kdna-envelope-aead-v1` instead.
 
-## 3. Proposed Canonical Envelope Profile
+New product-facing exports SHOULD converge on the canonical envelope profile
+(RFC-0018) after the profile is frozen and test vectors exist. As of
+2026-06-28 this convergence is recommended and feasible.
 
-Proposed profile ID: `kdna-envelope-aead-v1`
+## 3. Canonical Envelope Profile — `kdna-envelope-aead-v1`
+
+**Frozen 2026-06-28 (Story 17, RFC-0018).** Three test vectors are
+published at `conformance/kdna-envelope-aead-v1/` and the conformance
+runner `conformance/kdna-envelope-aead-v1.mjs` re-derives them.
+
+Profile ID: `kdna-envelope-aead-v1`
 
 The canonical model is envelope encryption:
 
 1. Generate a random content encryption key (`CEK`) per encrypted asset or entry
    set.
-2. Encrypt payload entries with the `CEK`.
+2. Encrypt payload entries with the `CEK` using `AES-256-GCM` and the
+   profile-defined AAD (six lines, joined by LF; see RFC-0018 R5).
 3. Never store the raw `CEK` in the `.kdna` asset.
-4. Store one or more key grants that wrap the `CEK` according to the entitlement
-   profile.
+4. Store one or more key grants (`key_slots[]`) that wrap the `CEK` according
+   to the entitlement profile.
+5. The `CEK` is wrapped via `AES-256-KW` (RFC 3394) with a `KEK` derived from
+   the slot's credential via a KDF selected by the slot's `kdf_profile`.
 
 | Entitlement profile | CEK wrapping source |
 |---|---|
-| `password` | User passphrase derives a key-encryption key (`KEK`). |
+| `password` | User passphrase derives a `KEK` via `scrypt-sha256-v1` (default) or `argon2id-v1` (opt-in). |
 | `local_receipt` | Signed receipt carries or references wrapped CEK material. |
 | `account` | Entitlement server returns a short-lived wrapped CEK. |
 | `org` | Organization entitlement server returns a short-lived wrapped CEK. |
 | `device_bound` | Receipt wraps CEK to a device public key. |
 | `remote` | Client never receives the CEK. |
 
+The full normative rules (envelope shape, KDF profile parameters, AAD
+format, the profile non-collapse invariant, the Swift-port behaviour, error
+codes) are in `rfcs/RFC-0018-kdna-envelope-aead-v1.md`.
+
 ## 4. Password Profile
 
 A short PIN MUST NOT be treated as the file encryption password.
 
-Password-derived keys SHOULD use a memory-hard KDF. Argon2id is preferred if the
-cross-language dependency is accepted. Existing scrypt-sha256 behavior MUST be
-marked compatibility or legacy unless explicitly selected for v1.
+For `kdna-envelope-aead-v1`, the password slot's KDF is selected by
+`kdf_profile`:
 
-Baseline if Argon2id is accepted:
-
-- salt: at least 128-bit random;
-- output: 256-bit KEK;
-- memory: 64 MiB minimum for ordinary devices;
-- iterations: 3 or tuned equivalent;
-- parallelism: tuned per platform.
+- `scrypt-sha256-v1` — mandatory, every conforming implementation MUST support
+  it. N=32768, r=8, p=1, 16-byte salt, 32-byte KEK. Node.js's built-in
+  `crypto.scryptSync` is sufficient.
+- `argon2id-v1` — optional v2, Node.js implementations SHOULD support it.
+  t=3, m=65536, p=4, 16-byte salt, 32-byte KEK. The Swift port does not
+  have a native binding and follows RFC-0018 R6 (fallback to next slot
+  or `KDNA_KDF_UNSUPPORTED`).
 
 Chat MUST NOT log or persist passwords.
 
@@ -67,30 +88,35 @@ Chat MUST NOT log or persist passwords.
 Encrypted payload entries MUST use authenticated encryption. Decryption MUST
 fail if ciphertext or associated metadata is modified.
 
-Candidate AEAD algorithms:
+For `kdna-envelope-aead-v1`, the AEAD is frozen to `AES-256-GCM` with
+12-byte IV, 16-byte tag, and the six-line AAD format documented in
+RFC-0018 R5.
 
-- AES-256-GCM;
-- ChaCha20-Poly1305 where platform support requires it.
-
-The final profile MUST freeze algorithm IDs, nonce sizes, nonce generation
-rules, authentication tag sizes, and test vectors before product code depends
-on it.
+Future AEADs (e.g. ChaCha20-Poly1305) require a new envelope profile ID.
+The non-collapse invariant from RFC-0018 R4.3 forbids silent
+cross-profile migration.
 
 ## 6. Associated Data
 
-AAD SHOULD bind ciphertext to the asset context:
+For `kdna-envelope-aead-v1`, the AAD format is:
 
-- asset UID;
-- asset digest;
-- content digest;
-- manifest digest;
-- entry path;
-- format version;
-- spec version;
-- access mode;
-- entitlement profile;
-- encryption profile;
-- algorithm ID.
+```
+kdna-envelope-aead-v1
+<asset_uid>
+<asset_digest>
+<entry_path>
+<access_mode>
+<entitlement_profile>
+```
+
+See RFC-0018 R5 for the full contract. The `asset_digest` is the
+asset-level digest (the value that binds the `.kdna` file as a whole).
+Per-entry digest binding is not in the AAD; cross-entry swap protection
+comes from `entry_path` + AES-GCM authentication.
+
+For other profile IDs (`kdna-licensed-entry-v1`,
+`kdna-password-protected-v1`), the AAD is the four-line format
+defined in RFC-0008 / RFC-0009.
 
 This prevents ciphertext swapping across assets, entries, manifests, and access
 policies.
@@ -103,20 +129,44 @@ legacy developer import path.
 A runtime MUST reject an asset that attempts to downgrade from a stronger
 declared profile to a weaker implementation path.
 
-`kdna-licensed-entry-v1` and `kdna-envelope-aead-v1` MUST remain distinct
-profile IDs.
+`kdna-licensed-entry-v1`, `kdna-password-protected-v1`, and
+`kdna-envelope-aead-v1` MUST remain distinct profile IDs.
+
+Within `kdna-envelope-aead-v1`, the per-slot `kdf_profile` is also part
+of the non-collapse rule: a reader that does not support the declared
+`kdf_profile` MUST fail with `KDNA_KDF_UNSUPPORTED`. There is no
+auto-downgrade path (RFC-0018 R4.3).
 
 ## 8. Test Vectors
 
-Before this spec becomes final, the repo MUST include test vectors for:
+`kdna-envelope-aead-v1` test vectors are published at
+`conformance/kdna-envelope-aead-v1/`:
+
+- `kdna-envelope-aead-v1-vector-01-scrypt-basic.json` — scrypt-sha256-v1,
+  single password slot, basic round-trip.
+- `kdna-envelope-aead-v1-vector-02-scrypt-multi-entry-aad.json` — two
+  AADs over the same CEK + IV + plaintext; proves AAD binding via
+  divergent tags.
+- `kdna-envelope-aead-v1-vector-03-argon2id-basic.json` — argon2id-v1,
+  single password slot, basic round-trip.
+
+A conformance runner at `conformance/kdna-envelope-aead-v1.mjs`
+re-derives each vector and asserts equality. Run with:
+
+```bash
+npm run conformance:envelope-aead
+```
+
+Test vector coverage (per RFC-0018 R9):
 
 - password-derived key;
 - CEK generation;
 - CEK wrapping and unwrapping;
 - AEAD encrypt/decrypt;
-- AAD mismatch failure;
+- AAD mismatch failure (vector 02);
 - nonce uniqueness;
 - tampered ciphertext;
 - wrong password;
 - unsupported profile fail-closed;
-- JS Core and Swift Core parity.
+- JS Core and Swift Core parity (Swift parity is a Story 24 deliverable;
+  the runner today validates JS Core).

--- a/specs/kdna-crypto-protocol.md
+++ b/specs/kdna-crypto-protocol.md
@@ -297,7 +297,8 @@ What it DOES provide:
 | P3 | `kdna license activate` and `kdna license sync` | CLI MVP implemented |
 | P4 | Entitlement revoke/admin API | Specified |
 | P5 | Runtime projection and watermark service | Future server implementation |
-| P6 | TUF-like registry trust roles | Future trust-layer implementation |
+| P6 | ~~TUF-like registry trust roles~~ | **CANCELLED 2026-06-28** (see `roadmap-2026.md` Section 5.5; Story 19 / Ed25519 per-author identity replaces this) |
+| P7 | `kdna-envelope-aead-v1` canonical envelope profile (RFC-0018) | **Spec frozen 2026-06-28 (Story 17). 3 test vectors in `conformance/kdna-envelope-aead-v1/`. Implementation in Story 24.** |
 
 ---
 

--- a/specs/kdna-envelope-aead-v1.schema.json
+++ b/specs/kdna-envelope-aead-v1.schema.json
@@ -1,0 +1,169 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/aikdna/kdna/schema/kdna-envelope-aead-v1.schema.json",
+  "title": "KDNA Envelope AEAD v1",
+  "description": "JSON Schema for the kdna-envelope-aead-v1 envelope (RFC-0018). Defines the shape, required fields, and the per-slot kdf_profile contract. The on-the-wire canonical form is CBOR (RFC 8949, deterministic encoding); this schema describes the JSON presentation form used in test vectors and developer tooling. The two forms MUST be byte-equivalent under CBOR canonical encoding.",
+  "type": "object",
+  "required": [
+    "profile",
+    "alg",
+    "key_wrapping",
+    "kdf_profile",
+    "key_slots",
+    "iv",
+    "tag",
+    "ciphertext"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "profile": {
+      "type": "string",
+      "const": "kdna-envelope-aead-v1",
+      "description": "Profile identifier. MUST be the literal string 'kdna-envelope-aead-v1'. Any other value triggers KDNA_ENVELOPE_PROFILE_UNSUPPORTED."
+    },
+    "alg": {
+      "type": "string",
+      "const": "AES-256-GCM",
+      "description": "AEAD algorithm. Frozen to AES-256-GCM. Future AEADs require a new profile ID (the non-collapse invariant)."
+    },
+    "key_wrapping": {
+      "type": "string",
+      "const": "AES-256-KW",
+      "description": "CEK wrapping algorithm per RFC 3394. Frozen to AES-256-KW."
+    },
+    "kdf_profile": {
+      "type": "string",
+      "enum": ["scrypt-sha256-v1", "argon2id-v1"],
+      "description": "KDF profile for the primary (first) key slot. MUST match the first entry's key_slots[].kdf_profile. Per-slot kdf_profile is the contract; this top-level field is a convenience copy. Readers MUST use the per-slot value, not this top-level field."
+    },
+    "key_slots": {
+      "type": "array",
+      "minItems": 1,
+      "description": "At least one key slot. Each slot describes one way to unwrap the CEK. The CEK is wrapped once and the same wrapped bytes are referenced by every slot.",
+      "items": { "$ref": "#/$defs/key_slot" }
+    },
+    "iv": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9+/]+={0,2}$",
+      "description": "Base64 of the 12-byte (96-bit) AES-GCM nonce. MUST be unique per (CEK, slot) pair. GCM nonce reuse with the same key is catastrophic."
+    },
+    "tag": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9+/]+={0,2}$",
+      "description": "Base64 of the 16-byte AES-GCM authentication tag. A reader MUST verify this tag against the AAD constructed per RFC-0018 R5."
+    },
+    "ciphertext": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9+/]+={0,2}$",
+      "description": "Base64 of the encrypted payload. Variable length; GCM is a stream cipher so no padding."
+    }
+  },
+  "$defs": {
+    "key_slot": {
+      "type": "object",
+      "required": [
+        "slot",
+        "kdf_profile",
+        "kdf_params",
+        "wrap",
+        "wrapped_key"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "slot": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Opaque slot name for human readability (e.g. 'password', 'recovery', 'account-grant-1'). The contract is in kdf_profile and kdf_params, not in this string."
+        },
+        "kdf_profile": {
+          "type": "string",
+          "enum": ["scrypt-sha256-v1", "argon2id-v1"],
+          "description": "KDF profile for this slot. Readers MUST use this value, not the envelope-level kdf_profile. The non-collapse invariant requires a reader to fail with KDNA_KDF_UNSUPPORTED if this value is not supported AND no other slot offers a supported KDF."
+        },
+    "kdf_params": {
+      "type": "object",
+      "description": "KDF-specific parameters. The shape depends on the slot's kdf_profile (scrypt-sha256-v1 needs N/r/p/salt; argon2id-v1 needs t/m/p/salt). The application layer MUST verify that the params match the kdf_profile; this schema accepts both shapes and lets the consumer pick.",
+      "anyOf": [
+        { "$ref": "#/$defs/scrypt_params" },
+        { "$ref": "#/$defs/argon2_params" }
+      ]
+    },
+        "wrap": {
+          "type": "string",
+          "const": "AES-256-KW",
+          "description": "Key-wrapping algorithm for the CEK. Frozen to AES-256-KW."
+        },
+        "wrapped_key": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9+/]+={0,2}$",
+          "description": "Base64 of the 40-byte AES-256-KW output for a 32-byte CEK. Same bytes across all slots of the same envelope."
+        }
+      }
+    },
+    "scrypt_params": {
+      "type": "object",
+      "required": ["N", "r", "p", "salt"],
+      "additionalProperties": false,
+      "properties": {
+        "N": {
+          "type": "integer",
+          "minimum": 16384,
+          "maximum": 1048576,
+          "description": "scrypt cost parameter. RFC-0018 freezes N=32768 for v1; this range allows future minor upward adjustments under the same profile ID."
+        },
+        "r": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 32,
+          "description": "scrypt block size. RFC-0018 freezes r=8 for v1."
+        },
+        "p": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 16,
+          "description": "scrypt parallelization. RFC-0018 freezes p=1 for v1."
+        },
+        "salt": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9+/]+={0,2}$",
+          "description": "Base64 of the 16-byte (128-bit) random salt. MUST be unique per slot."
+        }
+      }
+    },
+    "argon2_params": {
+      "type": "object",
+      "required": ["t", "m", "p", "dkLen", "salt"],
+      "additionalProperties": false,
+      "properties": {
+        "t": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 16,
+          "description": "Argon2id time cost. RFC-0018 freezes t=3 for v1."
+        },
+        "m": {
+          "type": "integer",
+          "minimum": 65536,
+          "description": "Argon2id memory cost in KiB. RFC-0018 freezes m=65536 (64 MiB) for v1. A reader that sees m below 65536 MUST reject with KDNA_KDF_PARAMS_INVALID."
+        },
+        "p": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 16,
+          "description": "Argon2id parallelism (lanes). RFC-0018 freezes p=4 for v1."
+        },
+        "dkLen": {
+          "type": "integer",
+          "minimum": 16,
+          "maximum": 64,
+          "description": "Argon2id output length in bytes. RFC-0018 freezes dkLen=32 for v1."
+        },
+        "salt": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9+/]+={0,2}$",
+          "description": "Base64 of the 16-byte (128-bit) random salt. MUST be unique per slot."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Story 17 — Envelope canonical profile RFC freeze + test vectors (RFC #148 / Section 13)

The KDF decision was recorded in PRIVATE/STATUS/private/_user-decisions-needed.md on 2026-06-28 (Story 13 close). This PR delivers the spec freeze and test vectors against that decision.

## What ships

- RFC-0018 at rfcs/RFC-0018-kdna-envelope-aead-v1.md — the frozen canonical envelope profile. 10 normative rules (R1-R10) covering profile ID, envelope shape, key slots, KDF profiles, AAD format, Swift-port behaviour, IV/tag/ciphertext sizes, memory-only rule, test vector conformance, and error conditions.
- JSON Schema at specs/kdna-envelope-aead-v1.schema.json — the envelope shape in standard JSON Schema 2020-12 form. Validates the 3 published envelopes.
- 3 known-answer test vectors at conformance/kdna-envelope-aead-v1/:
  - vector-01-scrypt-basic.json — scrypt-sha256-v1, single password slot, basic round-trip.
  - vector-02-scrypt-multi-entry-aad.json — two AADs over the same CEK + IV + plaintext. Proves GCM invariant (same ciphertext, divergent tags) and cross-AAD swap rejection.
  - vector-03-argon2id-basic.json — argon2id-v1, single password slot, basic round-trip.
- Conformance runner at conformance/kdna-envelope-aead-v1.mjs — re-derives each vector from declared inputs and asserts equality. npm run conformance:envelope-aead.
- Vector generator at scripts/generate-envelope-aead-vectors.js — idempotent regenerator. Not published to consumers; reserved for future spec revisions.
- Spec updates:
  - specs/kdna-crypto-profiles.md — status promoted from Draft to Active; envelope section updated.
  - specs/kdna-crypto-protocol.md — P7 row added in the implementation roadmap.
  - SPEC.md — new section 11.1 documents the three profile IDs and the non-collapse invariant.
  - rfcs/README.md — RFC-0018 added to the index.
- package.json — new conformance:envelope-aead script.

## What does NOT change

- No core code change. The spec freeze is a pure-spec deliverable; the implementation lands in Story 24.
- The existing kdna-licensed-entry-v1 (RFC-0008) and kdna-password-protected-v1 (RFC-0009) profiles keep their own profile IDs. No silent migration. The non-collapse invariant forbids it.
- No new npm dependencies for the conformance runner; uses Node built-in crypto.scryptSync and @noble/hashes/argon2.js (already a transitive dep).
- The CBOR canonical encoding form is documented as future work; today conformance is JSON-only.

## Test results



The existing conformance:phase2 (16 fixtures, 4 schemas) still passes.

## Profile non-collapse invariant (R4.3) — the single most important rule

A reader that does not support the declared kdf_profile MUST fail with KDNA_KDF_UNSUPPORTED. There is no auto-downgrade path. A reader that picks the strongest KDF it can locally support lets an attacker craft the envelope to force the weaker path. The kdf_profile field is a contract, not a hint.

## Story 17 closes; Story 24 unblocked

The Argon2id binding + envelope implementation (Story 24) can now reference the frozen spec. The conformance runner is the canonical is-this-implementation-correct check.

Closes the Story 17 strategic-decision blocker recorded in PRIVATE/STATUS/private/_user-decisions-needed.md (2026-06-28).