### PR TITLE
Enforce the packaged runtime asset boundary

### DIFF
--- a/.github/workflows/publish-health-cron.yml
+++ b/.github/workflows/publish-health-cron.yml
@@ -51,9 +51,8 @@ jobs:
 
       - name: Run publish-health (cross-repo 4-package check)
         id: cross
-        # The script lives in the kdna monorepo scripts/ folder; this is
-        # a re-implementation of the audit script in /Users/AI/K/OPEN/scripts/
-        # but kept in-tree so it has access to npm + gh CLIs.
+        # Keep the public package/release audit in-tree so CI can run it with
+        # npm and GitHub CLI access.
         run: |
           PACKAGES=(
             "kdna-cli:kdna-cli:package.json:v"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,6 @@ jobs:
           repository: aikdna/kdna-vscode
           ref: c0d885ba8222b6dccad87ec67f7d82fcc1283107
           path: .ecosystem-repos/kdna-vscode
-# kdna-writing, kdna-prompt_diagnosis, kdna-agent_safety repos deleted — artifacts migrated to internal curation (see PRIVATE/STATUS/ for mapping)
       - uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -134,7 +133,6 @@ jobs:
           repository: aikdna/kdna-vscode
           ref: c0d885ba8222b6dccad87ec67f7d82fcc1283107
           path: .ecosystem-repos/kdna-vscode
-# kdna-writing, kdna-prompt_diagnosis, kdna-agent_safety repos deleted — artifacts migrated to internal curation (see PRIVATE/STATUS/ for mapping)
       - uses: actions/setup-node@v6
         with:
           node-version: 22

--- a/SPEC.md
+++ b/SPEC.md
@@ -218,8 +218,8 @@ Implementations MAY conform at one of three levels:
 
 A KDNA domain MUST be represented, distributed, installed, verified, and loaded as a `.kdna` container.
 
-The internal tree of a `.kdna` container is encoded in `payload.kdnab` (JSON in
-CBOR-encoded). Source trees (KDNA_Core.json,
+The judgment payload of a `.kdna` container is encoded as strict CBOR in
+`payload.kdnab`. Source trees (`KDNA_Core.json`,
 KDNA_Patterns.json, etc.) are authoring workspaces only and MUST NOT appear as
 top-level entries in a distribution `.kdna` asset. See `specs/container.md`.
 

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -2,7 +2,8 @@
 
 This suite lets third-party loaders, validators, and adapters prove that they
 implement the asset-first KDNA contract. Some legacy profiles remain for
-historical compatibility testing; they are not the current Core v1 launch path.
+historical compatibility testing; they are not part of the current conformance
+path.
 
 Conformance means:
 
@@ -42,7 +43,7 @@ Profiles are intentionally explicit:
 | `loader` | Implementation can validate, load, render, and digest-check assets. |
 | `asset-loader` | Combined asset + loader compatibility for SDKs and adapters. |
 | `runtime` | Runtime follows asset-first loading behavior. |
-| `registry` | Legacy registry implementation profile; not part of the current Core v1 launch path. |
+| `registry` | Legacy registry implementation profile; not part of the current conformance path. |
 | `phase2-protocol` | Implementation validates all Phase 2 RFC schema fixtures (artifact-envelope, fidelity-result, product-runtime, stage-definition). |
 
 Passing this suite is a technical compatibility signal. It is not a content

--- a/conformance/authorization/cases.json
+++ b/conformance/authorization/cases.json
@@ -5,7 +5,7 @@
   "cases": [
     {
       "id": "public-valid",
-      "description": "Public v1 asset loads immediately through a minimal projection.",
+      "description": "Public packaged asset loads immediately through a minimal projection.",
       "fixture": "public-valid",
       "options": {},
       "cli_args": [],

--- a/conformance/authorization/goldens/account-required.loadplan.json
+++ b/conformance/authorization/goldens/account-required.loadplan.json
@@ -17,7 +17,7 @@
   "input_fingerprint": {
     "has_password_input": false,
     "entitlement_input": null,
-    "source_fingerprint": "sha256:9ccdc295883dfd70cc91fe344d8922fc9e5107255dc4927e1dd749a63950bb53"
+    "source_fingerprint": "sha256:c76e3c035382a7f0f100f17d8bb68dcbfe13bbbec344a9d0963bf1fdf6cde2b6"
   },
   "checks": {
     "format_valid": true,
@@ -35,7 +35,7 @@
     }
   ],
   "source": {
-    "kind": "dir",
+    "kind": "file",
     "path": "<fixture:account-required>"
   }
 }

--- a/conformance/authorization/goldens/account-required.loadplan.json
+++ b/conformance/authorization/goldens/account-required.loadplan.json
@@ -17,7 +17,7 @@
   "input_fingerprint": {
     "has_password_input": false,
     "entitlement_input": null,
-    "source_fingerprint": "sha256:c76e3c035382a7f0f100f17d8bb68dcbfe13bbbec344a9d0963bf1fdf6cde2b6"
+    "source_fingerprint": "sha256:9ccdc295883dfd70cc91fe344d8922fc9e5107255dc4927e1dd749a63950bb53"
   },
   "checks": {
     "format_valid": true,

--- a/conformance/authorization/goldens/expired-entitlement.loadplan.json
+++ b/conformance/authorization/goldens/expired-entitlement.loadplan.json
@@ -17,7 +17,7 @@
   "input_fingerprint": {
     "has_password_input": false,
     "entitlement_input": "expired",
-    "source_fingerprint": "sha256:224c7d35443286cea3dc06e05644c06a4a69ef59baa0d17d64e8e4293a68fae7"
+    "source_fingerprint": "sha256:18e62950560bddd025049f6449d187c316223590521a21fe462d838ddaa2772e"
   },
   "checks": {
     "format_valid": true,

--- a/conformance/authorization/goldens/expired-entitlement.loadplan.json
+++ b/conformance/authorization/goldens/expired-entitlement.loadplan.json
@@ -17,7 +17,7 @@
   "input_fingerprint": {
     "has_password_input": false,
     "entitlement_input": "expired",
-    "source_fingerprint": "sha256:18e62950560bddd025049f6449d187c316223590521a21fe462d838ddaa2772e"
+    "source_fingerprint": "sha256:224c7d35443286cea3dc06e05644c06a4a69ef59baa0d17d64e8e4293a68fae7"
   },
   "checks": {
     "format_valid": true,
@@ -35,7 +35,7 @@
     }
   ],
   "source": {
-    "kind": "dir",
+    "kind": "file",
     "path": "<fixture:expired-entitlement>"
   }
 }

--- a/conformance/authorization/goldens/offline-grace-active.loadplan.json
+++ b/conformance/authorization/goldens/offline-grace-active.loadplan.json
@@ -17,7 +17,7 @@
   "input_fingerprint": {
     "has_password_input": false,
     "entitlement_input": "offline_grace",
-    "source_fingerprint": "sha256:5b45a3e3121eecf98c267746d3046c8ed638ae3cc2f61497b88d9877a403b3dd"
+    "source_fingerprint": "sha256:0013d680f13cab37cfcf0e1b8b05201bfa424ac138a39335a584e0b2c7b5382b"
   },
   "checks": {
     "format_valid": true,
@@ -35,7 +35,7 @@
     }
   ],
   "source": {
-    "kind": "dir",
+    "kind": "file",
     "path": "<fixture:offline-grace-active>"
   }
 }

--- a/conformance/authorization/goldens/offline-grace-active.loadplan.json
+++ b/conformance/authorization/goldens/offline-grace-active.loadplan.json
@@ -17,7 +17,7 @@
   "input_fingerprint": {
     "has_password_input": false,
     "entitlement_input": "offline_grace",
-    "source_fingerprint": "sha256:0013d680f13cab37cfcf0e1b8b05201bfa424ac138a39335a584e0b2c7b5382b"
+    "source_fingerprint": "sha256:5b45a3e3121eecf98c267746d3046c8ed638ae3cc2f61497b88d9877a403b3dd"
   },
   "checks": {
     "format_valid": true,

--- a/conformance/authorization/goldens/org-required.loadplan.json
+++ b/conformance/authorization/goldens/org-required.loadplan.json
@@ -17,7 +17,7 @@
   "input_fingerprint": {
     "has_password_input": false,
     "entitlement_input": null,
-    "source_fingerprint": "sha256:df7e6c13ba597c349eeb7d8ab9cac5404a9256391bf172580ec0588fcba76fa2"
+    "source_fingerprint": "sha256:691d4cf19a1fee117c9d558dcb96472eda44ab385fa851602b52bf33914a7130"
   },
   "checks": {
     "format_valid": true,

--- a/conformance/authorization/goldens/org-required.loadplan.json
+++ b/conformance/authorization/goldens/org-required.loadplan.json
@@ -17,7 +17,7 @@
   "input_fingerprint": {
     "has_password_input": false,
     "entitlement_input": null,
-    "source_fingerprint": "sha256:691d4cf19a1fee117c9d558dcb96472eda44ab385fa851602b52bf33914a7130"
+    "source_fingerprint": "sha256:df7e6c13ba597c349eeb7d8ab9cac5404a9256391bf172580ec0588fcba76fa2"
   },
   "checks": {
     "format_valid": true,
@@ -35,7 +35,7 @@
     }
   ],
   "source": {
-    "kind": "dir",
+    "kind": "file",
     "path": "<fixture:org-required>"
   }
 }

