### PR TITLE
[codex] Fix public documentation links

### DIFF
--- a/docs/agent-feedback-loop.zh.md
+++ b/docs/agent-feedback-loop.zh.md
@@ -49,7 +49,7 @@ Agent 接收输入，加载一个或多个 KDNA 域，并产生判断。
 
 追踪记录了判断过程中触发了哪些 KDNA 规则。
 
-**Schema：** [`specs/judgment-trace-schema.json`](./judgment-trace-schema.json)
+**Schema：** [`specs/judgment-trace-schema.json`](../specs/judgment-trace-schema.json)
 
 **关键字段：**
 - `trace_id`：唯一标识符
@@ -99,7 +99,7 @@ Agent 接收输入，加载一个或多个 KDNA 域，并产生判断。
 
 Agent 行动后，现实产生结果。结果记录将判断的预测与实际发生的情况进行比较。
 
-**Schema：** [`specs/outcome-record-schema.json`](./outcome-record-schema.json)
+**Schema：** [`specs/outcome-record-schema.json`](../specs/outcome-record-schema.json)
 
 **关键字段：**
 - `judgment_reference.trace_id`：链接回追踪

--- a/docs/agents-lack-judgment.md
+++ b/docs/agents-lack-judgment.md
@@ -110,7 +110,8 @@ The full score is harder because KDNA-loaded agents are more conservative — th
 
 **In judgment, being conservative is better than being wrong.**
 
-The benchmark is fully reproducible: [benchmarks/decision-state-comparison-report.md](../benchmarks/decision-state-comparison-report.md)
+The benchmark summary is historical public narrative evidence. The detailed
+benchmark artifact is not part of the current public beta repository.
 
 ## The Six Layers, Properly Defined
 
@@ -151,4 +152,4 @@ The answer starts with encoding judgment.
 
 ---
 
