### PR TITLE
docs: make public authoring guides executable

### DIFF
--- a/docs/15-minute-agent-guide.md
+++ b/docs/15-minute-agent-guide.md
@@ -69,8 +69,8 @@ and can load judgment on demand.
 
 | Feature | Status | Notes |
 |---|---|---|
-| `kdna demo minimal` | stable | Creates a local v1 fixture |
-| `kdna inspect` | stable | Reads v1 source dirs and .kdna containers |
+| `kdna demo minimal` | stable | Creates a local fixture for the current format |
+| `kdna inspect` | stable | Reads current source dirs and `.kdna` containers |
 | `kdna validate` | stable | Schema + format + payload + checksums + load-contract |
 | `kdna pack` | stable | Deterministic ZIP (same input → same SHA-256) |
 | `kdna unpack` | stable | Extract .kdna container |
@@ -79,8 +79,8 @@ and can load judgment on demand.
 
 ## Current limitations
 
-- **Agent runtime loading is available for v1.** `kdna load` supports v1 `.kdna`
-  containers produced by the current `kdna pack` command. Pin a released CLI
+- **Agent runtime loading is available for the current format.** `kdna load`
+  supports `.kdna` containers produced by the current `kdna pack` command. Pin a released CLI
   version when you need reproducible automation.
 - **Agent support varies by platform.** The `kdna-loader` skill adapter supports
   discovery of local `.kdna` files. Agent-specific integration quality varies

--- a/docs/30-minute-authoring-guide.md
+++ b/docs/30-minute-authoring-guide.md
@@ -42,9 +42,11 @@ kdna-studio card add my_expertise axiom \
   --field one_sentence="KDNA assets preserve judgment before style." \
   --field full_statement="A KDNA asset must preserve boundaries, self-checks, and failure modes before presentation polish." \
   --field why="Without boundaries, a KDNA asset becomes a prompt template instead of reusable judgment." \
-  --field applies_when="teaching KDNA to a new user" \
-  --field does_not_apply_when="only demonstrating CLI syntax" \
-  --field failure_risk="Users may copy the format without preserving judgment."
+  --field applies_when='["teaching KDNA to a new user"]' \
+  --field does_not_apply_when='["only demonstrating CLI syntax"]' \
+  --field failure_risk="Users may copy the format without preserving judgment." \
+  --field confidence="high" \
+  --field evidence_type="practice"
 ```
 
 A minimal valid `.kdna` payload contains:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,9 +35,11 @@ kdna-studio card add my-domain axiom \
   --field one_sentence="KDNA assets preserve judgment before style." \
   --field full_statement="A KDNA asset must preserve boundaries, self-checks, and failure modes before presentation polish." \
   --field why="Without boundaries, a KDNA asset becomes a prompt template instead of reusable judgment." \
-  --field applies_when="teaching KDNA to a new user" \
-  --field does_not_apply_when="only demonstrating CLI syntax" \
-  --field failure_risk="Users may copy the format without preserving judgment."
+  --field applies_when='["teaching KDNA to a new user"]' \
+  --field does_not_apply_when='["only demonstrating CLI syntax"]' \
+  --field failure_risk="Users may copy the format without preserving judgment." \
+  --field confidence="high" \
+  --field evidence_type="practice"
 ```
 
 ### Approve and export

--- a/docs/getting-started.zh.md
+++ b/docs/getting-started.zh.md
@@ -33,9 +33,11 @@ kdna-studio card add my_domain axiom \
   --field one_sentence="KDNA assets preserve judgment before style." \
   --field full_statement="A KDNA asset must preserve boundaries, self-checks, and failure modes before presentation polish." \
   --field why="Without boundaries, a KDNA asset becomes a prompt template instead of reusable judgment." \
-  --field applies_when="teaching KDNA to a new user" \
-  --field does_not_apply_when="only demonstrating CLI syntax" \
-  --field failure_risk="Users may copy the format without preserving judgment."
+  --field applies_when='["teaching KDNA to a new user"]' \
+  --field does_not_apply_when='["only demonstrating CLI syntax"]' \
+  --field failure_risk="Users may copy the format without preserving judgment." \
+  --field confidence="high" \
+  --field evidence_type="practice"
 ```
 
 ### 确认并导出

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -86,7 +86,7 @@ Then install the `kdna-loader` skill for your agent from [kdna-skills](https://g
 
 - KDNA domains themselves (they are `.kdna` assets, discovered and loaded on
   demand through the CLI/Core path)
-- A domain creator. Use the Studio CLI for formal v1 `.kdna` creation; CLI dev
+- A domain creator. Use the Studio CLI for packaged `.kdna` creation; CLI dev
   scaffolds are non-canonical.
 - Per-project pinning (the v0.7–v0.8 `.kdna/config.json` mechanism was
   removed in v0.9 because it forced loading on tasks the user didn't

--- a/docs/integrations.zh.md
+++ b/docs/integrations.zh.md
@@ -69,5 +69,5 @@ kdna load ./minimal.kdna --profile=compact --as=prompt
 ## 什么不会作为 skill 安装
 
 - KDNA 领域本身。领域是 `.kdna` 资产，通过 CLI/Core 路径按需发现和加载。
-- 领域创建器。正式 v1 `.kdna` 创建优先使用 Studio CLI；其它高级创作/调试工具不属于基础加载路径。
+- 领域创建器。正式的 packaged `.kdna` 创建优先使用 Studio CLI；其它高级创作/调试工具不属于基础加载路径。
 - 每项目强制加载配置。旧 `.kdna/config.json` 机制已移出主路径，因为它会让资产在用户没有请求的任务中被强制加载。

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -64,9 +64,11 @@ kdna-studio card add my-domain axiom \
   --field one_sentence="KDNA assets preserve judgment before style." \
   --field full_statement="A KDNA asset must preserve boundaries, self-checks, and failure modes before presentation polish." \
   --field why="Without boundaries, a KDNA asset becomes a prompt template instead of reusable judgment." \
-  --field applies_when="teaching KDNA to a new user" \
-  --field does_not_apply_when="only demonstrating CLI syntax" \
-  --field failure_risk="Users may copy the format without preserving judgment."
+  --field applies_when='["teaching KDNA to a new user"]' \
+  --field does_not_apply_when='["only demonstrating CLI syntax"]' \
+  --field failure_risk="Users may copy the format without preserving judgment." \
+  --field confidence="high" \
+  --field evidence_type="practice"
 kdna-studio card approve my-domain --all --by your-id --statement "I confirm this judgment for export."
 kdna-studio export my-domain --out ./my-domain.kdna
 kdna validate ./my-domain.kdna


### PR DESCRIPTION
## Summary

- add the strict axiom fields required by the released Studio CLI to every first-run authoring example
- encode applicability boundaries with the documented array shape
- remove obsolete split-generation wording from active Agent guides

## Verification

- executed the documented create → card add → approve → export → runtime validate lifecycle with published CLIs
- `npm run validate:public-truth`
- `npm run format:check`
- `git diff --check`