### PR TITLE
[codex] Align public ecosystem truth with web package state

### DIFF
--- a/docs/kdna-ecosystem/00-current-truth.md
+++ b/docs/kdna-ecosystem/00-current-truth.md
@@ -31,7 +31,10 @@
 
 - Web packages are public repositories but are not published to npm as of
   2026-07-03. Treat their README promises as implementation targets until PR #1
-  in each web repository is merged and packages are published.
+  in each web repository is merged and packages are published. The current
+  server MVP covers upload/inspect/plan-load/load and activation proxying only;
+  server-side Studio export, remote forwarding, CORS policy helpers, and durable
+  Cloudflare/R2 storage are not shipped web-package capabilities yet.
 - Remote runtime and activation server are self-hostable support surfaces, not
   an AIKDNA-hosted loading or licensing service.
 - Swift runtime and Studio Swift are beta/support surfaces until parity is
@@ -58,7 +61,8 @@
 - B5: 旧 run.mjs → canonical-conformance (kdna)
 - Web package release path: merge PR #1 in `kdna-web-server`,
   `kdna-web-client`, `kdna-react`, and `create-kdna-web-app`, publish packages,
-  then run a generated-app smoke test against published versions.
+  then run a generated-app smoke test against published versions. Keep the
+  central `npm run validate:web-packages` gate green before publishing.
 - Public truth drift: keep this file, `docs/public-roadmap.md`,
   `ecosystem-manifest.json`, website copy, and package READMEs aligned whenever
   versions or maturity claims change.

--- a/docs/kdna-ecosystem/00-current-truth.md
+++ b/docs/kdna-ecosystem/00-current-truth.md
@@ -1,13 +1,43 @@
 # Current Truth (live)
 
+> Last updated: 2026-07-03. This file records the public ecosystem truth that
+> should constrain README, roadmap, website, and package claims.
+
 ## Versions
 
-| Component | npm | source |
-|---|---:|
-| @aikdna/kdna-cli | 0.28.1 | kdna-cli (main) |
-| @aikdna/kdna-studio-cli | 0.7.0 | kdna-studio-cli (main) |
-| @aikdna/kdna-core | 0.14.0 | kdna (packages/kdna-core) |
-| @aikdna/kdna-studio-core | 1.6.0 | kdna-studio-core (main) |
+| Component | npm latest | source version | public state |
+|---|---:|---:|---|
+| `@aikdna/kdna-core` | 0.15.10 | 0.15.10 | Beta runtime baseline for local public `.kdna` assets |
+| `@aikdna/kdna-cli` | 0.28.34 | 0.28.34 | Beta CLI baseline for validate / inspect / plan-load / load |
+| `@aikdna/kdna-studio-core` | 1.7.9 | 1.7.8 | Beta authoring SDK; npm is ahead of local source checkout |
+| `@aikdna/kdna-studio-cli` | 0.8.11 | 0.8.10 | Beta authoring CLI; npm is ahead of local source checkout |
+| `@aikdna/kdna-mcp-server` | 0.2.4 | 0.2.4 | Experimental MCP bridge |
+| `@aikdna/kdna-activation-server` | 0.1.0 | 0.1.0 | Experimental self-hosted licensed-mode support |
+| `@aikdna/kdna-remote-server` | 0.1.0 | 0.1.0 | Experimental self-hosted remote projection support |
+| `@aikdna/kdna-web-server` | not published | 0.1.0 | Experimental public repo; MVP implementation in PR #1 |
+| `@aikdna/kdna-web-client` | not published | 0.1.0 | Experimental public repo; MVP implementation in PR #1 |
+| `@aikdna/kdna-react` | not published | 0.1.0 | Experimental public repo; MVP implementation in PR #1 |
+| `create-kdna-web-app` | not published | 0.1.0 | Experimental public repo; MVP implementation in PR #1 |
+
+## Stable Baseline
+
+- KDNA Core v1 local public `.kdna` assets are the current public baseline.
+- `kdna validate`, `kdna inspect`, `kdna plan-load`, and `kdna load
+  --profile=compact --as=prompt` are the recommended first-run path.
+- KDNA Core remains content-neutral: format validity does not imply content
+  endorsement, ranking, or quality certification.
+
+## Experimental / Not Yet Stable Baseline
+
+- Web packages are public repositories but are not published to npm as of
+  2026-07-03. Treat their README promises as implementation targets until PR #1
+  in each web repository is merged and packages are published.
+- Remote runtime and activation server are self-hostable support surfaces, not
+  an AIKDNA-hosted loading or licensing service.
+- Swift runtime and Studio Swift are beta/support surfaces until parity is
+  proven against fixed Core v1 conformance fixtures.
+- Hosted registry, marketplace, content ranking, and paid distribution remain
+  out of scope for KDNA Core v1.
 
 ## P0 fix log
 
