### PR TITLE
[codex] Fix Core v1 packaged runtime paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1806,7 +1806,7 @@
     },
     "packages/kdna-core": {
       "name": "@aikdna/kdna-core",
-      "version": "0.15.10",
+      "version": "0.15.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.8.0",

--- a/packages/kdna-core/CHANGELOG.md
+++ b/packages/kdna-core/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.15.11 (2026-07-03)
+
+**Fix**: repair Core v1 container dispatcher module resolution in the
+published package layout.
+
+- Corrects internal `src/container-dispatcher.js` imports so the dispatcher can
+  load sibling `asset-reader` and `v1` modules after npm packaging.
+- Loads v1 JSON schemas through package-relative static imports before falling
+  back to disk discovery, so bundled server environments do not look for
+  KDNA schemas in the host application directory.
+- Adds regression coverage for loading a v1 source asset through the dispatcher
+  from the package `src/` layout and for validating from a non-repository cwd.
+
+No public API changes.
 
 ## v0.15.10 (2026-06-30)
 

--- a/packages/kdna-core/package.json
+++ b/packages/kdna-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aikdna/kdna-core",
-    "version": "0.15.10",
+    "version": "0.15.11",
     "description": "KDNA Core library for validating, planning, and loading local .kdna judgment assets.",
     "engines": {
         "node": ">=18.0.0"

--- a/packages/kdna-core/src/container-dispatcher.js
+++ b/packages/kdna-core/src/container-dispatcher.js
@@ -4,7 +4,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const crypto = require('node:crypto');
 
-const { createKdnaAssetReader } = require('../asset-reader.js');
+const { createKdnaAssetReader } = require('./asset-reader.js');
 
 const MIMETYPE_V1 = 'application/vnd.kdna.asset';
 const MIMETYPE_V2 = 'application/vnd.aikdna.kdna+zip';
@@ -220,7 +220,7 @@ function readSourceDirectory(absPath, _opts) {
  */
 function readV1Container(absPath, _opts) {
   // Delegate to the existing v1 layout reader for validation
-  const v1Layout = require('../v1/index.js').readV1Layout(absPath);
+  const v1Layout = require('./v1/index.js').readV1Layout(absPath);
 
   const containerBuf = fs.readFileSync(absPath);
   const assetDigest = crypto.createHash('sha256').update(containerBuf).digest();

--- a/packages/kdna-core/src/v1/index.js
+++ b/packages/kdna-core/src/v1/index.js
@@ -91,6 +91,16 @@ const FORBIDDEN_OUTPUT_TERMS = Object.freeze([
 let _ajv = null;
 let _validators = null;
 
+function loadPackagedSchemas() {
+  return {
+    manifestSchema: require('../../schema/manifest.schema.json'),
+    payloadSchema: require('../../schema/payload-profile-v1.schema.json'),
+    bundlePayloadSchema: require('../../schema/bundle-profile-v1.schema.json'),
+    checksumsSchema: require('../../schema/checksums.schema.json'),
+    loadContractSchema: require('../../schema/load-contract.schema.json'),
+  };
+}
+
 function getRepoRoot() {
   // Walk up from this file to find the repo root (where schema/ lives).
   // Works whether this module is loaded from packages/kdna/src/ or
@@ -106,6 +116,26 @@ function getRepoRoot() {
   return process.cwd();
 }
 
+function loadSchemasFromDisk() {
+  const repoRoot = getRepoRoot();
+  const schemaDir = path.join(repoRoot, 'schema');
+  return {
+    manifestSchema: JSON.parse(fs.readFileSync(path.join(schemaDir, 'manifest.schema.json'), 'utf8')),
+    payloadSchema: JSON.parse(
+      fs.readFileSync(path.join(schemaDir, 'payload-profile-v1.schema.json'), 'utf8'),
+    ),
+    bundlePayloadSchema: JSON.parse(
+      fs.readFileSync(path.join(schemaDir, 'bundle-profile-v1.schema.json'), 'utf8'),
+    ),
+    checksumsSchema: JSON.parse(
+      fs.readFileSync(path.join(schemaDir, 'checksums.schema.json'), 'utf8'),
+    ),
+    loadContractSchema: JSON.parse(
+      fs.readFileSync(path.join(schemaDir, 'load-contract.schema.json'), 'utf8'),
+    ),
+  };
+}
+
 function loadSchemas() {
   if (_validators) return _validators;
   let Ajv;
@@ -119,21 +149,13 @@ function loadSchemas() {
     // to structural checks (no JSON-schema enforcement).
     return null;
   }
-  const repoRoot = getRepoRoot();
-  const schemaDir = path.join(repoRoot, 'schema');
-  const manifestSchema = JSON.parse(fs.readFileSync(path.join(schemaDir, 'manifest.schema.json'), 'utf8'));
-  const payloadSchema = JSON.parse(
-    fs.readFileSync(path.join(schemaDir, 'payload-profile-v1.schema.json'), 'utf8'),
-  );
-  const bundlePayloadSchema = JSON.parse(
-    fs.readFileSync(path.join(schemaDir, 'bundle-profile-v1.schema.json'), 'utf8'),
-  );
-  const checksumsSchema = JSON.parse(
-    fs.readFileSync(path.join(schemaDir, 'checksums.schema.json'), 'utf8'),
-  );
-  const loadContractSchema = JSON.parse(
-    fs.readFileSync(path.join(schemaDir, 'load-contract.schema.json'), 'utf8'),
-  );
+  let schemas;
+  try {
+    schemas = loadPackagedSchemas();
+  } catch {
+    schemas = loadSchemasFromDisk();
+  }
+  const { manifestSchema, payloadSchema, bundlePayloadSchema, checksumsSchema, loadContractSchema } = schemas;
   const ajv = new Ajv({ allErrors: true, strict: false });
   addFormats(ajv);
   ajv.addSchema(loadContractSchema, 'load-contract.schema.json');

--- a/packages/kdna-core/test/container-dispatcher.test.js
+++ b/packages/kdna-core/test/container-dispatcher.test.js
@@ -1,0 +1,34 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+const os = require('node:os');
+const path = require('node:path');
+
+const { readAsset } = require('../src/container-dispatcher.js');
+
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+
+test('container dispatcher loads sibling modules from packaged src layout', () => {
+  const asset = readAsset(path.join(repoRoot, 'examples', 'minimal'));
+
+  assert.equal(asset.sourceKind, 'dir');
+  assert.equal(asset.format, 'v1-dir');
+  assert.equal(asset.mimetype, 'application/vnd.kdna.asset');
+  assert.equal(asset.manifest.asset_id, 'kdna:example:agent-project-context');
+  assert.equal(asset.manifest.title, 'Agent Project Context');
+});
+
+test('v1 schema validation does not depend on the host project cwd', () => {
+  const tmp = os.tmpdir();
+  const v1Entry = path.join(repoRoot, 'packages', 'kdna-core', 'src', 'v1', 'index.js');
+  const example = path.join(repoRoot, 'examples', 'minimal');
+  const script = `
+    const v1 = require(${JSON.stringify(v1Entry)});
+    const result = v1.validate(${JSON.stringify(example)});
+    if (!result.overall_valid) {
+      throw new Error(JSON.stringify(result.problems || result, null, 2));
+    }
+  `;
+
+  execFileSync(process.execPath, ['-e', script], { cwd: tmp });
+});


### PR DESCRIPTION
## What changed

Fixes two npm package-layout issues in `@aikdna/kdna-core` and bumps the package to `0.15.11`:

- Corrects `src/container-dispatcher.js` sibling imports so packaged Core can load `asset-reader` and the v1 entrypoint.
- Loads v1 JSON schemas through package-relative static imports before falling back to disk discovery, so bundled server runtimes do not search the host app cwd for KDNA schemas.
- Adds regression coverage for dispatcher loading and cwd-independent v1 validation.

## Why

The first real `npx create-kdna-web-app@0.1.0` production-template E2E exposed that `@aikdna/kdna-web-server` cannot safely use the Core v1 runtime in a Next/Turbopack app until Core resolves its own packaged files and schemas from the package layout.

## Validation

- `npm --workspace @aikdna/kdna-core test` -> passed.
- `node tests/cli-v1/v1-cli-shared.test.js` -> passed, 35/35.
- `npm run format:check` -> passed.
- `npm test` -> passed, 104/104.
- Packed local `@aikdna/kdna-core@0.15.11` and installed it into a generated Next.js app with local `@aikdna/kdna-web-server@0.1.1`.
- In that generated app, `npm test` and `npm run build` passed.
- Started the generated app and verified `/api/kdna/health`, `/validate`, `/inspect`, `/plan-load`, and `/load` against `agent-project-context-v0.1.2.kdna`.
