### PR TITLE
[codex] Fix core lint baseline

### DIFF
--- a/packages/kdna-core/src/asset-reader.js
+++ b/packages/kdna-core/src/asset-reader.js
@@ -47,7 +47,7 @@ function parseJson(buf, entryName) {
   try {
     return JSON.parse(Buffer.isBuffer(buf) ? buf.toString('utf8') : String(buf));
   } catch (e) {
-    throw new Error(`${entryName}: invalid JSON: ${e.message}`);
+    throw new Error(`${entryName}: invalid JSON: ${e.message}`, { cause: e });
   }
 }
 
@@ -325,7 +325,7 @@ function verifyHumanLockSignatures(coreData, manifest, errors, warnings) {
   ];
 
   let verified = 0, missing = 0, invalid = 0;
-  for (const [arrayName, _cardType] of CORE_CARD_ARRAYS) {
+  for (const [arrayName] of CORE_CARD_ARRAYS) {
     const cards = coreData?.[arrayName];
     if (!Array.isArray(cards) || cards.length === 0) continue;
 

--- a/packages/kdna-core/src/crypto-profile.js
+++ b/packages/kdna-core/src/crypto-profile.js
@@ -102,7 +102,6 @@ function hkdfSha256(ikm, salt = null, info = '', length = 32) {
 
 // ── AES-256-KW (RFC 3394) ─────────────────────────────────────────
 
-const AES_BLOCK = 16;
 const KW_IV = Buffer.from('a6a6a6a6a6a6a6a6', 'hex'); // RFC 3394 default IV
 
 function aesWrap(key, plaintext) {

--- a/packages/kdna-core/src/public-api.js
+++ b/packages/kdna-core/src/public-api.js
@@ -110,7 +110,7 @@ async function validateKDNA(input, options = {}) {
   const reader = readerFrom(options);
   const asset = await asAsset(input, { ...options, reader });
   const assetResult = await reader.verify(asset, options);
-  let dataMap = null;
+  let dataMap;
   let lintResult = { errors: [], warnings: [] };
   let schemaResult = { errors: [], warnings: [] };
   let crossFileResult = { errors: [], warnings: [] };

--- a/packages/kdna-core/src/v1/index.js
+++ b/packages/kdna-core/src/v1/index.js
@@ -521,7 +521,7 @@ function readV1Layout(absPath) {
 
   const map = {};
   let entries = null; // ZIP entries if container
-  let kind = null; // 'dir' | 'file'
+  let kind; // 'dir' | 'file'
 
   if (stat.isDirectory()) {
     kind = 'dir';
@@ -589,7 +589,7 @@ function readV1Layout(absPath) {
   try {
     manifest = parseJsonEntry('kdna.json', map['kdna.json']);
   } catch (e) {
-    throw new Error(`kdna.json is not valid JSON: ${e.message}`);
+    throw new Error(`kdna.json is not valid JSON: ${e.message}`, { cause: e });
   }
   if (manifest.lineage !== undefined && Array.isArray(manifest.lineage)) {
     throw new Error('kdna.json.lineage must be an object, not an array');
@@ -1773,7 +1773,7 @@ function loadV1Unsafe(inputPath, opts = {}) {
     const rawPayload = v1.map['payload.kdnab'];
     payload = parseJsonEntry('payload.kdnab', rawPayload);
   } catch (e) {
-    throw new Error(`payload.kdnab is not valid JSON: ${e.message}`);
+    throw new Error(`payload.kdnab is not valid JSON: ${e.message}`, { cause: e });
   }
 
   if (payload.profile && payload.ciphertext && (m.payload?.encrypted || m.encryption?.encrypted_entries?.includes('payload.kdnab'))) {
@@ -1946,7 +1946,7 @@ function loadV1Unsafe(inputPath, opts = {}) {
         }));
         result.inheritance_applied = true;
       }
-    } catch (_) {
+    } catch {
       // extends merge is best-effort — never block load
       result.inheritance_applied = false;
     }

--- a/packages/kdna-core/src/workpack-pure.js
+++ b/packages/kdna-core/src/workpack-pure.js
@@ -169,9 +169,6 @@ function checkWorkPackStructure(manifest, rootDir) {
  */
 function inspectWorkPack(manifest, rootDir) {
   const kdnaMode = manifest.kdna?.mode || 'unknown';
-  const kdnaCount =
-    kdnaMode === 'single' ? 1 : (manifest.kdna?.assets || []).length;
-
   const structure = checkWorkPackStructure(manifest, rootDir);
 
   return {
@@ -240,7 +237,8 @@ function _lazyAjv() {
     return _ajvInstance;
   } catch (e) {
     throw new Error(
-      'ajv is required for Work Pack validation. Install: npm install ajv ajv-formats'
+      'ajv is required for Work Pack validation. Install: npm install ajv ajv-formats',
+      { cause: e },
     );
   }
 }


### PR DESCRIPTION
## Summary

Fixes the current `packages/kdna-core/src/*` lint baseline so CI failures on follow-on open ecosystem PRs point at the actual changed surface again.

Changes are intentionally narrow:

- preserve caught JSON/AJV errors with `Error.cause`
- remove unused locals flagged by eslint
- remove useless initial assignments that eslint treats as errors

## Why

`open/kdna` PR #166 and PR #167 are currently reporting lint failures from pre-existing core files, unrelated to their public-truth and web-readiness changes. This PR restores `npm run lint` as a useful gate before we continue landing the ecosystem stabilization wave.

## Verification

- `npm run lint` -> passed
- `npm test` -> passed, 104/104