@@ -26,3 +56,9 @@
 ## Remaining P1
 
 - B5: 旧 run.mjs → canonical-conformance (kdna)
+- Web package release path: merge PR #1 in `kdna-web-server`,
+  `kdna-web-client`, `kdna-react`, and `create-kdna-web-app`, publish packages,
+  then run a generated-app smoke test against published versions.
+- Public truth drift: keep this file, `docs/public-roadmap.md`,
+  `ecosystem-manifest.json`, website copy, and package READMEs aligned whenever
+  versions or maturity claims change.

--- a/docs/open-ecosystem-readiness.md
+++ b/docs/open-ecosystem-readiness.md
@@ -16,6 +16,9 @@ verify, publish, and contribute without relying on private project knowledge.
 - Reference domains publish limitations, evals, and benchmark evidence.
 - Skill + KDNA demo explains judgment-layer separation.
 - RFC index defines protocol participation path.
+- Web package path is implemented, published, and smoke-tested end to end:
+  `kdna-web-server` -> `kdna-web-client` -> `kdna-react` ->
+  `create-kdna-web-app`.
 
 ## Completion Criteria
 
@@ -25,3 +28,6 @@ An external developer can:
 2. Run conformance tests to check compatibility.
 3. (Registry is out of scope; see 00-current-truth.md. Local asset creation via `kdna demo` / `kdna pack` / `kdna-studio-cli` is the supported path.)
 4. Connect KDNA to an agent through MCP or a loader skill.
+5. Scaffold a KDNA web application from published packages and complete an
+   upload -> inspect -> plan-load -> load flow without private workspace
+   knowledge.

--- a/docs/public-roadmap.md
+++ b/docs/public-roadmap.md
@@ -1,63 +1,91 @@
 # KDNA Public Roadmap
 
-> Last updated: 2026-06-30. This is the public-facing roadmap summary.
+> Last updated: 2026-07-03. This is the public-facing roadmap summary.
 > Detailed sprint planning is internal.
 
 ## Where we are
 
-The KDNA Core v1 protocol, runtime, and toolchain are **complete**.
-All 21 planned stories have shipped:
+The KDNA Core v1 local public asset path is the current public baseline. The
+protocol, CLI, Core runtime, and Studio authoring tools are usable today for
+creating, validating, planning, and loading local public `.kdna` assets.
+
+Do not read this as a claim that every support surface is stable. Hosted
+registry, marketplace, paid distribution, AIKDNA-hosted loading, and broad
+cross-language parity are not part of the stable public baseline.
 
 | Layer | Status | What shipped |
 |---|---|---|
 | **File format** | Stable | Container layout, manifest schema, payload profile v1, checksums |
 | **Runtime loading** | Stable | `kdna load`, `kdna validate`, `kdna plan-load`, `kdna pack`, `kdna unpack` |
