### PR TITLE
fix docs-ci.yml: add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -1,16 +1,19 @@
 name: Docs CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:
       - 'docs/**'
       - 'scripts/docs-ci.js'
+      - '.github/workflows/docs-ci.yml'
   pull_request:
     branches: [main]
     paths:
       - 'docs/**'
       - 'scripts/docs-ci.js'
+      - '.github/workflows/docs-ci.yml'
 
 jobs:
   docs-check:


### PR DESCRIPTION
The docs-ci.yml workflow has never run on GitHub since I created it. Two reasons:\n\n1. No `workflow_dispatch` trigger — cannot be run manually\n2. `.github/workflows/docs-ci.yml` was not in path filters — modifying the workflow file itself never triggers it\n\nAlso added the yml file to path filters so future changes to the workflow trigger a run.