-*KDNA (Knowledge DNA) is an open format for encoding domain judgment for AI agents. See [github.com/aikdna/kdna](https://github.com/aikdna/kdna) for the specification, reference implementations, and reproducible benchmarks.*
+*KDNA (Knowledge DNA) is an open format for encoding domain judgment for AI agents. See [github.com/aikdna/kdna](https://github.com/aikdna/kdna) for the specification and reference implementations.*

--- a/docs/app-runtime-contract.md
+++ b/docs/app-runtime-contract.md
@@ -244,6 +244,6 @@ The examples are intentionally different product scenarios. The validator checks
 - [KDNA Specification](../SPEC.md)
 - [Runtime Routing](./runtime-routing.md)
 - [KDNA Trace](./kdna-trace.md)
-- [Registry CI](./kdna-registry-ci.md)
+- [Registry CI](./archive/kdna-registry-ci.md)
 - [KDNA Studio CLI](https://github.com/aikdna/kdna-studio-cli)
 - [KDNA and AI Stack](./kdna-and-ai-stack.md)

--- a/docs/archive/kdna-compatible-certification.md
+++ b/docs/archive/kdna-compatible-certification.md
@@ -17,7 +17,7 @@ runtime loading does not require users to unpack or edit internal entries.
 This document defines the public compatibility levels. It is a technical
 compatibility program, not a trademark license by itself. Use of `Certified
 KDNA`, `Official KDNA`, or AIKDNA marks is governed by
-[`TRADEMARK.md`](../TRADEMARK.md).
+[`TRADEMARK.md`](../../TRADEMARK.md).
 
 ## Levels
 

--- a/docs/case-study-meeting-decisions.md
+++ b/docs/case-study-meeting-decisions.md
@@ -184,4 +184,4 @@ KDNA does the opposite. It adds a **judgment gate** between discussion and execu
 
 ---
 
-*This case study is based on a composite of real incidents. Identifying details have been changed. The KDNA analysis was produced using the `decision_state` domain asset with reproducible benchmark methodology documented in [../benchmarks/decision-state-comparison-report.md](../benchmarks/decision-state-comparison-report.md).*
+*This case study is based on a composite of real incidents. Identifying details have been changed. The KDNA analysis was produced using the `decision_state` domain asset and historical benchmark methodology. The detailed benchmark artifact is not part of the current public beta repository.*

--- a/docs/examples/sample-assets.md
+++ b/docs/examples/sample-assets.md
@@ -2,6 +2,6 @@
 
 > **Status: Phase 1 placeholder.**
 
-Sample assets are larger reference `.kdna` files that demonstrate the full payload profile. They live under [`samples/`](../../samples/) in this repository.
+Sample assets are larger reference `.kdna` files that demonstrate the full payload profile. No larger sample asset directory is currently shipped in this repository.
 
 Phase 1 only ships the minimal example at [`examples/minimal/`](../../examples/minimal/). More samples will be added in later phases as the format evolves.

--- a/docs/kdna-compare-report.md
+++ b/docs/kdna-compare-report.md
@@ -1,6 +1,8 @@
 # KDNA Compare Report — Design Specification
 
-> **Status:** Implemented. `kdna compare` available in `@aikdna/kdna-cli`. Benchmark infrastructure exists with 5-model results at [benchmarks/](../benchmarks/).
+> **Status:** Implemented. `kdna compare` available in `@aikdna/kdna-cli`.
+> Historical benchmark artifacts are not part of the current public beta
+> repository.
 
 ## Overview
 

--- a/docs/kdna-v1rc-standard-kit.md
+++ b/docs/kdna-v1rc-standard-kit.md
@@ -30,7 +30,7 @@ instead of forcing them to infer the standard from scattered repository files.
 | Conformance | [`conformance/README.md`](../conformance/README.md) |
 | Compatibility policy | [`COMPATIBILITY.md`](../COMPATIBILITY.md) |
 | Trademark and naming | [`TRADEMARK.md`](../TRADEMARK.md) |
-| Certification levels | [`docs/kdna-compatible-certification.md`](./kdna-compatible-certification.md) |
+| Certification levels | [`docs/archive/kdna-compatible-certification.md`](./archive/kdna-compatible-certification.md) |
 | Governance | [`docs/GOVERNANCE.md`](./GOVERNANCE.md) |
 | Release gate | [`docs/V1RC_RELEASE_GATE.md`](./V1RC_RELEASE_GATE.md) |
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # KDNA Core Status — June 2026
 
-> Current status page. For historical perspective, see [STATE_OF_KDNA.md](./STATE_OF_KDNA.md) (historical snapshot, dated 2026-06-09).
+> Current status page. For historical perspective, see [STATE_OF_KDNA.md](../STATE_OF_KDNA.md) (historical snapshot, dated 2026-06-09).
 > **Version naming**: See [version-taxonomy.md](./version-taxonomy.md). "Core GA" refers to the KDNA Core 2026.06 Baseline, not legacy formats.
 
 ## Current positioning

--- a/docs/studio-export-example/README.md
+++ b/docs/studio-export-example/README.md
@@ -209,5 +209,5 @@ artifact. Export a `.kdna` container through Studio and verify it with
 ## See Also
 
 - [STUDIO_EXPORT_CONTRACT.md](../STUDIO_EXPORT_CONTRACT.md) — full contract specification
-- [kdna-compatible-certification.md](../kdna-compatible-certification.md) — certification levels
+- [kdna-compatible-certification.md](../archive/kdna-compatible-certification.md) — certification levels
 - [kdna-v1rc-standard-kit.md](../kdna-v1rc-standard-kit.md) — v1.0-rc implementer bundle

--- a/packages/kdna-core/src/asset-reader.js
+++ b/packages/kdna-core/src/asset-reader.js
@@ -47,7 +47,7 @@ function parseJson(buf, entryName) {
   try {
     return JSON.parse(Buffer.isBuffer(buf) ? buf.toString('utf8') : String(buf));
   } catch (e) {
-    throw new Error(`${entryName}: invalid JSON: ${e.message}`);
+    throw new Error(`${entryName}: invalid JSON: ${e.message}`, { cause: e });
   }
 }
 
@@ -325,7 +325,7 @@ function verifyHumanLockSignatures(coreData, manifest, errors, warnings) {
   ];
 
   let verified = 0, missing = 0, invalid = 0;
-  for (const [arrayName, _cardType] of CORE_CARD_ARRAYS) {
+  for (const [arrayName] of CORE_CARD_ARRAYS) {
     const cards = coreData?.[arrayName];
     if (!Array.isArray(cards) || cards.length === 0) continue;
 

--- a/packages/kdna-core/src/crypto-profile.js
+++ b/packages/kdna-core/src/crypto-profile.js
@@ -102,7 +102,6 @@ function hkdfSha256(ikm, salt = null, info = '', length = 32) {
 
 // ── AES-256-KW (RFC 3394) ─────────────────────────────────────────
 
-const AES_BLOCK = 16;
 const KW_IV = Buffer.from('a6a6a6a6a6a6a6a6', 'hex'); // RFC 3394 default IV
 
 function aesWrap(key, plaintext) {

--- a/packages/kdna-core/src/public-api.js
+++ b/packages/kdna-core/src/public-api.js
@@ -110,7 +110,7 @@ async function validateKDNA(input, options = {}) {
   const reader = readerFrom(options);
   const asset = await asAsset(input, { ...options, reader });
   const assetResult = await reader.verify(asset, options);
-  let dataMap = null;
+  let dataMap;
   let lintResult = { errors: [], warnings: [] };
   let schemaResult = { errors: [], warnings: [] };
   let crossFileResult = { errors: [], warnings: [] };

--- a/packages/kdna-core/src/v1/index.js
+++ b/packages/kdna-core/src/v1/index.js
@@ -521,7 +521,7 @@ function readV1Layout(absPath) {
 
   const map = {};
   let entries = null; // ZIP entries if container
-  let kind = null; // 'dir' | 'file'
+  let kind; // 'dir' | 'file'
 
   if (stat.isDirectory()) {
     kind = 'dir';
@@ -589,7 +589,7 @@ function readV1Layout(absPath) {
   try {
     manifest = parseJsonEntry('kdna.json', map['kdna.json']);
   } catch (e) {
-    throw new Error(`kdna.json is not valid JSON: ${e.message}`);
+    throw new Error(`kdna.json is not valid JSON: ${e.message}`, { cause: e });
   }
   if (manifest.lineage !== undefined && Array.isArray(manifest.lineage)) {
     throw new Error('kdna.json.lineage must be an object, not an array');
@@ -1773,7 +1773,7 @@ function loadV1Unsafe(inputPath, opts = {}) {
     const rawPayload = v1.map['payload.kdnab'];
     payload = parseJsonEntry('payload.kdnab', rawPayload);
   } catch (e) {
-    throw new Error(`payload.kdnab is not valid JSON: ${e.message}`);
+    throw new Error(`payload.kdnab is not valid JSON: ${e.message}`, { cause: e });
   }
 
   if (payload.profile && payload.ciphertext && (m.payload?.encrypted || m.encryption?.encrypted_entries?.includes('payload.kdnab'))) {
@@ -1946,7 +1946,7 @@ function loadV1Unsafe(inputPath, opts = {}) {
         }));
         result.inheritance_applied = true;
       }
-    } catch (_) {
+    } catch {
       // extends merge is best-effort — never block load
       result.inheritance_applied = false;
     }

--- a/packages/kdna-core/src/workpack-pure.js
+++ b/packages/kdna-core/src/workpack-pure.js
@@ -169,9 +169,6 @@ function checkWorkPackStructure(manifest, rootDir) {
  */
 function inspectWorkPack(manifest, rootDir) {
   const kdnaMode = manifest.kdna?.mode || 'unknown';
-  const kdnaCount =
-    kdnaMode === 'single' ? 1 : (manifest.kdna?.assets || []).length;
-
   const structure = checkWorkPackStructure(manifest, rootDir);
 
   return {
@@ -240,7 +237,8 @@ function _lazyAjv() {
     return _ajvInstance;
   } catch (e) {
     throw new Error(
-      'ajv is required for Work Pack validation. Install: npm install ajv ajv-formats'
+      'ajv is required for Work Pack validation. Install: npm install ajv ajv-formats',
+      { cause: e },
     );
   }
 }

--- a/specs/runtime-capsule.md
+++ b/specs/runtime-capsule.md
@@ -2,7 +2,7 @@
 
 **Version:** 1.0  
 **Status:** Draft  
-**Depends on:** [KDNA Container v2](./container-v2.md)
+**Depends on:** [KDNA Asset Container](./container.md)
 
 ## 1. Purpose
 


### PR DESCRIPTION
## Summary
- fix public Markdown links whose targets exist but had stale relative paths
- remove links to unpublished `benchmarks/` and `samples/` artifacts from active docs
- downgrade benchmark/sample claims where the detailed artifacts are not part of the current public beta repository
- update Runtime Capsule dependency link from the old container-v2 filename to the current KDNA Asset Container spec

## Verification
- ad-hoc relative Markdown link scan -> only `/en/docs/loader-behavior` and `/zh/docs/loader-behavior` remain, both website routes rather than repo files
- `npm run format:check` -> passed
- `git diff --check` -> passed
- `node scripts/check-public-surface.mjs` -> passed, 0 violations across 660 scanned files
- `npm run lint` -> passed
- `npm test` -> passed, 104/104

## Stacking note
This branch includes #168 (`codex/fix-core-lint-baseline`) so the PR is not blocked by the existing shared core lint baseline failure while review/audit proceeds.