--- a/conformance/authorization/goldens/password-missing.loadplan.json
+++ b/conformance/authorization/goldens/password-missing.loadplan.json
@@ -17,7 +17,7 @@
   "input_fingerprint": {
     "has_password_input": false,
     "entitlement_input": null,
-    "source_fingerprint": "sha256:eb3fef23e509339bbff5ddbe68fd5418cd843aff431785a7328b4f3e9c534a12"
+    "source_fingerprint": "sha256:15f1c4ed2055d06b3e166fd446084ff8890a55566c1495bee8a37d16501a8cbc"
   },
   "checks": {
     "format_valid": true,
@@ -35,7 +35,7 @@
     }
   ],
   "source": {
-    "kind": "dir",
+    "kind": "file",
     "path": "<fixture:password-missing>"
   }
 }

--- a/conformance/authorization/goldens/password-missing.loadplan.json
+++ b/conformance/authorization/goldens/password-missing.loadplan.json
@@ -17,7 +17,7 @@
   "input_fingerprint": {
     "has_password_input": false,
     "entitlement_input": null,
-    "source_fingerprint": "sha256:15f1c4ed2055d06b3e166fd446084ff8890a55566c1495bee8a37d16501a8cbc"
+    "source_fingerprint": "sha256:eb3fef23e509339bbff5ddbe68fd5418cd843aff431785a7328b4f3e9c534a12"
   },
   "checks": {
     "format_valid": true,

--- a/conformance/authorization/goldens/password-valid.loadplan.json
+++ b/conformance/authorization/goldens/password-valid.loadplan.json
@@ -17,7 +17,7 @@
   "input_fingerprint": {
     "has_password_input": true,
     "entitlement_input": null,
-    "source_fingerprint": "sha256:d65a2dc47683f51da8519c1dae46c2db817f26602423a799d7457ba3cf7727f7"
+    "source_fingerprint": "sha256:9c2d1743001c71c594e128eaa94b6210eb1f1b19e1b2986468d439ce4fcde2f3"
   },
   "checks": {
     "format_valid": true,
@@ -35,7 +35,7 @@
     }
   ],
   "source": {
-    "kind": "dir",
+    "kind": "file",
     "path": "<fixture:password-valid>"
   }
 }

--- a/conformance/authorization/goldens/password-valid.loadplan.json
+++ b/conformance/authorization/goldens/password-valid.loadplan.json
@@ -17,7 +17,7 @@
   "input_fingerprint": {
     "has_password_input": true,
     "entitlement_input": null,
-    "source_fingerprint": "sha256:9c2d1743001c71c594e128eaa94b6210eb1f1b19e1b2986468d439ce4fcde2f3"
+    "source_fingerprint": "sha256:d65a2dc47683f51da8519c1dae46c2db817f26602423a799d7457ba3cf7727f7"
   },
   "checks": {
     "format_valid": true,

--- a/conformance/authorization/goldens/public-valid.loadplan.json
+++ b/conformance/authorization/goldens/public-valid.loadplan.json
@@ -17,7 +17,7 @@
   "input_fingerprint": {
     "has_password_input": false,
     "entitlement_input": null,
-    "source_fingerprint": "sha256:90c01e50ee62764511cde607272a98074efe05ba292e62fa1e791c72403f4c06"
+    "source_fingerprint": "sha256:df8909f5bdcfcf9a60e77c21ff1f298c91e1f3aa79b99bd35162cd1e4b01c33d"
   },
   "checks": {
     "format_valid": true,
@@ -29,7 +29,7 @@
   },
   "issues": [],
   "source": {
-    "kind": "dir",
+    "kind": "file",
     "path": "<fixture:public-valid>"
   }
 }

--- a/conformance/authorization/goldens/public-valid.loadplan.json
+++ b/conformance/authorization/goldens/public-valid.loadplan.json
@@ -17,7 +17,7 @@
   "input_fingerprint": {
     "has_password_input": false,
     "entitlement_input": null,
-    "source_fingerprint": "sha256:df8909f5bdcfcf9a60e77c21ff1f298c91e1f3aa79b99bd35162cd1e4b01c33d"
+    "source_fingerprint": "sha256:90c01e50ee62764511cde607272a98074efe05ba292e62fa1e791c72403f4c06"
   },
   "checks": {
     "format_valid": true,

--- a/conformance/authorization/goldens/receipt-missing.loadplan.json
+++ b/conformance/authorization/goldens/receipt-missing.loadplan.json
@@ -17,7 +17,7 @@
   "input_fingerprint": {
     "has_password_input": false,
     "entitlement_input": null,
-    "source_fingerprint": "sha256:d6928f9077c0b5741d88fb80ea763588cee3833efd150c728dcfdc0df03d386f"
+    "source_fingerprint": "sha256:2560e604af39e8bf6ffd339e29e344e4cebe562ec4d4aa91fcd14d082a6a1c4a"
   },
   "checks": {
     "format_valid": true,

--- a/conformance/authorization/goldens/receipt-missing.loadplan.json
+++ b/conformance/authorization/goldens/receipt-missing.loadplan.json
@@ -17,7 +17,7 @@
   "input_fingerprint": {
     "has_password_input": false,
     "entitlement_input": null,
-    "source_fingerprint": "sha256:2560e604af39e8bf6ffd339e29e344e4cebe562ec4d4aa91fcd14d082a6a1c4a"
+    "source_fingerprint": "sha256:d6928f9077c0b5741d88fb80ea763588cee3833efd150c728dcfdc0df03d386f"
   },
   "checks": {
     "format_valid": true,
@@ -35,7 +35,7 @@
     }
   ],
   "source": {
-    "kind": "dir",
+    "kind": "file",
     "path": "<fixture:receipt-missing>"
   }
 }

--- a/conformance/authorization/goldens/receipt-valid.loadplan.json
+++ b/conformance/authorization/goldens/receipt-valid.loadplan.json
@@ -17,7 +17,7 @@
   "input_fingerprint": {
     "has_password_input": false,
     "entitlement_input": "active",
-    "source_fingerprint": "sha256:2776e8cbdea3fe253dffb36035c1bc4efce0d1ce3cb74083b77343bddafb8b5b"
+    "source_fingerprint": "sha256:8fbc87bbc60a6edf0c631479adf1c109cb246d0cabc58b4bc5db88cab99401c5"
   },
   "checks": {
     "format_valid": true,
@@ -29,7 +29,7 @@
   },
   "issues": [],
   "source": {
-    "kind": "dir",
+    "kind": "file",
     "path": "<fixture:receipt-valid>"
   }
 }

--- a/conformance/authorization/goldens/receipt-valid.loadplan.json
+++ b/conformance/authorization/goldens/receipt-valid.loadplan.json
@@ -17,7 +17,7 @@
   "input_fingerprint": {
     "has_password_input": false,
     "entitlement_input": "active",
-    "source_fingerprint": "sha256:8fbc87bbc60a6edf0c631479adf1c109cb246d0cabc58b4bc5db88cab99401c5"
+    "source_fingerprint": "sha256:2776e8cbdea3fe253dffb36035c1bc4efce0d1ce3cb74083b77343bddafb8b5b"
   },
   "checks": {
     "format_valid": true,

--- a/conformance/authorization/goldens/remote-recognized-not-loaded.loadplan.json
+++ b/conformance/authorization/goldens/remote-recognized-not-loaded.loadplan.json
@@ -17,7 +17,7 @@
   "input_fingerprint": {
     "has_password_input": false,
     "entitlement_input": null,
-    "source_fingerprint": "sha256:8a7f15ab8f78ba42446520ce5d5b7f2f71ac7e115bf1a3e0bf8d6ce1d1795c5b"
+    "source_fingerprint": "sha256:974becec97d801d5395dcc6e3705f98e3e362b2600348dfb500d43e2f1c80d85"
   },
   "checks": {
     "format_valid": true,
@@ -35,7 +35,7 @@
     }
   ],
   "source": {
-    "kind": "dir",
+    "kind": "file",
     "path": "<fixture:remote-recognized-not-loaded>"
   }
 }

--- a/conformance/authorization/goldens/remote-recognized-not-loaded.loadplan.json
+++ b/conformance/authorization/goldens/remote-recognized-not-loaded.loadplan.json
@@ -17,7 +17,7 @@
   "input_fingerprint": {
     "has_password_input": false,
     "entitlement_input": null,
-    "source_fingerprint": "sha256:974becec97d801d5395dcc6e3705f98e3e362b2600348dfb500d43e2f1c80d85"
+    "source_fingerprint": "sha256:8a7f15ab8f78ba42446520ce5d5b7f2f71ac7e115bf1a3e0bf8d6ce1d1795c5b"
   },
   "checks": {
     "format_valid": true,

--- a/conformance/authorization/goldens/revoked-entitlement.loadplan.json
+++ b/conformance/authorization/goldens/revoked-entitlement.loadplan.json
@@ -17,7 +17,7 @@
   "input_fingerprint": {
     "has_password_input": false,
     "entitlement_input": "revoked",
-    "source_fingerprint": "sha256:90e21f1c1469c245c3279480ad095af5c0afa8a77d41b84097c110a51e50dcdf"
+    "source_fingerprint": "sha256:befdb9465b1d9469a6a2dba74c980a71560e0b390707334cdea0c2067ad85573"
   },
   "checks": {
     "format_valid": true,
@@ -35,7 +35,7 @@
     }
   ],
   "source": {
-    "kind": "dir",
+    "kind": "file",
     "path": "<fixture:revoked-entitlement>"
   }
 }