-| **Identity & trust** | Stable | Ed25519 signing, signature verification, trust levels, deprecation signaling |
-| **Revocation** | Stable | Signed revocation records, revocation status checks, cross-key attack resistance |
-| **Watermarking** | Stable | Payload-level HMAC tracing for licensed and remote assets |
-| **Composition** | Stable | Bundle payload type, dependency runtime, topological ordering, conflict analysis |
-| **Remote runtime** | Stable | Self-hostable remote projection server, CLI remote-mode client |
-| **Activation server** | Stable | Self-hostable activation server for licensed asset entitlements |
-| **Asset inheritance** | Stable | `extends` field, axiom / boundary merge semantics |
-| **RAG namespacing** | Stable | `rag_namespace` isolation per Bundle component |
-| **Audit logging** | Stable | Local audit trail for all load events |
-| **Context budget** | Stable | Token cost reporting in `plan-load` output |
+| **Identity & trust** | Beta | Ed25519 signing, signature verification, trust levels, deprecation signaling |
+| **Revocation** | Beta | Signed revocation records, revocation status checks, cross-key attack resistance |
+| **Watermarking** | Beta | Payload-level HMAC tracing for licensed and remote assets |
+| **Composition** | Beta | Bundle payload type, dependency runtime, topological ordering, conflict analysis |
+| **Remote runtime** | Experimental | Self-hostable remote projection server, CLI remote-mode client |
+| **Activation server** | Experimental | Self-hostable activation server for licensed asset entitlements |
+| **Asset inheritance** | Beta | `extends` field, axiom / boundary merge semantics |
+| **RAG namespacing** | Beta | `rag_namespace` isolation per Bundle component |
+| **Audit logging** | Beta | Local audit trail for load events |
+| **Context budget** | Beta | Token cost reporting in `plan-load` output |
 | **Studio authoring** | Beta | `kdna-studio create`, `import`, `distill`, `card`, `export` |
 | **Agent integration** | Beta | `kdna-loader` skill for OpenCode, Codex, Claude Code, Cursor |
+| **Web packages** | Experimental | Public repos exist; MVP implementation PRs are open; npm packages are not published yet |
 
 ## What's available now
 
-- **`@aikdna/kdna-cli` v0.28.31** — full runtime CLI
-- **`@aikdna/kdna-core` v0.15.9** — embeddable JS runtime library
-- **`@aikdna/kdna-studio-cli` v0.8.9** — authoring CLI
-- **`@aikdna/kdna-studio-core` v1.7.7** — authoring SDK
-- **`@aikdna/kdna-remote-server` v0.1.1** — self-hostable projection server
-- **`@aikdna/kdna-activation-server` v0.1.1** — self-hostable activation server
-- **Public assets**: `agent:project_context`, `agent:completion_adjudication`
+- **`@aikdna/kdna-cli` v0.28.34** - runtime CLI
+- **`@aikdna/kdna-core` v0.15.10** - embeddable JS runtime library
+- **`@aikdna/kdna-studio-cli` v0.8.11** - authoring CLI on npm
+- **`@aikdna/kdna-studio-core` v1.7.9** - authoring SDK on npm
+- **`@aikdna/kdna-mcp-server` v0.2.4** - experimental MCP bridge
+- **`@aikdna/kdna-remote-server` v0.1.0** - experimental self-hostable projection server
+- **`@aikdna/kdna-activation-server` v0.1.0** - experimental self-hostable activation server
+- **Public assets**: see `aikdna/kdna-assets` `assets.json` and GitHub Releases
+
+Not yet published to npm as of 2026-07-03:
+
+- `@aikdna/kdna-web-server`
+- `@aikdna/kdna-web-client`
+- `@aikdna/kdna-react`
+- `create-kdna-web-app`
 
 ## What comes next
 
 The next phase focuses on four areas:
 
-### 1. More public assets (the real bottleneck)
+### 1. Web package release path
+
+The four public web package repositories currently need PR #1 merged, package
+publication, and a real generated-app smoke test:
+
+- `kdna-web-server`
+- `kdna-web-client`
+- `kdna-react`
+- `create-kdna-web-app`
+
+Until that happens, treat the web package READMEs as implementation targets, not
+published stable surfaces.
+
+### 2. More public assets
 
 A protocol without content is an empty container. The bottleneck is not more protocol features — it's high-quality `.kdna` assets that demonstrate what judgment-in-a-file actually feels like.
 
 We are looking for domain experts who want to package their judgment. If you have a domain where you consistently apply specific principles, boundaries, and standards that a generalist wouldn't have — that's exactly what KDNA is designed for. Read the [30-minute authoring guide](./30-minute-authoring-guide.md).
 
