### PR TITLE
[codex] Sync scaffolder 0.1.2 public truth

### DIFF
--- a/docs/kdna-ecosystem/00-current-truth.md
+++ b/docs/kdna-ecosystem/00-current-truth.md
@@ -17,7 +17,7 @@
 | `@aikdna/kdna-web-server` | 0.1.1 | 0.1.1 | Experimental server-side web adapter |
 | `@aikdna/kdna-web-client` | 0.1.1 | 0.1.1 | Experimental browser-safe web utilities |
 | `@aikdna/kdna-react` | 0.1.1 | 0.1.1 | Experimental React hooks and components |
-| `create-kdna-web-app` | 0.1.1 | 0.1.1 | Experimental KDNA web app scaffolder |
+| `create-kdna-web-app` | 0.1.2 | 0.1.2 | Experimental KDNA web app scaffolder |
 
 ## Stable Baseline
 

--- a/docs/public-roadmap.md
+++ b/docs/public-roadmap.md
@@ -43,7 +43,7 @@ cross-language parity are not part of the stable public baseline.
 - **`@aikdna/kdna-web-server` v0.1.1** - experimental server-side web adapter
 - **`@aikdna/kdna-web-client` v0.1.1** - experimental browser-safe web utilities
 - **`@aikdna/kdna-react` v0.1.1** - experimental React hooks and components
-- **`create-kdna-web-app` v0.1.1** - experimental KDNA web app scaffolder
+- **`create-kdna-web-app` v0.1.2** - experimental KDNA web app scaffolder
 - **Public assets**: see `aikdna/kdna-assets` `assets.json` and GitHub Releases
 
 ## What comes next

--- a/ecosystem-manifest.json
+++ b/ecosystem-manifest.json
@@ -190,7 +190,7 @@
       "local_path": "../create-kdna-web-app",
       "npm_package": "create-kdna-web-app",
       "package_json": "../create-kdna-web-app/package.json",
-      "current_version": "0.1.1",
+      "current_version": "0.1.2",
       "lifecycle": "Experimental",
       "supported_kdna_version": "1.0",
       "supported_access_modes": ["public"],


### PR DESCRIPTION
## Summary

- Update `create-kdna-web-app` from `0.1.1` to `0.1.2` in the live ecosystem truth table.
- Update the public roadmap package list to the published `0.1.2` scaffolder version.
- Update `ecosystem-manifest.json` so the manifest matches source and npm latest.

## Why

The final maintenance-mode acceptance audit found one remaining public truth drift: `create-kdna-web-app` had been published and source-aligned at `0.1.2`, while `open/kdna` still claimed `0.1.1`.

## Verification

- `npm run format:check`
- `npm run validate:ecosystem-manifest`
- `npm run validate:public-truth`
- `npm run validate:web-packages`
- `node scripts/docs-ci.js`
- `node scripts/check-publish-drift.js`
- `npm run release:preflight`
