### PR TITLE
add npm publish drift gate to Docs CI

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -7,12 +7,14 @@ on:
     paths:
       - 'docs/**'
       - 'scripts/docs-ci.js'
+      - 'scripts/check-publish-drift.js'
       - '.github/workflows/docs-ci.yml'
   pull_request:
     branches: [main]
     paths:
       - 'docs/**'
       - 'scripts/docs-ci.js'
+      - 'scripts/check-publish-drift.js'
       - '.github/workflows/docs-ci.yml'
 
 jobs:
@@ -25,3 +27,5 @@ jobs:
           node-version: 22
       - name: Run docs evidence checks
         run: node scripts/docs-ci.js
+      - name: Run npm publish drift check
+        run: node scripts/check-publish-drift.js

--- a/scripts/check-publish-drift.js
+++ b/scripts/check-publish-drift.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { execSync } = require('node:child_process');
+
+let failures = 0;
+
+function check(name, condition, detail = '') {
+  if (condition) {
+    console.log(`  PASS: ${name}`);
+    return true;
+  }
+  console.error(`  FAIL: ${name}${detail ? ' — ' + detail : ''}`);
+  failures++;
+  return false;
+}
+
+const REPOS_ROOT = path.resolve(__dirname, '..', '..');
+
+const PACKAGES = [
+  { repo: 'kdna/packages/kdna-core', pkg: '@aikdna/kdna-core' },
+  { repo: 'kdna-cli', pkg: '@aikdna/kdna-cli' },
+  { repo: 'kdna-studio-cli', pkg: '@aikdna/kdna-studio-cli' },
+  { repo: 'kdna-studio-core', pkg: '@aikdna/kdna-studio-core' },
+  { repo: 'kdna-web-client', pkg: '@aikdna/kdna-web-client' },
+  { repo: 'kdna-web-server', pkg: '@aikdna/kdna-web-server' },
+  { repo: 'kdna-react', pkg: '@aikdna/kdna-react' },
+  { repo: 'create-kdna-web-app', pkg: 'create-kdna-web-app' },
+];
+
+console.log('── npm publish drift check\n');
+
+for (const { repo, pkg } of PACKAGES) {
+  const repoPath = path.join(REPOS_ROOT, repo);
+  const pkgJsonPath = path.join(repoPath, 'package.json');
+
+  let repoVersion = null;
+  if (fs.existsSync(pkgJsonPath)) {
+    repoVersion = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8')).version;
+  }
+
+  let npmVersion;
+  try {
+    npmVersion = execSync(`npm view ${pkg} version`, {
+      encoding: 'utf8',
+      timeout: 15000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    npmVersion = null;
+  }
+
+  if (!npmVersion) {
+    check(`${pkg}: published on npm`, false, 'npm view returned nothing');
+    continue;
+  }
+
+  if (!repoVersion) {
+    check(`${pkg}: published (v${npmVersion})`, /^\d+\.\d+\.\d+$/.test(npmVersion), 'repo not cloned, only npm checked');
+    continue;
+  }
+
+  check(
+    `${pkg} repo=${repoVersion} npm=${npmVersion}`,
+    repoVersion === npmVersion,
+    `drift detected`,
+  );
+}
+
+console.log(`\n${failures === 0 ? 'No drift — all packages aligned.' : `${failures} package(s) drifted.`}`);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
Adds `scripts/check-publish-drift.js` and wires it into `docs-ci.yml`.

**What it checks:** For all 8 published npm packages, compares the repo's `package.json` version against `npm view <pkg> version`. Fails when they don't match.

**Why:** The web packages (web-client, web-server, react) had repo version 0.1.1 but npm was still 0.1.0 for several hours. This gate catches that drift automatically instead of relying on manual `npm view`.

**CI behavior:** On GitHub Actions, only the kdna repo is checked out. `kdna/packages/kdna-core` gets a full cross-check; the other 7 packages do npm-only verification (checks published + semver valid). On local workspace with all repos cloned, all 8 get full cross-check.