--- a/conformance/authorization/goldens/revoked-entitlement.loadplan.json
+++ b/conformance/authorization/goldens/revoked-entitlement.loadplan.json
@@ -17,7 +17,7 @@
   "input_fingerprint": {
     "has_password_input": false,
     "entitlement_input": "revoked",
-    "source_fingerprint": "sha256:befdb9465b1d9469a6a2dba74c980a71560e0b390707334cdea0c2067ad85573"
+    "source_fingerprint": "sha256:90e21f1c1469c245c3279480ad095af5c0afa8a77d41b84097c110a51e50dcdf"
   },
   "checks": {
     "format_valid": true,

--- a/conformance/authorization/goldens/tampered-payload.loadplan.json
+++ b/conformance/authorization/goldens/tampered-payload.loadplan.json
@@ -17,7 +17,7 @@
   "input_fingerprint": {
     "has_password_input": false,
     "entitlement_input": null,
-    "source_fingerprint": "sha256:70c6f7684ea88068dd97c27b7151bbea69e5bff9a54b929065f78587aec56d8e"
+    "source_fingerprint": "sha256:dfb2ebd306101688d72bdd9cd4fa5e9c332eeb9614cb0c16185858033b166863"
   },
   "checks": {
     "format_valid": true,
@@ -40,7 +40,7 @@
     }
   ],
   "source": {
-    "kind": "dir",
+    "kind": "file",
     "path": "<fixture:tampered-payload>"
   }
 }

--- a/conformance/authorization/goldens/tampered-payload.loadplan.json
+++ b/conformance/authorization/goldens/tampered-payload.loadplan.json
@@ -17,7 +17,7 @@
   "input_fingerprint": {
     "has_password_input": false,
     "entitlement_input": null,
-    "source_fingerprint": "sha256:dfb2ebd306101688d72bdd9cd4fa5e9c332eeb9614cb0c16185858033b166863"
+    "source_fingerprint": "sha256:70c6f7684ea88068dd97c27b7151bbea69e5bff9a54b929065f78587aec56d8e"
   },
   "checks": {
     "format_valid": true,

--- a/conformance/authorization/goldens/unknown-access.loadplan.json
+++ b/conformance/authorization/goldens/unknown-access.loadplan.json
@@ -17,7 +17,7 @@
   "input_fingerprint": {
     "has_password_input": false,
     "entitlement_input": null,
-    "source_fingerprint": "sha256:d7a34d3617c992376be4354ab63a82b97ee46708a92576f2be088b996244dace"
+    "source_fingerprint": "sha256:7750d552c91001cbbf7b1a97588599891ec78dc52f1988eba4a2f1954d44a095"
   },
   "checks": {
     "format_valid": true,
@@ -35,7 +35,7 @@
     }
   ],
   "source": {
-    "kind": "dir",
+    "kind": "file",
     "path": "<fixture:unknown-access>"
   }
 }

--- a/conformance/authorization/goldens/unknown-access.loadplan.json
+++ b/conformance/authorization/goldens/unknown-access.loadplan.json
@@ -17,7 +17,7 @@
   "input_fingerprint": {
     "has_password_input": false,
     "entitlement_input": null,
-    "source_fingerprint": "sha256:7750d552c91001cbbf7b1a97588599891ec78dc52f1988eba4a2f1954d44a095"
+    "source_fingerprint": "sha256:d7a34d3617c992376be4354ab63a82b97ee46708a92576f2be088b996244dace"
   },
   "checks": {
     "format_valid": true,

--- a/conformance/authorization/goldens/unknown-entitlement-profile.loadplan.json
+++ b/conformance/authorization/goldens/unknown-entitlement-profile.loadplan.json
@@ -17,7 +17,7 @@
   "input_fingerprint": {
     "has_password_input": false,
     "entitlement_input": null,
-    "source_fingerprint": "sha256:5a23f89be08301a08a58983fc70916bb79f62e4ec5d9bae416ea82c96592dd54"
+    "source_fingerprint": "sha256:57c8278795f296ebed7cceea17d4e0b02e1dd305f81746761648db330542c210"
   },
   "checks": {
     "format_valid": true,

--- a/conformance/authorization/goldens/unknown-entitlement-profile.loadplan.json
+++ b/conformance/authorization/goldens/unknown-entitlement-profile.loadplan.json
@@ -17,7 +17,7 @@
   "input_fingerprint": {
     "has_password_input": false,
     "entitlement_input": null,
-    "source_fingerprint": "sha256:57c8278795f296ebed7cceea17d4e0b02e1dd305f81746761648db330542c210"
+    "source_fingerprint": "sha256:5a23f89be08301a08a58983fc70916bb79f62e4ec5d9bae416ea82c96592dd54"
   },
   "checks": {
     "format_valid": true,
@@ -35,7 +35,7 @@
     }
   ],
   "source": {
-    "kind": "dir",
+    "kind": "file",
     "path": "<fixture:unknown-entitlement-profile>"
   }
 }

--- a/docs/V1RC_RELEASE_BOARD.md
+++ b/docs/V1RC_RELEASE_BOARD.md
@@ -1,6 +1,8 @@
 # KDNA v1.0-rc Public Confidence Release
 
-> ⚠️ **Historical snapshot.** This document describes the pre-v1 KDNA release board and is out of scope for KDNA Core v1. KDNA Core v1 is the official KDNA judgment-asset format and runtime loading contract. Current docs: README.md, docs/core/definition.md, docs/core/principles.md.
+> ⚠️ **Historical snapshot.** This obsolete release board does not describe the
+> current KDNA Core or the single KDNA Asset Container. Current docs:
+> README.md, docs/core/definition.md, and docs/core/principles.md.
 
 > **Milestone:** v1.0-rc  
 > **Target:** External developers can integrate, verify, publish, and contribute to KDNA — without reading internal docs or asking the maintainer.  

--- a/docs/V1RC_RELEASE_GATE.md
+++ b/docs/V1RC_RELEASE_GATE.md
@@ -1,6 +1,8 @@
 # KDNA v1.0-rc Release Gate
 
-> ⚠️ **Historical snapshot.** This document describes the pre-v1 KDNA release gate and is out of scope for KDNA Core v1. KDNA Core v1 is the official KDNA judgment-asset format and runtime loading contract. Current docs: README.md, docs/core/definition.md, docs/core/principles.md.
+> ⚠️ **Historical snapshot.** This obsolete release gate does not describe the
+> current KDNA Core or the single KDNA Asset Container. Current docs:
+> README.md, docs/core/definition.md, and docs/core/principles.md.
 
 This release gate applies to the open protocol and tooling only. Applications
 and already-published assets follow the protocol after the tools are released.

--- a/docs/adr/ADR-003-canonical-distribution-container.md
+++ b/docs/adr/ADR-003-canonical-distribution-container.md
@@ -1,8 +1,14 @@
 # ADR-003: Canonical Distribution Container
 
-- **Status**: accepted
+- **Status**: superseded by the current single-container specification
 - **Date**: 2026-06-25
 - **Deciders**: KDNA Core team
+
+> **Historical decision record.** This ADR captures the consolidation work that
+> removed the former multi-format implementation. It is not current format
+> guidance. There is one user-facing KDNA Asset Container. See
+> [SPEC.md](../../SPEC.md), [file-format.md](../core/file-format.md), and
+> [version-taxonomy.md](../version-taxonomy.md).
 
 ## Context
 

--- a/docs/adr/ADR-006-naming-convention.md
+++ b/docs/adr/ADR-006-naming-convention.md
@@ -1,8 +1,13 @@
 # ADR-006: Naming Convention for "Core" / "v1" / "GA" References
 
-- **Status**: accepted
+- **Status**: superseded by `docs/version-taxonomy.md`
 - **Date**: 2026-06-26
 - **Deciders**: KDNA Core team
+
+> **Historical decision record.** The product-generation naming below is no
+> longer current guidance. Public documentation now says `KDNA Core` and `KDNA
+> Asset Container`, without presenting user-facing V1/V2/V3 generations. Wire
+> fields and npm package versions remain independently versioned.
 
 ## Context
 

--- a/docs/authoring-guide.md
+++ b/docs/authoring-guide.md
@@ -83,7 +83,7 @@ If you write KDNA JSON from scratch, you MUST use these exact field names. The l
 | `brief` / `bad_pattern` / `master_pattern` (on cases) | `title` / `what_happened` / `structural_pattern` |
 | `capability_layers` (on evolution) | `stages` |
 
-For dev source experiments, start from `kdna dev scaffold <name>` or `kdna cluster init <name>` so field names stay consistent. This creates a non-canonical workspace only. A formal `.kdna` asset is valid when it is exported to the v1 container format and passes `kdna validate`; the Studio toolchain is the recommended authoring path, not the only valid creation path.
+For dev source experiments, start from `kdna dev scaffold <name>` or `kdna cluster init <name>` so field names stay consistent. This creates a non-canonical workspace only. A formal asset exists when it is exported to the KDNA Asset Container and passes `kdna validate`; the Studio toolchain is one authoring path, not a creation gate.
 
 ---
 

--- a/docs/core/payload-profile.md
+++ b/docs/core/payload-profile.md
@@ -143,7 +143,7 @@ This is the **smallest** payload that conforms to the schema. The conformance su
 
 ## Why `judgment-profile-v1` is explicit
 
-A previous design allowed the payload to be any JSON object. That forced every loader to learn a custom schema for every asset, and made the "what is a valid judgment asset?" question impossible to answer statically. By pinning a single profile in Phase 1, the format gains a **conformance target**: a tool can claim to be a "KDNA v1 loader" and validate against this profile. Future profiles will be additive; the `profile` field is the version pin.
+A previous design allowed the payload to be any JSON object. That forced every loader to learn a custom schema for every asset, and made the "what is a valid judgment asset?" question impossible to answer statically. By pinning a single profile, the format gains a **conformance target**: a tool can claim to be a conforming KDNA loader and validate against this profile. The `profile` field is a wire-level schema discriminator, not a user-facing container generation.
 
 ## What this profile does NOT define
 