-### 2. Applications built on KDNA
+### 3. Applications built on KDNA
 
 `.kdna` assets are not only for personal agent configuration — they are the judgment layer that applications can build on top of. When an application's core reasoning is a versioned `.kdna` asset, upgrading the asset improves every user's output on the same day. This is KDNA as infrastructure, not just as personal tooling.
 
-Applications in this direction are in development. The protocol is ready. The toolchain is ready.
+Applications in this direction are in development. The local public asset path
+is ready; web adapters are the next open integration surface.
 
-### 3. Native app experience
+### 4. Native app experience
 
 The current path is CLI + MCP. Native app experiences for loading, comparing, and authoring `.kdna` assets are in development. Swift runtime parity (`kdna-core-swift`) is a prerequisite for full native integration.
 
-### 4. Test coverage and reliability
+### 5. Test coverage and reliability
 
-`@aikdna/kdna-cli` has 190 tests but several high-complexity command
+`@aikdna/kdna-cli` has more than 200 tests but several high-complexity command
 modules (agent, cluster, compare, diff) lack unit tests. Good first
 issues are available for contributors — see [open issues](https://github.com/aikdna/kdna-cli/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
 

--- a/docs/public-roadmap.md
+++ b/docs/public-roadmap.md
@@ -64,7 +64,10 @@ publication, and a real generated-app smoke test:
 - `create-kdna-web-app`
 
 Until that happens, treat the web package READMEs as implementation targets, not
-published stable surfaces.
+published stable surfaces. The current web server MVP is intentionally narrow:
+upload/inspect/plan-load/load plus activation proxying. Server-side Studio
+export, remote forwarding, CORS policy helpers, and durable Cloudflare/R2
+storage remain future web-package work.
 
 ### 2. More public assets
 

--- a/ecosystem-manifest.json
+++ b/ecosystem-manifest.json
@@ -9,14 +9,14 @@
     "Future",
     "Draft Normative"
   ],
