### PR TITLE
[codex] Block internal workspace path leaks

### DIFF
--- a/docs/maturity.md
+++ b/docs/maturity.md
@@ -44,13 +44,13 @@ KDNA is an open file format for packaging scoped judgment. The project has reach
 - **Cross-language parity** — `@aikdna/kdna-core` (JS) is the public
   first-run path. `kdna-core-swift` and `kdna-studio-swift` are
   beta until parity is proven against fixed Core v1 conformance
-  fixtures (see `PRIVATE/STATUS/open/kdna-core-swift.md`).
+  fixtures published through the public Swift repositories.
 
 ### Not part of the public baseline
 
 - Internal test infrastructure (`aikdna/kdna-lab`) is referenced by
   some RFCs as audit anchors but is a private repo.
-- Any path under `PRIVATE/` is internal-only. Do not publish to GitHub.
+- Internal-only workspace paths must not appear in public docs.
 
 ## Release cadence
 

--- a/packages/kdna-core/src/asset-reader.js
+++ b/packages/kdna-core/src/asset-reader.js
@@ -47,7 +47,7 @@ function parseJson(buf, entryName) {
   try {
     return JSON.parse(Buffer.isBuffer(buf) ? buf.toString('utf8') : String(buf));
   } catch (e) {
-    throw new Error(`${entryName}: invalid JSON: ${e.message}`);
+    throw new Error(`${entryName}: invalid JSON: ${e.message}`, { cause: e });
   }
 }
 
@@ -325,7 +325,7 @@ function verifyHumanLockSignatures(coreData, manifest, errors, warnings) {
   ];
 
   let verified = 0, missing = 0, invalid = 0;