--- a/docs/creator-workflow.md
+++ b/docs/creator-workflow.md
@@ -224,7 +224,7 @@ kdna-<domain-id>/
 
 # kdna-<domain-id>
 
-[![KDNA Spec](https://img.shields.io/badge/KDNA-v1.0-4c1)](https://github.com/aikdna/kdna)
+[![KDNA Spec](https://img.shields.io/badge/KDNA-open_protocol-4c1)](https://github.com/aikdna/kdna)
 
 **<Domain Name>** — <one-line description>
 

--- a/docs/design/private-asset-security-gate.md
+++ b/docs/design/private-asset-security-gate.md
@@ -1,8 +1,13 @@
 # Private Asset Security Gate — Design
 
-> **Status:** Gate design (pre-implementation). No code is defined in this document.
+> **Status:** Superseded historical gate design. Do not use as implementation guidance.
 > **Audience:** Owner + downstream implementation agents (Core / CLI / Studio).
 > **Scope boundary:** This document covers the **entry gate** for adding signature and encryption handling to `.kdna` private assets. It does **not** redesign the existing `kdna-licensed-entry-v1` profile (see [kdna-encryption-authorization.md](../kdna-encryption-authorization.md)) and it does **not** introduce any authorization, entitlement, billing, registry scoring, or content-quality concepts.
+
+> Signature, encryption, LoadPlan, authorization, and Runtime Capsule behavior
+> has since shipped under the single-container contract. For current behavior,
+> use SPEC.md and `docs/kdna-encryption-authorization.md`. Commands and gates
+> below are retained only as design history.
 
 ---
 

--- a/docs/domain-quality-baseline.md
+++ b/docs/domain-quality-baseline.md
@@ -86,7 +86,7 @@ When publishing a new public KDNA entry, verify:
 | Stances | 3 (each with applies_when / does_not_apply_when) |
 | Standard terms | 4 with definitions |
 | Banned terms | 3 (each with why + replace_with) |
-| Misunderstandings | 3 with full v2.1 governance fields |
+| Misunderstandings | 3 with the historical governance fields |
 | Self-checks | 5 yes/no questions |
 | Scenes | 2 with sub-scenarios |
 | Cases | Documented |

--- a/docs/first-domain.md
+++ b/docs/first-domain.md
@@ -17,7 +17,7 @@ npm i -g @aikdna/kdna-cli
 kdna demo minimal ./my-domain
 ```
 
-This creates a minimal v1 source directory with `mimetype`, `kdna.json`,
+This creates a minimal authoring source directory with `mimetype`, `kdna.json`,
 `payload.kdnab`, and `checksums.json`. For real authoring, use the Studio CLI
 producer path in [30-minute-authoring-guide.md](./30-minute-authoring-guide.md).
 

--- a/docs/version-taxonomy.md
+++ b/docs/version-taxonomy.md
@@ -10,7 +10,7 @@ in all active public documents, code comments, and specifications.
 
 | Layer | Canonical Name | Examples |
 |-------|---------------|----------|
-| Core release generation | `KDNA Core 2026.06` or `Core GA` | "KDNA Core 2026.06 Baseline is the current stable release" |
+| Core implementation | `KDNA Core` | "KDNA Core implements the open protocol" |
 | Asset container format | `KDNA Asset Container` | "The KDNA Asset Container uses `kdna.json` + `payload.kdnab`" |
 | Legacy plaintext ZIP | `legacy plaintext ZIP` | "Legacy plaintext ZIP containers placed `KDNA_Core.json` directly in the archive" |
 | Legacy registry asset | `legacy registry asset` | "Legacy registry assets used `kdna_spec` and registry-based distribution" |
@@ -25,14 +25,14 @@ in all active public documents, code comments, and specifications.
 
 | Forbidden | Reason | Use Instead |
 |-----------|--------|-------------|
-| `v1` | Ambiguous: could mean Core GA, legacy plaintext, or something else | `Core GA` or `legacy plaintext ZIP` |
+| `v1` | Ambiguous: could mean the Core implementation, legacy plaintext, or something else | `KDNA Core` or `legacy plaintext ZIP` |
 | `v2` | Ambiguous: could mean asset container, legacy registry, or future spec | `KDNA Asset Container` or `legacy registry asset` |
-| `v1.0-rc` | Historical label, conflicts with current Core GA | `Core GA` or `2026.06 Baseline` |
+| `v1.0-rc` | Historical label, not a current product generation | `KDNA Core` or an explicitly historical release label |
 | `v2.0` | Chronologically inverted (legacy v2.0 predates Core v1) | `legacy registry asset` or `KDNA Asset Container` |
 | `V1 format` | Identical string means both current Core and removed plaintext | `legacy plaintext ZIP` |
 | `Container v2` | Suggests a release generation, not a container format | `KDNA Asset Container` |
-| `Core v1` | Without "GA" qualifier, reads as a version number | `Core GA` |
-| `v1 Core GA` | Superseded — pre-v0.7 label; v0.7 (2026-05-22) is the current stable line | `Core GA` or `v0.7` |
+| `Core v1` | Presents an obsolete user-facing generation | `KDNA Core` |
+| `v1 Core GA` | Presents an obsolete user-facing generation | `KDNA Core` |
 
 ## Mapping: Old → New
 
@@ -40,8 +40,8 @@ in all active public documents, code comments, and specifications.
 |----------|----------------------|
 | `V1 plaintext (removed)` | `legacy plaintext ZIP` |
 | `v2.0 / Legacy` | `legacy registry asset` |
-| `KDNA Core v1 GA` | `Core GA` or `KDNA Core 2026.06 Baseline` |
-| `KDNA Specification v1.0-rc` | `KDNA Core Specification — 2026.06 Baseline` |
+| `KDNA Core v1 GA` | `KDNA Core` |
+| `KDNA Specification v1.0-rc` | `KDNA Core specification` |
 | `KDNA Container Version 2.0` | `KDNA Asset Container` |
 | `v1 container` (current) | `KDNA Asset Container` |
 | `v2 container` (future) | Future asset container (draft) |

--- a/packages/kdna-core/CHANGELOG.md
+++ b/packages/kdna-core/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+- Reject authoring source directories at the public runtime API boundary;
+  `planLoad`, `load`, `loadAsset`, and `loadAuthorized` now require a packaged
+  `.kdna` file, including resolver-provided dependencies.
+- Regenerate authorization conformance fixtures from packaged assets and keep
+  source directories available only to authoring operations such as inspect,
+  validate, pack, and unpack.
+- Remove stale public format-generation wording and local coordination-path
+  assumptions from protocol documentation and public audit scripts.
+- Make release readiness fail for dirty inputs or when the selected version
+  tag does not point to the current commit.
+
 ## v0.15.12 (2026-07-12)
 
 **Single-format refactor + CBOR wire contract + Runtime Capsule.**

--- a/packages/kdna-core/schema/load-plan.schema.json
+++ b/packages/kdna-core/schema/load-plan.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/aikdna/kdna/schema/load-plan.schema.json",
   "title": "KDNA LoadPlan v1",
-  "description": "Machine-readable pre-load authorization and runtime planning result for KDNA Core v1 assets.",
+  "description": "Machine-readable pre-load authorization and runtime planning result for packaged KDNA assets.",
   "type": "object",
   "required": [
     "kdna_version",

--- a/packages/kdna-core/scripts/check-release-readiness.js
+++ b/packages/kdna-core/scripts/check-release-readiness.js
@@ -20,12 +20,29 @@ function check(label, fn) {
 
 console.log(`Release readiness check: ${name}@${version}\n`);
 
+check('worktree is clean', () => {
+  const out = execSync('git status --porcelain', { encoding: 'utf8' }).trim();
+  if (out) throw new Error('tracked or untracked release inputs are not committed');
+});
+
 check('git tag exists', () => {
   const coreOut = execSync(`git tag -l "${coreTag}"`, { encoding: 'utf8' }).trim();
   const simpleOut = execSync(`git tag -l "${simpleTag}"`, { encoding: 'utf8' }).trim();
   if (!coreOut && !simpleOut) {
     throw new Error(
       `Neither tag ${coreTag} nor ${simpleTag} found. Run: git tag ${coreTag} && git push origin ${coreTag}`,
+    );
+  }
+});
+
+check('version tag points to HEAD', () => {
+  const head = execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
+  const coreOut = execSync(`git tag -l "${coreTag}"`, { encoding: 'utf8' }).trim();
+  const releaseTag = coreOut ? coreTag : simpleTag;
+  const tagged = execSync(`git rev-list -n 1 "${releaseTag}"`, { encoding: 'utf8' }).trim();
+  if (head !== tagged) {
+    throw new Error(
+      `${releaseTag} points to ${tagged.slice(0, 12)}, not HEAD ${head.slice(0, 12)}`,
     );
   }
 });

--- a/packages/kdna-core/src/index.js
+++ b/packages/kdna-core/src/index.js
@@ -11,6 +11,7 @@ const cryptoProfile = require('./crypto-profile');
 const publicApi = require('./public-api');
 const workpackPure = require('./workpack-pure');
 const v1 = require('./v1');
+const runtimeApi = require('./runtime-api');
 
 module.exports = {
   ...publicApi,
@@ -23,4 +24,5 @@ module.exports = {
   ...cryptoProfile,
   ...workpackPure,
   ...v1,
+  ...runtimeApi,
 };

--- a/packages/kdna-core/src/index.mjs
+++ b/packages/kdna-core/src/index.mjs
@@ -20,19 +20,21 @@ export {
   readLayout,
   inspect,
   validate,
-  planLoad,
-  loadAuthorized,
   buildChecksums,
   pack,
   unpack,
-  load,
-  loadAsset,
   buildCapsule,
   FORBIDDEN_OUTPUT_TERMS,
   parseSemver,
   compareSemver,
   satisfies,
 } from './v1/index.js';
+
+import runtimeApi from './runtime-api.js';
+export const planLoad = runtimeApi.planLoad;
+export const loadAuthorized = runtimeApi.loadAuthorized;
+export const load = runtimeApi.load;
+export const loadAsset = runtimeApi.loadAsset;
 
 export { validateDomainSchema, validateCrossFile } from './validate-pure.js';
 

--- a/packages/kdna-core/src/runtime-api.js
+++ b/packages/kdna-core/src/runtime-api.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const v1 = require('./v1');
+
+function invalidDirectoryPlan(inputPath) {
+  const resolved = path.resolve(inputPath);
+  return {
+    kdna_version: null,
+    asset: { asset_id: null, asset_uid: null, title: null, version: null, judgment_version: null },
+    access: null,
+    access_alias: null,
+    entitlement_profile: null,
+    state: 'invalid',
+    required_action: 'block',
+    can_load_now: false,
+    projection_policy: 'none',
+    input_fingerprint: null,
+    checks: {
+      format_valid: false,
+      schema_valid: false,
+      payload_valid: false,
+      checksums_valid: false,
+      load_contract_valid: false,
+      overall_valid: false,
+    },
+    issues: [{
+      code: 'KDNA_ASSET_FILE_REQUIRED',
+      severity: 'blocking',
+      message: 'Runtime loading requires a packaged .kdna asset file. Source directories are authoring inputs only.',
+    }],
+    source: { kind: 'dir', path: resolved },
+  };
+}
+
+function isDirectory(inputPath) {
+  if (typeof inputPath !== 'string') return false;
+  try {
+    return fs.statSync(path.resolve(inputPath)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function guardResolver(options = {}) {
+  if (typeof options.resolveAsset !== 'function') return options;
+  const resolveAsset = options.resolveAsset;
+  return {
+    ...options,
+    resolveAsset(name) {
+      const resolved = resolveAsset(name);
+      if (resolved?.path && isDirectory(resolved.path)) {
+        const error = new Error(
+          `Resolved asset "${name}" is a source directory. Runtime dependencies must be packaged .kdna files.`,
+        );
+        error.code = 'KDNA_ASSET_FILE_REQUIRED';
+        throw error;
+      }
+      return resolved;
+    },
+  };
+}
+
+function planLoad(inputPath, options = {}) {
+  if (isDirectory(inputPath)) return invalidDirectoryPlan(inputPath);
+  return v1.planLoad(inputPath, guardResolver(options));
+}
+
+function loadAuthorized(inputPath, options = {}) {
+  const plan = planLoad(inputPath, options);
+  if (plan.can_load_now !== true) {
+    const issueCodes = Array.isArray(plan.issues)
+      ? plan.issues.map((issue) => issue.code).filter(Boolean)
+      : [];
+    const error = new Error(
+      `LoadPlan denied loading: state=${plan.state || 'invalid'} required_action=${plan.required_action || 'block'}`,
+    );
+    error.code = issueCodes[0] || 'KDNA_LOAD_NOT_AUTHORIZED';
+    error.plan = plan;
+    throw error;
+  }
+  return v1.loadAuthorized(inputPath, guardResolver(options));
+}
+
+module.exports = {
+  planLoad,
+  loadAuthorized,
+  load: loadAuthorized,
+  loadAsset: loadAuthorized,
+};

--- a/packages/kdna-core/src/types.d.ts
+++ b/packages/kdna-core/src/types.d.ts
@@ -482,7 +482,7 @@ export function matchDomain(input: string, candidates: Array<KDNAAssetInput | KD
 export function matchDomainSync(input: string, candidates: Array<KDNAAssetInput | KDNAInspectResult>, options?: KdnaDecryptOptions): KDNAMatchResult[];
 export function composeKDNA(inputs: KDNAAssetInput[], options?: { input?: string; profile?: 'compact' | 'scenario' | 'full' | string; separator?: string } & KdnaDecryptOptions): Promise<KDNAComposeResult>;
 
-// KDNA Core — source directory / container API
+// KDNA Core — authoring source and packaged runtime API
 export const MIMETYPE: string;
 export const REQUIRED_DIR_ENTRIES: string[];
 

--- a/packages/kdna-core/src/v1/index.js
+++ b/packages/kdna-core/src/v1/index.js
@@ -1889,7 +1889,7 @@ function loadV1Unsafe(inputPath, opts = {}) {
     const hasJudgment = (core.axioms && core.axioms.length > 0)
       || (core.boundaries && core.boundaries.length > 0)
       || (payload.patterns && payload.patterns.length > 0)
-      || (payload.reasoning && ((payload.reasoning.self_checks && payload.reasoning.self_checks.length > 0) || (payload.reasoning.failure_modes && payload.reasoning.failure_modes.length > 0)));
+      || (payload.reasoning && ((payload.reasoning.self_check && payload.reasoning.self_check.length > 0) || (payload.reasoning.failure_modes && payload.reasoning.failure_modes.length > 0)));
     profiles.push('index');
     if (hasJudgment) profiles.push('compact');
     if (payload.scenarios && payload.scenarios.length > 0) profiles.push('scenario');
@@ -1924,7 +1924,11 @@ function loadV1Unsafe(inputPath, opts = {}) {
       highest_question: core.highest_question || null,
       axioms: (core.axioms || []).map(normalizeCompactAxiom).filter(Boolean),
       boundaries: normalizeList(core.boundaries),
-      self_checks: normalizeList(payload.reasoning && payload.reasoning.self_checks),
+      // The canonical payload field is singular (`reasoning.self_check`).
+      // Runtime Capsule uses plural (`context.self_checks`) as its projection
+      // field. Reading the plural name from the payload silently discarded
+      // every Studio-authored self-check.
+      self_checks: normalizeList(payload.reasoning && payload.reasoning.self_check),
       failure_modes: normalizeList(payload.reasoning && payload.reasoning.failure_modes),
       patterns: normalizeList(payload.patterns).slice(0, 3),
     };

--- a/packages/kdna-core/src/v1/index.js
+++ b/packages/kdna-core/src/v1/index.js
@@ -1099,12 +1099,11 @@ function finalizeLoadPlan(plan) {
   return plan;
 }
 
-function computeSourceFingerprint(inputPath, v1) {
-  const absPath = path.resolve(inputPath);
-  if (v1.kind === 'file') {
-    return `sha256:${crypto.createHash('sha256').update(fs.readFileSync(absPath)).digest('hex')}`;
-  }
-
+function computeSourceFingerprint(_inputPath, v1) {
+  // Fingerprint the logical entries, not the transport ZIP bytes. DEFLATE
+  // output can differ between zlib versions and operating systems even when
+  // every uncompressed KDNA entry is identical. LoadPlan conformance must be
+  // stable across JS, Swift, CI runners, and repackaging transports.
   const hash = crypto.createHash('sha256');
   for (const name of Object.keys(v1.map).sort()) {
     const bytes = v1.map[name];

--- a/packages/kdna-core/src/v1/index.js
+++ b/packages/kdna-core/src/v1/index.js
@@ -1,17 +1,15 @@
 /**
- * v1-cli.js — KDNA Core v1 inspect / validate / pack / unpack for the
- * kdna monorepo CLI shim.
+ * KDNA Asset Container inspect / validate / pack / unpack implementation.
  *
  * KDNA Core is the official KDNA judgment-asset format and runtime
  * loading contract. .kdna assets are created, inspected, packed,
  * unpacked, and validated through the official KDNA toolchain. This
- * module is the v1 component of that toolchain.
  *
- * The KDNA Core v1 file format is documented in docs/core/file-format.md.
+ * The KDNA Asset Container is documented in docs/core/file-format.md.
  * This module is the shared implementation that:
  *
- *   - packages/kdna/bin/kdna.js uses as a v1-aware router
- *   - scripts/v1-*.mjs delegate to (via child_process) so the legacy
+ *   - packages/kdna/bin/kdna.js uses as its container router
+ *   - compatibility scripts delegate to it so historical tooling
  *     scripts and the official CLI cannot drift
  *
  * Hard rules from the format spec:
@@ -178,7 +176,7 @@ function loadSchemas() {
 // ─── Format detection ──────────────────────────────────────────────────
 
 /**
- * Detect whether a directory is a v1 source layout.
+ * Detect whether a directory is a KDNA authoring source layout.
  * Required entries: mimetype, kdna.json, payload.kdnab.
  * mimetype content must equal "application/vnd.kdna.asset".
  */
@@ -536,10 +534,10 @@ function readV1Layout(absPath) {
     for (const f of V1_REQUIRED_DIR_ENTRIES) {
       const full = path.join(absPath, f);
       if (!fs.existsSync(full)) {
-        throw new Error(`not a KDNA v1 source dir: missing ${f}`);
+        throw new Error(`not a KDNA authoring source directory: missing ${f}`);
       }
       if (fs.lstatSync(full).isSymbolicLink()) {
-        throw new Error(`not a KDNA v1 source dir: ${f} must not be a symlink`);
+        throw new Error(`not a KDNA authoring source directory: ${f} must not be a symlink`);
       }
     }
     for (const f of [...V1_REQUIRED_DIR_ENTRIES, ...V1_OPTIONAL_DIR_ENTRIES]) {
@@ -557,10 +555,10 @@ function readV1Layout(absPath) {
     kind = 'file';
     entries = listZipEntries(absPath);
     if (entries.length === 0 || entries[0].name !== 'mimetype') {
-      throw new Error('not a KDNA v1 container: first entry is not mimetype');
+      throw new Error('not a KDNA Asset Container: first entry is not mimetype');
     }
     if (entries[0].method !== 0) {
-      throw new Error('not a KDNA v1 container: mimetype must be uncompressed');
+      throw new Error('not a KDNA Asset Container: mimetype must be uncompressed');
     }
     for (const e of entries) {
       // We only need the well-known entries; signatures/ attachments/ etc.
@@ -576,7 +574,7 @@ function readV1Layout(absPath) {
     }
     for (const f of V1_REQUIRED_DIR_ENTRIES) {
       if (!map[f]) {
-        throw new Error(`not a KDNA v1 container: missing ${f}`);
+        throw new Error(`not a KDNA Asset Container: missing ${f}`);
       }
     }
   } else {
@@ -725,7 +723,7 @@ function runValidate(v1) {
   if (!validators) {
     result.schema_valid = false;
     problems.push(
-      'schema: ajv not available. KDNA Core v1 requires ajv and ajv-formats for JSON-Schema validation. Run: npm install ajv ajv-formats (or: npm install -g ajv ajv-formats for global CLI users)',
+      'schema: KDNA Core requires ajv and ajv-formats for JSON-Schema validation. Run: npm install ajv ajv-formats (or: npm install -g ajv ajv-formats for global CLI users)',
     );
     return finalizeValidate(result, problems);
   }
@@ -919,7 +917,7 @@ function buildChecksumsV1(sourceDir) {
 // ─── pack ──────────────────────────────────────────────────────────────
 
 /**
- * Pack a v1 source directory into a .kdna container. Output is
+ * Pack an authoring source directory into a .kdna asset. Output is
  * deterministic: the same source directory packed twice produces
  * byte-identical output (fixed DOS timestamps, fixed entry order,
  * mimetype first).
@@ -1017,7 +1015,7 @@ function unpack(inputPath, outputDir) {
     throw new Error(`not a file: ${absIn}`);
   }
   const entries = listZipEntries(absIn);
-  // Sanity: v1 container must have mimetype as first entry with the v1 media type.
+  // Sanity: the asset must have mimetype as its first, uncompressed entry.
   if (entries.length === 0 || entries[0].name !== 'mimetype') {
     throw new Error('not a KDNA container: first entry is not mimetype');
   }
@@ -1211,14 +1209,15 @@ function canonicalToV1Layout(asset) {
 }
 
 /**
- * Plan a KDNA v1 runtime load without decrypting or emitting judgment content.
+ * Plan a KDNA runtime load without decrypting or emitting judgment content.
  * Product consumers such as Chat should render authorization UI from this
  * result instead of parsing manifest fields directly.
  */
 function planLoad(inputPath, opts = {}) {
   let v1;
 
-  // Try the unified container dispatcher first (handles v1 dirs, v1 containers, v2 containers)
+  // Try the unified container dispatcher first; the internal compatibility
+  // reader below remains available only for authoring and migration tooling.
   if (readAsset !== null) {
     try {
       const asset = readAsset(path.resolve(inputPath));

--- a/packages/kdna-core/test/single-format-api.test.js
+++ b/packages/kdna-core/test/single-format-api.test.js
@@ -49,7 +49,13 @@ test('Core runtime API rejects source directories and accepts packaged assets', 
   try {
     const assetPath = path.join(tmp, 'minimal.kdna');
     v1.pack(source, assetPath);
-    assert.equal(core.planLoad(assetPath).state, 'ready');
+    const packagedPlan = core.planLoad(assetPath);
+    assert.equal(packagedPlan.state, 'ready');
+    assert.equal(
+      packagedPlan.input_fingerprint.source_fingerprint,
+      v1.planLoad(source).input_fingerprint.source_fingerprint,
+      'source fingerprint is stable across source and packaged transports',
+    );
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true });
   }

--- a/packages/kdna-core/test/single-format-api.test.js
+++ b/packages/kdna-core/test/single-format-api.test.js
@@ -37,6 +37,24 @@ test('Core root exports single-format public API', () => {
   assert.equal(core.isSourceDir, undefined, 'isSourceDir alias must not be exported');
 });
 
+test('Core runtime API rejects source directories and accepts packaged assets', () => {
+  const repoRoot = path.resolve(__dirname, '..', '..', '..');
+  const source = path.join(repoRoot, 'examples', 'minimal');
+  const plan = core.planLoad(source);
+  assert.equal(plan.state, 'invalid');
+  assert.equal(plan.can_load_now, false);
+  assert.equal(plan.issues[0].code, 'KDNA_ASSET_FILE_REQUIRED');
+
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kdna-runtime-file-'));
+  try {
+    const assetPath = path.join(tmp, 'minimal.kdna');
+    v1.pack(source, assetPath);
+    assert.equal(core.planLoad(assetPath).state, 'ready');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test('v1 entry exports single-format public API', () => {
   assert.equal(v1.MIMETYPE, 'application/vnd.kdna.asset');
   assert.equal(typeof v1.isKdnaSourceDir, 'function');

--- a/registry/README.md
+++ b/registry/README.md
@@ -1,8 +1,8 @@
 # Archived Registry Fixture
 
 This directory is retained only for CLI/validator development fixtures from the
-pre-v1 registry experiment. It is not a public asset catalog and is not part of
-the KDNA Core v1 public beta path.
+historical registry experiment. It is not a public asset catalog and is not
+part of the current KDNA Core path.
 
 Rules:
 - Do not add public domains here.

--- a/registry/domains.json
+++ b/registry/domains.json
@@ -1,6 +1,6 @@
 {
   "_deprecated": true,
-  "_deprecation_note": "This registry file is a historical artifact. Domain entries have been removed as part of Wave 2.5 private-repo leak cleanup (2026-06-25). KDNA Core v1 does not define a canonical registry. Domain discovery is local-first: any .kdna file that passes kdna validate is a valid asset.",
+  "_deprecation_note": "This registry file is a historical artifact. Domain entries have been removed. KDNA Core does not define a canonical registry. Domain discovery is local-first: any .kdna file that passes kdna validate is a valid asset.",
   "registry_version": "1.0-rc",
   "updated": "2026-06-25T00:00:00Z",
   "domains": []

--- a/scripts/check-public-surface.mjs
+++ b/scripts/check-public-surface.mjs
@@ -10,12 +10,10 @@
 //      remediation is structural deletion: remove the field/line/node entirely
 //      (and re-allowlist the consuming schema if a placeholder is genuinely
 //      needed).
-//   2. Forbidden name: any occurrence of a known private repo name or private
-//      domain example outside allowlisted paths. As of 2026-06-27 the
-//      forbidden set is sourced from PRIVATE/STATUS/open/kdna.md [BLOCKING]
-//      entries: aikdna/kdna-website, atomspeak. Update by appending, not
-//      editing history.
-//   3. Internal workspace path: any literal PRIVATE/... path outside
+//   2. Forbidden name: any occurrence of a non-public repository or internal
+//      domain example outside allowlisted paths. Keep this public-safe list in
+//      the script and update it when repository visibility changes.
+//   3. Internal workspace path: any literal internal coordination path outside
 //      allowlisted audit/history files. Public docs must describe public
 //      evidence, not point readers at inaccessible workspace paths.
 //
@@ -40,13 +38,10 @@ const ALLOWLIST_PATHS = new Set([
   // names. They live under docs/audits/ and docs/rfc-status.md.
   'docs/audits/',
   'docs/rfc-status.md',
-  // Known workflow-file exception: this public comment should be cleaned up,
-  // but the current GitHub OAuth token cannot push workflow edits.
-  '.github/workflows/publish.yml',
 ]);
 
 const REDACTED_PATTERN = /\bREDACTED\b/;
-const PRIVATE_PATH_PATTERN = /\bPRIVATE[\\/]/;
+const PRIVATE_PATH_PATTERN = new RegExp(`\\b${'PRIVATE'}[\\\\/]`);
 const FORBIDDEN_PATTERNS = [
   { name: 'aikdna/kdna-website', pattern: /\baikdna\/kdna-website\b|kdna-website\b/ },
   { name: 'atomspeak', pattern: /\batomspeak\b|@atomspeak\b/ },

--- a/scripts/ecosystem-version-lock.js
+++ b/scripts/ecosystem-version-lock.js
@@ -15,8 +15,8 @@
  *   - KDNA_CORE_BASELINE env var, OR
  *   - packages/kdna-core/package.json (the monorepo source of truth)
  *
- * Repos to scan are read from KDNA_REPOS_ROOT (defaults to parent of
- * kdna monorepo, i.e. /Users/AI/K/OPEN). Each subdirectory is treated
+ * Repos to scan are read from KDNA_REPOS_ROOT (defaults to the parent of
+ * the kdna monorepo). Each subdirectory is treated
  * as a consumer if it has a package.json declaring a @aikdna/* dep.
  *
  * Usage:

--- a/scripts/generate-authorization-conformance.mjs
+++ b/scripts/generate-authorization-conformance.mjs
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
@@ -22,7 +23,7 @@ const cases = [
   {
     id: 'public-valid',
     fixture: 'public-valid',
-    description: 'Public v1 asset loads immediately through a minimal projection.',
+    description: 'Public packaged asset loads immediately through a minimal projection.',
     manifest: { access: 'public' },
     options: {},
     cli_args: [],
@@ -256,7 +257,11 @@ ensureDir(goldensRoot);
 
 const caseIndex = cases.map((testCase) => {
   const fixtureDir = writeFixture(testCase);
-  const plan = normalizePlan(v1.planLoad(fixtureDir, testCase.options), testCase);
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kdna-auth-golden-'));
+  const assetPath = path.join(tempRoot, `${testCase.fixture}.kdna`);
+  v1.pack(fixtureDir, assetPath);
+  const plan = normalizePlan(v1.planLoad(assetPath, testCase.options), testCase);
+  fs.rmSync(tempRoot, { recursive: true, force: true });
   fs.writeFileSync(path.join(goldensRoot, `${testCase.id}.loadplan.json`), json(plan));
   return {
     id: testCase.id,

--- a/scripts/scan-repo-compliance.sh
+++ b/scripts/scan-repo-compliance.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 # scripts/scan-repo-compliance.sh
 # Reproducible 28 KDNA 仓库 compliance scan
-# 用法: bash scripts/scan-repo-compliance.sh /Users/AI/K/OPEN
+# 用法: bash scripts/scan-repo-compliance.sh <public-repositories-root>
 # 输出: stdout + 写到 .compliance-scan-YYYYMMDD.log
 
 set -u
-ROOT="${1:-/Users/AI/K/OPEN}"
+ROOT="${1:-}"
+[ -n "$ROOT" ] || { echo "Usage: $0 <public-repositories-root>"; exit 2; }
 LOG=".compliance-scan-$(date -u +%Y%m%d).log"
 cd "$ROOT" || { echo "ERROR: $ROOT not found"; exit 2; }
 

--- a/templates/minimal-domain/README.md
+++ b/templates/minimal-domain/README.md
@@ -35,12 +35,15 @@ This template demonstrates the minimum viable KDNA domain structure. Use it as a
 ### 4. How do I use it?
 
 ```bash
-# Copy this template and customize
+# Copy this expanded project view and customize
 cp -r templates/minimal-domain domains/my-domain
 # Edit the project-view JSON files and kdna.json
 # Add evaluation cases to evals/
-kdna validate .
-kdna pack . ./my-domain.kdna
+
+# Import the expanded project view into Studio, then export one .kdna asset
+kdna-studio create ../my-domain-studio --from-folder . --name @yourscope/my-domain
+kdna-studio export ../my-domain-studio --out ./my-domain.kdna
+
 kdna validate ./my-domain.kdna
 kdna plan-load ./my-domain.kdna
 ```

--- a/templates/standard-domain/README.md
+++ b/templates/standard-domain/README.md
@@ -2,7 +2,7 @@
 
 # [Your domain name]
 
-[![KDNA Spec](https://img.shields.io/badge/KDNA-v1.0-4c1)](https://github.com/aikdna/kdna)
+[![KDNA Spec](https://img.shields.io/badge/KDNA-open_protocol-4c1)](https://github.com/aikdna/kdna)
 
 > This README is for an expanded authoring project view. The public runtime
 > asset is the packaged `.kdna` file exported from this project, not the source
@@ -18,15 +18,17 @@
 
 ```bash
 mkdir -p dist
-kdna pack . ./dist/your-domain.kdna
+kdna-studio create ../your-domain-studio --from-folder . --name @yourscope/your-domain
+kdna-studio export ../your-domain-studio --out ./dist/your-domain.kdna
 kdna validate ./dist/your-domain.kdna
 kdna plan-load ./dist/your-domain.kdna
 kdna load ./dist/your-domain.kdna --profile=compact --as=prompt
 ```
 
-## The Four Questions (v2.1 governance)
+## Optional evidence questions
 
-Every KDNA must answer four questions. Here are this domain's answers.
+These questions can document authorship, scope, evidence, and limitations.
+They do not determine whether the asset may be created or loaded.
 
 ### 1. Where does it come from?
 
@@ -44,10 +46,9 @@ This KDNA helps agents [specific judgment] in:
 
 ### 3. How is it verified?
 
-- `kdna verify @yourscope/your_domain_id --judgment` — checks v2.1 governance fields
-- `kdna compare @yourscope/your_domain_id --input "<task>"` — runs with/without KDNA on a real LLM and shows the reasoning-trajectory diff
-- `evals/` directory contains 10 cases: 3 core + 3 boundary + 3 failure + 1 excluded
-- `demo/` directory holds rendered before/after comparisons. Regenerate with `ANTHROPIC_API_KEY=... node scripts/build-demo.js`
+- `evals/` contains optional author-declared cases: 3 core + 3 boundary + 3 failure + 1 excluded
+- [Describe any evidence or review process you actually performed]
+- Format validity is checked separately with `kdna validate` after Studio export
 
 ### 4. When does it NOT apply?
 
@@ -71,7 +72,7 @@ If any of the above is true, the agent should decline to load this domain.
 
 | File | Purpose |
 |------|---------|
-| `KDNA_Core.json` | Axioms (with v2.1 boundaries), ontology, frameworks, causal structure, stances |
+| `KDNA_Core.json` | Axioms (with optional boundaries), ontology, frameworks, causal structure, stances |
 | `KDNA_Patterns.json` | Terminology, banned terms, misunderstandings (with v2.1 boundaries), self-checks |
 | `evals/` | Test cases for `kdna compare` and quality scoring |
 | `kdna.json` | Domain manifest (name, version, judgment_version, signature) |

--- a/templates/standard-domain/USAGE.md
+++ b/templates/standard-domain/USAGE.md
@@ -42,12 +42,12 @@ kdna identity init
 
 # 5. Fill out evals/ — 10 real cases
 
-# 6. Verify quality
-kdna verify ./.
+# 6. Optionally review and customize the declared cases in evals/
 
-# 7. Export and verify the local v1 asset
+# 7. Import the expanded project view into Studio and export one asset
 mkdir -p dist
-kdna pack . ./dist/your-domain.kdna
+kdna-studio create ../your-domain-studio --from-folder . --name @yourscope/your-domain
+kdna-studio export ../your-domain-studio --out ./dist/your-domain.kdna
 kdna validate ./dist/your-domain.kdna
 kdna plan-load ./dist/your-domain.kdna
 

--- a/tests/cli-v1/v1-authorization-conformance.test.js
+++ b/tests/cli-v1/v1-authorization-conformance.test.js
@@ -11,6 +11,7 @@ const { test } = require('node:test');
 const assert = require('node:assert/strict');
 const { spawnSync } = require('node:child_process');
 const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
 const Ajv = require('ajv/dist/2020.js');
 
@@ -55,6 +56,17 @@ function runCli(args) {
   });
 }
 
+function withPackedFixture(fixturePath, fn) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kdna-auth-conformance-'));
+  const assetPath = path.join(tmp, 'fixture.kdna');
+  try {
+    v1.pack(fixturePath, assetPath);
+    return fn(assetPath);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
 test('authorization conformance: cases index matches schema', () => {
   assert.equal(
     validateCasesSchema(caseIndex),
@@ -67,21 +79,26 @@ for (const testCase of cases) {
   test(`authorization conformance: JS Core matches ${testCase.id}`, () => {
     const fixturePath = path.join(authRoot, 'fixtures', testCase.fixture);
     const golden = JSON.parse(fs.readFileSync(path.join(authRoot, testCase.golden), 'utf8'));
-    const actual = normalizePlan(v1.planLoad(fixturePath, testCase.options), testCase);
-    assertValidLoadPlan(actual);
-    assert.deepEqual(actual, golden);
+    withPackedFixture(fixturePath, (assetPath) => {
+      const actual = normalizePlan(v1.planLoad(assetPath, testCase.options), testCase);
+      assertValidLoadPlan(actual);
+      assert.deepEqual(actual, golden);
+    });
   });
 
   if (Array.isArray(testCase.cli_args)) {
     test(`authorization conformance: CLI matches ${testCase.id}`, () => {
       const fixturePath = path.join(authRoot, 'fixtures', testCase.fixture);
       const golden = JSON.parse(fs.readFileSync(path.join(authRoot, testCase.golden), 'utf8'));
-      const r = runCli(['plan-load', fixturePath, ...testCase.cli_args]);
-      const actual = normalizePlan(JSON.parse(r.stdout), testCase);
-      assertValidLoadPlan(actual);
-      assert.deepEqual(actual, golden);
-      const expectedStatus = golden.state === 'invalid' ? 1 : golden.can_load_now === true ? 0 : 3;
-      assert.equal(r.status, expectedStatus, r.stderr);
+      withPackedFixture(fixturePath, (assetPath) => {
+        const r = runCli(['plan-load', assetPath, ...testCase.cli_args]);
+        const actual = normalizePlan(JSON.parse(r.stdout), testCase);
+        assertValidLoadPlan(actual);
+        assert.deepEqual(actual, golden);
+        const expectedStatus =
+          golden.state === 'invalid' ? 1 : golden.can_load_now === true ? 0 : 3;
+        assert.equal(r.status, expectedStatus, r.stderr);
+      });
     });
   }
 }

--- a/tests/cli-v1/v1-cli-shared.test.js
+++ b/tests/cli-v1/v1-cli-shared.test.js
@@ -552,6 +552,35 @@ test('loadV1: compact profile preserves Human Lock boundary fields', () => {
   }
 });
 
+test('load: compact profile preserves canonical reasoning.self_check entries', () => {
+  const dir = makeTmp('kdna-self-check-projection-');
+  try {
+    copyMinimal(dir);
+    const payloadPath = path.join(dir, 'payload.kdnab');
+    const payload = readPayload(payloadPath);
+    payload.reasoning = {
+      ...(payload.reasoning || {}),
+      self_check: [
+        'Did I preserve the judgment boundary?',
+        { type: 'question', text: 'Did I avoid inventing human provenance?' },
+      ],
+    };
+    fs.writeFileSync(payloadPath, cbor.encode(payload));
+    fs.writeFileSync(
+      path.join(dir, 'checksums.json'),
+      JSON.stringify(v1.buildChecksums(dir), null, 2),
+    );
+
+    const loaded = v1.load(dir, { profile: 'compact', as: 'json' });
+    assert.deepEqual(loaded.context.self_checks, [
+      { type: 'text', text: 'Did I preserve the judgment boundary?' },
+      { type: 'question', text: 'Did I avoid inventing human provenance?' },
+    ]);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('planLoad: unknown access fails closed with a schema-valid plan', () => {
   const dir = makeTmp('kdna-v1-plan-unknown-access-');
   try {

--- a/tests/cli-v1/v1-cli-subprocess.test.js
+++ b/tests/cli-v1/v1-cli-subprocess.test.js
@@ -94,8 +94,10 @@ test('cli: kdna validate --runtime exits 3 when LoadPlan cannot load now', () =>
       path.join(dir, 'checksums.json'),
       JSON.stringify(v1.buildChecksums(dir), null, 2),
     );
+    const assetPath = path.join(dir, 'remote.kdna');
+    v1.pack(dir, assetPath);
 
-    const r = runCli(['validate', dir, '--runtime']);
+    const r = runCli(['validate', assetPath, '--runtime']);
     assert.equal(r.status, 3, `stdout=${r.stdout}\nstderr=${r.stderr}`);
     const out = JSON.parse(r.stdout);
     assert.equal(out.overall_valid, true);
@@ -108,8 +110,19 @@ test('cli: kdna validate --runtime exits 3 when LoadPlan cannot load now', () =>
   }
 });
 
-test('cli: kdna plan-load examples/minimal returns a ready LoadPlan', () => {
+test('cli: kdna plan-load rejects an authoring source directory', () => {
   const r = runCli(['plan-load', exampleMinimal]);
+  assert.equal(r.status, 1, `stdout=${r.stdout}\nstderr=${r.stderr}`);
+  const out = JSON.parse(r.stdout);
+  assert.equal(out.state, 'invalid');
+  assert.equal(out.can_load_now, false);
+  assert.equal(out.issues[0].code, 'KDNA_ASSET_FILE_REQUIRED');
+});
+
+test('cli: kdna plan-load accepts a packaged .kdna asset', () => {
+  const assetPath = tmpFile('minimal.kdna');
+  v1.pack(exampleMinimal, assetPath);
+  const r = runCli(['plan-load', assetPath]);
   assert.equal(r.status, 0, `stdout=${r.stdout}\nstderr=${r.stderr}`);
   const out = JSON.parse(r.stdout);
   assert.equal(out.access, 'public');
@@ -135,8 +148,10 @@ test('cli: kdna plan-load returns 3 when the plan is valid but cannot load now',
       path.join(dir, 'checksums.json'),
       JSON.stringify(v1.buildChecksums(dir), null, 2),
     );
+    const assetPath = path.join(dir, 'remote.kdna');
+    v1.pack(dir, assetPath);
 
-    const r = runCli(['plan-load', dir]);
+    const r = runCli(['plan-load', assetPath]);
     assert.equal(r.status, 3, `stdout=${r.stdout}\nstderr=${r.stderr}`);
     const out = JSON.parse(r.stdout);
     assert.equal(out.state, 'needs_runtime');

--- a/tests/cli-v1/v1-fixture-matrix.test.js
+++ b/tests/cli-v1/v1-fixture-matrix.test.js
@@ -3,14 +3,14 @@
  *
  * Covers: source dir, container, load profiles, invalid cases, content-neutrality.
  */
-const { test } = require('node:test');
+const { after, test } = require('node:test');
 const assert = require('node:assert/strict');
 const { spawnSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
 const crypto = require('node:crypto');
 const cbor = require('cbor-x');
-const { buildChecksums } = require('../../packages/kdna-core/src/v1');
+const { buildChecksums, pack } = require('../../packages/kdna-core/src/v1');
 
 function readPayload(p) {
   const buf = fs.readFileSync(p);
@@ -19,6 +19,10 @@ function readPayload(p) {
 
 const cliBin = path.join(__dirname, '..', '..', 'packages', 'kdna', 'bin', 'kdna.js');
 const minimalSource = path.join(__dirname, '..', '..', 'examples', 'minimal');
+const runtimeTmp = fs.mkdtempSync(path.join(require('node:os').tmpdir(), 'kdna-fixture-runtime-'));
+const minimalAsset = path.join(runtimeTmp, 'minimal.kdna');
+pack(minimalSource, minimalAsset);
+after(() => fs.rmSync(runtimeTmp, { recursive: true, force: true }));
 const fixturesDir = path.join(__dirname, '..', '..', 'fixtures', 'v1');
 const FORBIDDEN = [
   'trusted',
@@ -125,7 +129,7 @@ test('unpack + revalidate', () => {
 // ── Positive: load profiles ───────────────────────────────────────
 
 test('load index profile as json', () => {
-  const r = run(['load', minimalSource, '--profile=index', '--as=json']);
+  const r = run(['load', minimalAsset, '--profile=index', '--as=json']);
   assert.equal(r.status, 0, r.stderr);
   const out = JSON.parse(r.stdout);
   assert.equal(out.profile, 'index');
@@ -134,7 +138,7 @@ test('load index profile as json', () => {
 });
 
 test('load compact profile as json', () => {
-  const r = run(['load', minimalSource, '--profile=compact', '--as=json']);
+  const r = run(['load', minimalAsset, '--profile=compact', '--as=json']);
   assert.equal(r.status, 0, r.stderr);
   const out = JSON.parse(r.stdout);
   assert.equal(out.profile, 'compact');
@@ -143,7 +147,7 @@ test('load compact profile as json', () => {
 });
 
 test('load compact profile as prompt is content-neutral', () => {
-  const r = run(['load', minimalSource, '--profile=compact', '--as=prompt']);
+  const r = run(['load', minimalAsset, '--profile=compact', '--as=prompt']);
   assert.equal(r.status, 0, r.stderr);
   assert.ok(r.stdout.includes('KDNA Judgment Asset'));
   assert.ok(
@@ -191,7 +195,9 @@ test('load compact profile as prompt renders object patterns readably', () => {
     ];
     fs.writeFileSync(path.join(tmp, 'payload.kdnab'), cbor.encode(payload));
 
-    const r = run(['load', tmp, '--profile=compact', '--as=prompt']);
+    const assetPath = path.join(tmp, 'patterns.kdna');
+    pack(tmp, assetPath);
+    const r = run(['load', assetPath, '--profile=compact', '--as=prompt']);
     assert.equal(r.status, 0, r.stderr);
     assert.ok(!r.stdout.includes('[object Object]'));
     assert.ok(r.stdout.includes('Structure first, wording second.'));
@@ -208,7 +214,7 @@ test('load compact profile as prompt renders object patterns readably', () => {
 });
 
 test('load scenario profile falls back to compact', () => {
-  const r = run(['load', minimalSource, '--profile=scenario', '--as=json']);
+  const r = run(['load', minimalAsset, '--profile=scenario', '--as=json']);
   assert.equal(r.status, 0, r.stderr);
   const out = JSON.parse(r.stdout);
   assert.equal(out.profile, 'scenario');
@@ -217,7 +223,7 @@ test('load scenario profile falls back to compact', () => {
 });
 
 test('load full profile as json', () => {
-  const r = run(['load', minimalSource, '--profile=full', '--as=json']);
+  const r = run(['load', minimalAsset, '--profile=full', '--as=json']);
   assert.equal(r.status, 0, r.stderr);
   const out = JSON.parse(r.stdout);
   assert.equal(out.profile, 'full');
@@ -301,7 +307,7 @@ test('load: missing payload gives clear error', () => {
 
 for (const profile of ['index', 'compact', 'scenario', 'full']) {
   test(`load ${profile} profile: no forbidden terms in json output`, () => {
-    const r = run(['load', minimalSource, `--profile=${profile}`, '--as=json']);
+    const r = run(['load', minimalAsset, `--profile=${profile}`, '--as=json']);
     assert.equal(r.status, 0, r.stderr);
     const merged = r.stdout + r.stderr;
     for (const t of FORBIDDEN) {
@@ -313,7 +319,7 @@ for (const profile of ['index', 'compact', 'scenario', 'full']) {
 // ── Unknown profile ────────────────────────────────────────────────
 
 test('load: unknown profile gives clear error', () => {
-  const r = run(['load', minimalSource, '--profile=nonexistent', '--as=json']);
+  const r = run(['load', minimalAsset, '--profile=nonexistent', '--as=json']);
   assert.notEqual(r.status, 0);
   assert.match(r.stderr || r.stdout, /unknown/i);
 });


### PR DESCRIPTION
Summary
- Reject authoring directories at public plan/load/runtime entry points.
- Preserve source directories only for authoring and packaging.
- Regenerate authorization conformance from packaged assets.
- Remove stale format-generation wording and public internal-path references.
- Make release readiness require a clean tree and a version tag at HEAD.

Validation
- npm test
- canonical 15/15
- ecosystem 18/18
- authorization 29/29 inside the CLI conformance suite
- AEAD PASS
- lint, format, docs, public-surface and pack checks pass

Release note
- Package versions are intentionally unchanged.
- The release check blocks reuse of the existing version tag; release engineering must choose the next versions and order.