-  "baseline_statement": "KDNA Core v1 public local .kdna assets are beta. Protected assets, remote runtime, registry, signing, encryption, paid authorization, and full cross-implementation parity are not stable baseline claims.",
+  "baseline_statement": "KDNA Core v1 public local .kdna assets are beta. Web packages are experimental until PR #1 in each web repository is merged and packages are published. Protected assets, remote runtime, registry, signing, encryption, paid authorization, and full cross-implementation parity are not stable baseline claims.",
   "components": [
     {
       "repository": "aikdna/kdna",
       "local_path": ".",
       "npm_package": "@aikdna/kdna-core",
       "package_json": "packages/kdna-core/package.json",
-      "current_version": "0.15.0",
+      "current_version": "0.15.10",
       "lifecycle": "Beta",
       "supported_kdna_version": "1.0",
       "supported_access_modes": ["public"],
@@ -34,7 +34,7 @@
       "local_path": "../kdna-cli",
       "npm_package": "@aikdna/kdna-cli",
       "package_json": "../kdna-cli/package.json",
-      "current_version": "0.28.9",
+      "current_version": "0.28.34",
       "lifecycle": "Beta",
       "supported_kdna_version": "1.0",
       "supported_access_modes": ["public"],
@@ -68,7 +68,7 @@
       "local_path": "../kdna-studio-core",
       "npm_package": "@aikdna/kdna-studio-core",
       "package_json": "../kdna-studio-core/package.json",
-      "current_version": "1.7.0",
+      "current_version": "1.7.8",
       "lifecycle": "Beta",
       "supported_kdna_version": "1.0",
       "supported_access_modes": ["public"],
@@ -85,7 +85,7 @@
       "local_path": "../kdna-studio-cli",
       "npm_package": "@aikdna/kdna-studio-cli",
       "package_json": "../kdna-studio-cli/package.json",
-      "current_version": "0.8.1",
+      "current_version": "0.8.10",
       "lifecycle": "Beta",
       "supported_kdna_version": "1.0",
       "supported_access_modes": ["public"],
@@ -93,6 +93,114 @@
       "conformance_commit": "e2674e3cf8093d6656d51015a4658e32b1992916",
       "known_limitations": ["author happy path is available for public local assets only"],
       "recommended_entrypoint": "kdna-studio create/add/approve/export v1",
+      "legacy_replacement": null
+    },
+    {
+      "repository": "aikdna/kdna-activation-server",
+      "local_path": "../kdna-activation-server",
+      "npm_package": "@aikdna/kdna-activation-server",
+      "package_json": "../kdna-activation-server/package.json",
+      "current_version": "0.1.0",
+      "lifecycle": "Experimental",
+      "supported_kdna_version": "1.0",
+      "supported_access_modes": ["licensed"],
+      "supported_entitlement_profiles": ["license_key"],
+      "conformance_commit": null,
+      "known_limitations": [
+        "self-hosted support surface only; not an AIKDNA-hosted activation service",
+        "paid distribution and commercial delivery flows are not part of the public Core v1 baseline"
+      ],
+      "recommended_entrypoint": "self-host only after reviewing specs/kdna-authorization-contract.md",
+      "legacy_replacement": null
+    },
+    {
+      "repository": "aikdna/kdna-remote-server",
+      "local_path": "../kdna-remote-server",
+      "npm_package": "@aikdna/kdna-remote-server",
+      "package_json": "../kdna-remote-server/package.json",
+      "current_version": "0.1.0",
+      "lifecycle": "Experimental",
+      "supported_kdna_version": "1.0",
+      "supported_access_modes": ["remote"],
+      "supported_entitlement_profiles": [],
+      "conformance_commit": null,
+      "known_limitations": [
+        "self-hosted projection server only; there is no AIKDNA-hosted remote loading service",
+        "remote-mode interoperability is not yet a stable baseline claim"
+      ],
+      "recommended_entrypoint": "kdna load <asset> --remote-server <self-hosted-url> --profile=compact --as=prompt",
+      "legacy_replacement": null
+    },
+    {
+      "repository": "aikdna/kdna-web-server",
+      "local_path": "../kdna-web-server",
+      "npm_package": "@aikdna/kdna-web-server",
+      "package_json": "../kdna-web-server/package.json",
+      "current_version": "0.1.0",
+      "lifecycle": "Experimental",
+      "supported_kdna_version": "1.0",
+      "supported_access_modes": ["public"],
+      "supported_entitlement_profiles": [],
+      "conformance_commit": null,
+      "known_limitations": [
+        "not published to npm as of 2026-07-03",
+        "MVP implementation is in PR #1 and should not be treated as a stable runtime surface before merge and release"
+      ],
+      "recommended_entrypoint": "wait for package publication, then mount the server adapter and run npm run ci",
+      "legacy_replacement": null
+    },
+    {
+      "repository": "aikdna/kdna-web-client",
+      "local_path": "../kdna-web-client",
+      "npm_package": "@aikdna/kdna-web-client",
+      "package_json": "../kdna-web-client/package.json",
+      "current_version": "0.1.0",
+      "lifecycle": "Experimental",
+      "supported_kdna_version": "1.0",
+      "supported_access_modes": ["public"],
+      "supported_entitlement_profiles": [],
+      "conformance_commit": null,
+      "known_limitations": [
+        "not published to npm as of 2026-07-03",
+        "browser utilities must never perform KDNA decryption; server-side loading remains required"
+      ],
+      "recommended_entrypoint": "wait for package publication, then use readKDNAMetadata plus server-side plan-load/load",
+      "legacy_replacement": null
+    },
+    {
+      "repository": "aikdna/kdna-react",
+      "local_path": "../kdna-react",
+      "npm_package": "@aikdna/kdna-react",
+      "package_json": "../kdna-react/package.json",
+      "current_version": "0.1.0",
+      "lifecycle": "Experimental",
+      "supported_kdna_version": "1.0",
+      "supported_access_modes": ["public"],
+      "supported_entitlement_profiles": [],
+      "conformance_commit": null,
+      "known_limitations": [
+        "not published to npm as of 2026-07-03",
+        "React components depend on the web server contract and should be released after web-server and web-client"
+      ],
+      "recommended_entrypoint": "wait for package publication, then use endpoint-backed hooks/components",
+      "legacy_replacement": null
+    },
+    {
+      "repository": "aikdna/create-kdna-web-app",
+      "local_path": "../create-kdna-web-app",
+      "npm_package": "create-kdna-web-app",
+      "package_json": "../create-kdna-web-app/package.json",
+      "current_version": "0.1.0",
+      "lifecycle": "Experimental",
+      "supported_kdna_version": "1.0",
+      "supported_access_modes": ["public"],
+      "supported_entitlement_profiles": [],
+      "conformance_commit": null,
+      "known_limitations": [
+        "not published to npm as of 2026-07-03",
+        "generated-app smoke tests should run only after the sibling web packages are published"
+      ],
+      "recommended_entrypoint": "npx create-kdna-web-app <app> after coordinated web package publication",
       "legacy_replacement": null
     },
     {

--- a/ecosystem-manifest.json
+++ b/ecosystem-manifest.json
@@ -144,7 +144,8 @@
       "conformance_commit": null,
       "known_limitations": [
         "not published to npm as of 2026-07-03",
-        "MVP implementation is in PR #1 and should not be treated as a stable runtime surface before merge and release"
+        "MVP implementation is in PR #1 and should not be treated as a stable runtime surface before merge and release",
+        "server-side Studio export, remote forwarding, CORS helpers, and durable Cloudflare/R2 storage are not implemented in the web-server MVP"
       ],
       "recommended_entrypoint": "wait for package publication, then mount the server adapter and run npm run ci",
       "legacy_replacement": null
@@ -198,7 +199,8 @@
       "conformance_commit": null,
       "known_limitations": [
         "not published to npm as of 2026-07-03",
-        "generated-app smoke tests should run only after the sibling web packages are published"
+        "generated-app smoke tests should run only after the sibling web packages are published",
+        "generated templates target the public upload/inspect/plan-load/load flow only; remote-mode web forwarding is not wired"
       ],
       "recommended_entrypoint": "npx create-kdna-web-app <app> after coordinated web package publication",
       "legacy_replacement": null

--- a/packages/kdna-core/src/asset-reader.js
+++ b/packages/kdna-core/src/asset-reader.js
@@ -47,7 +47,7 @@ function parseJson(buf, entryName) {
   try {
     return JSON.parse(Buffer.isBuffer(buf) ? buf.toString('utf8') : String(buf));
   } catch (e) {
-    throw new Error(`${entryName}: invalid JSON: ${e.message}`);
+    throw new Error(`${entryName}: invalid JSON: ${e.message}`, { cause: e });
   }
 }
 
@@ -325,7 +325,7 @@ function verifyHumanLockSignatures(coreData, manifest, errors, warnings) {
   ];
 
   let verified = 0, missing = 0, invalid = 0;
-  for (const [arrayName, _cardType] of CORE_CARD_ARRAYS) {
+  for (const [arrayName] of CORE_CARD_ARRAYS) {
     const cards = coreData?.[arrayName];
     if (!Array.isArray(cards) || cards.length === 0) continue;
 

--- a/packages/kdna-core/src/crypto-profile.js
+++ b/packages/kdna-core/src/crypto-profile.js
@@ -102,7 +102,6 @@ function hkdfSha256(ikm, salt = null, info = '', length = 32) {
 
 // ── AES-256-KW (RFC 3394) ─────────────────────────────────────────
 
-const AES_BLOCK = 16;
 const KW_IV = Buffer.from('a6a6a6a6a6a6a6a6', 'hex'); // RFC 3394 default IV
 
 function aesWrap(key, plaintext) {

--- a/packages/kdna-core/src/public-api.js
+++ b/packages/kdna-core/src/public-api.js
@@ -110,7 +110,7 @@ async function validateKDNA(input, options = {}) {
   const reader = readerFrom(options);
   const asset = await asAsset(input, { ...options, reader });
   const assetResult = await reader.verify(asset, options);
-  let dataMap = null;
+  let dataMap;
   let lintResult = { errors: [], warnings: [] };
   let schemaResult = { errors: [], warnings: [] };
   let crossFileResult = { errors: [], warnings: [] };

--- a/packages/kdna-core/src/v1/index.js
+++ b/packages/kdna-core/src/v1/index.js
@@ -521,7 +521,7 @@ function readV1Layout(absPath) {
 
   const map = {};
   let entries = null; // ZIP entries if container
-  let kind = null; // 'dir' | 'file'
+  let kind; // 'dir' | 'file'
 
   if (stat.isDirectory()) {
     kind = 'dir';
@@ -589,7 +589,7 @@ function readV1Layout(absPath) {
   try {
     manifest = parseJsonEntry('kdna.json', map['kdna.json']);
   } catch (e) {
-    throw new Error(`kdna.json is not valid JSON: ${e.message}`);
+    throw new Error(`kdna.json is not valid JSON: ${e.message}`, { cause: e });
   }
   if (manifest.lineage !== undefined && Array.isArray(manifest.lineage)) {
     throw new Error('kdna.json.lineage must be an object, not an array');
@@ -1773,7 +1773,7 @@ function loadV1Unsafe(inputPath, opts = {}) {
     const rawPayload = v1.map['payload.kdnab'];
     payload = parseJsonEntry('payload.kdnab', rawPayload);
   } catch (e) {
-    throw new Error(`payload.kdnab is not valid JSON: ${e.message}`);
+    throw new Error(`payload.kdnab is not valid JSON: ${e.message}`, { cause: e });
   }
 
   if (payload.profile && payload.ciphertext && (m.payload?.encrypted || m.encryption?.encrypted_entries?.includes('payload.kdnab'))) {
@@ -1946,7 +1946,7 @@ function loadV1Unsafe(inputPath, opts = {}) {
         }));
         result.inheritance_applied = true;
       }
-    } catch (_) {
+    } catch {
       // extends merge is best-effort — never block load
       result.inheritance_applied = false;
     }

--- a/packages/kdna-core/src/workpack-pure.js
+++ b/packages/kdna-core/src/workpack-pure.js
@@ -169,9 +169,6 @@ function checkWorkPackStructure(manifest, rootDir) {
  */
 function inspectWorkPack(manifest, rootDir) {
   const kdnaMode = manifest.kdna?.mode || 'unknown';
-  const kdnaCount =
-    kdnaMode === 'single' ? 1 : (manifest.kdna?.assets || []).length;
-
   const structure = checkWorkPackStructure(manifest, rootDir);
 
   return {
@@ -240,7 +237,8 @@ function _lazyAjv() {
     return _ajvInstance;
   } catch (e) {
     throw new Error(
-      'ajv is required for Work Pack validation. Install: npm install ajv ajv-formats'
+      'ajv is required for Work Pack validation. Install: npm install ajv ajv-formats',
+      { cause: e },
     );
   }
 }


### PR DESCRIPTION
## Summary

Aligns KDNA public truth docs and ecosystem metadata with the current open ecosystem state.

- Updates `docs/kdna-ecosystem/00-current-truth.md` with current npm/source versions and explicit stable vs experimental boundaries.
- Updates `docs/public-roadmap.md` to avoid over-claiming stable support surfaces and to mark the web packages as experimental/unpublished until PR #1 in each web repo is merged and published.
- Adds activation, remote, web-server, web-client, React, and scaffolder components to `ecosystem-manifest.json` with current source versions and known limitations.
- Updates `docs/open-ecosystem-readiness.md` so the web package path has a concrete readiness gate and completion criterion.

## Impact

This reduces public-claim drift: external users can distinguish the current local public `.kdna` baseline from experimental support surfaces, especially the not-yet-published web packages.

## Verification

- `node -e "JSON.parse(require('fs').readFileSync('ecosystem-manifest.json','utf8')); console.log('json ok')"` -> passed
- `npm run validate:ecosystem-manifest` -> passed, 18 components
- `npm run validate:public-truth` -> passed

## Notes

This PR intentionally does not claim that the web packages are available on npm yet. It records their current source version and pending PR/publication status.