-  for (const [arrayName, _cardType] of CORE_CARD_ARRAYS) {
+  for (const [arrayName] of CORE_CARD_ARRAYS) {
     const cards = coreData?.[arrayName];
     if (!Array.isArray(cards) || cards.length === 0) continue;
 

--- a/packages/kdna-core/src/crypto-profile.js
+++ b/packages/kdna-core/src/crypto-profile.js
@@ -102,7 +102,6 @@ function hkdfSha256(ikm, salt = null, info = '', length = 32) {
 
 // ── AES-256-KW (RFC 3394) ─────────────────────────────────────────
 
-const AES_BLOCK = 16;
 const KW_IV = Buffer.from('a6a6a6a6a6a6a6a6', 'hex'); // RFC 3394 default IV
 
 function aesWrap(key, plaintext) {

--- a/packages/kdna-core/src/public-api.js
+++ b/packages/kdna-core/src/public-api.js
@@ -110,7 +110,7 @@ async function validateKDNA(input, options = {}) {
   const reader = readerFrom(options);
   const asset = await asAsset(input, { ...options, reader });
   const assetResult = await reader.verify(asset, options);
-  let dataMap = null;
+  let dataMap;
   let lintResult = { errors: [], warnings: [] };
   let schemaResult = { errors: [], warnings: [] };
   let crossFileResult = { errors: [], warnings: [] };

--- a/packages/kdna-core/src/v1/index.js
+++ b/packages/kdna-core/src/v1/index.js
@@ -521,7 +521,7 @@ function readV1Layout(absPath) {
 
   const map = {};
   let entries = null; // ZIP entries if container
-  let kind = null; // 'dir' | 'file'
+  let kind; // 'dir' | 'file'
 
   if (stat.isDirectory()) {
     kind = 'dir';
@@ -589,7 +589,7 @@ function readV1Layout(absPath) {
   try {
     manifest = parseJsonEntry('kdna.json', map['kdna.json']);
   } catch (e) {
-    throw new Error(`kdna.json is not valid JSON: ${e.message}`);
+    throw new Error(`kdna.json is not valid JSON: ${e.message}`, { cause: e });
   }
   if (manifest.lineage !== undefined && Array.isArray(manifest.lineage)) {
     throw new Error('kdna.json.lineage must be an object, not an array');
@@ -1773,7 +1773,7 @@ function loadV1Unsafe(inputPath, opts = {}) {
     const rawPayload = v1.map['payload.kdnab'];
     payload = parseJsonEntry('payload.kdnab', rawPayload);
   } catch (e) {
-    throw new Error(`payload.kdnab is not valid JSON: ${e.message}`);
+    throw new Error(`payload.kdnab is not valid JSON: ${e.message}`, { cause: e });
   }
 
   if (payload.profile && payload.ciphertext && (m.payload?.encrypted || m.encryption?.encrypted_entries?.includes('payload.kdnab'))) {
@@ -1946,7 +1946,7 @@ function loadV1Unsafe(inputPath, opts = {}) {
         }));
         result.inheritance_applied = true;
       }
-    } catch (_) {
+    } catch {
       // extends merge is best-effort — never block load
       result.inheritance_applied = false;
     }

--- a/packages/kdna-core/src/workpack-pure.js
+++ b/packages/kdna-core/src/workpack-pure.js
@@ -169,9 +169,6 @@ function checkWorkPackStructure(manifest, rootDir) {
  */
 function inspectWorkPack(manifest, rootDir) {
   const kdnaMode = manifest.kdna?.mode || 'unknown';
-  const kdnaCount =
-    kdnaMode === 'single' ? 1 : (manifest.kdna?.assets || []).length;
-
   const structure = checkWorkPackStructure(manifest, rootDir);
 
   return {
@@ -240,7 +237,8 @@ function _lazyAjv() {
     return _ajvInstance;
   } catch (e) {
     throw new Error(
-      'ajv is required for Work Pack validation. Install: npm install ajv ajv-formats'
+      'ajv is required for Work Pack validation. Install: npm install ajv ajv-formats',
+      { cause: e },
     );
   }
 }

--- a/scripts/check-public-surface.mjs
+++ b/scripts/check-public-surface.mjs
@@ -15,6 +15,9 @@
 //      forbidden set is sourced from PRIVATE/STATUS/open/kdna.md [BLOCKING]
 //      entries: aikdna/kdna-website, atomspeak. Update by appending, not
 //      editing history.
+//   3. Internal workspace path: any literal PRIVATE/... path outside
+//      allowlisted audit/history files. Public docs must describe public
+//      evidence, not point readers at inaccessible workspace paths.
 //
 // Allowlist rationale: RFC files (specs/RFC-*) are technical documents that
 // legitimately reference private repos as test fixtures and worked examples.
@@ -37,9 +40,13 @@ const ALLOWLIST_PATHS = new Set([
   // names. They live under docs/audits/ and docs/rfc-status.md.
   'docs/audits/',
   'docs/rfc-status.md',
+  // Known workflow-file exception: this public comment should be cleaned up,
+  // but the current GitHub OAuth token cannot push workflow edits.
+  '.github/workflows/publish.yml',
 ]);
 
 const REDACTED_PATTERN = /\bREDACTED\b/;
+const PRIVATE_PATH_PATTERN = /\bPRIVATE[\\/]/;
 const FORBIDDEN_PATTERNS = [
   { name: 'aikdna/kdna-website', pattern: /\baikdna\/kdna-website\b|kdna-website\b/ },
   { name: 'atomspeak', pattern: /\batomspeak\b|@atomspeak\b/ },
@@ -64,6 +71,13 @@ function scanContent(relPath, content) {
       file: relPath,
       rule: 'REDACTED-literal',
       detail: 'redact is an anti-pattern; delete the field/line/node structurally instead',
+    });
+  }
+  if (PRIVATE_PATH_PATTERN.test(content)) {
+    failures.push({
+      file: relPath,
+      rule: 'internal-workspace-path',
+      detail: 'public docs must not reference inaccessible internal workspace paths',
     });
   }
   for (const { name, pattern } of FORBIDDEN_PATTERNS) {
@@ -106,6 +120,9 @@ if (allFailures.length > 0) {
   }
   console.error('Remediation:');
   console.error('  - REDACTED literals: remove the field/line/node from the schema entirely.');
+  console.error(
+    '  - Internal workspace paths: describe the public evidence or delete the reference.',
+  );
   console.error('  - forbidden names:  move references to an allowlisted path (specs/RFC-*,');
   console.error(
     '                       docs/audits/, docs/rfc-status.md, CHANGELOG.md) or delete.',


### PR DESCRIPTION
## Summary
- remove an inaccessible internal workspace path from the public maturity disclosure
- extend the public-surface check to reject literal internal workspace paths outside allowlisted audit/history files
- temporarily allowlist `.github/workflows/publish.yml` because the current OAuth token cannot push workflow-file edits; the existing workflow comment still needs a maintainer-token cleanup with `workflow` scope

## Verification
- `node --check scripts/check-public-surface.mjs` -> passed
- `node scripts/check-public-surface.mjs` -> passed, 0 violations across 659 scanned files
- `npm run format:check` -> passed
- `git diff --check` -> passed
- `npm run lint` -> passed
- `npm test` -> passed, 104/104

## Stacking note
This branch includes #168 (`codex/fix-core-lint-baseline`) so the PR is not blocked by the existing shared core lint baseline failure while review/audit proceeds.
