### PR TITLE
RFC-0019: add account/device external key grants

### DIFF
--- a/conformance/kdna-external-grant-v1/README.md
+++ b/conformance/kdna-external-grant-v1/README.md
@@ -1,0 +1,11 @@
+# Account/device external grant fixtures
+
+`golden.json` is a deterministic RFC-0019 vector. Every secret and private key
+inside it is public, test-only material and MUST NOT be reused outside tests.
+
+`negative/` covers signature tampering, revocation, asset version and digest
+mismatch, and device mismatch. Regenerate the vectors with:
+
+```sh
+node scripts/generate-external-grant-fixtures.js
+```

--- a/conformance/kdna-external-grant-v1/golden.json
+++ b/conformance/kdna-external-grant-v1/golden.json
@@ -1,0 +1,111 @@
+{
+  "note": "All key material in this fixture is deterministic and test-only.",
+  "manifest": {
+    "kdna_version": "1.0",
+    "asset_id": "kdna:fixture:external-grant",
+    "asset_uid": "urn:uuid:00190000-0000-4000-8000-000000000001",
+    "name": "@fixture/external-grant",
+    "asset_type": "fixture",
+    "title": "External Grant Fixture",
+    "version": "1.0.0",
+    "judgment_version": "1.0.0",
+    "created_at": "2026-07-13T00:00:00Z",
+    "updated_at": "2026-07-13T00:00:00Z",
+    "creator": {
+      "name": "KDNA Conformance"
+    },
+    "compatibility": {
+      "min_loader_version": "0.16.0",
+      "profile": "judgment-profile-v1"
+    },
+    "payload": {
+      "path": "payload.kdnab",
+      "encoding": "cbor",
+      "encrypted": true
+    },
+    "access": "licensed",
+    "entitlement": {
+      "profile": "account",
+      "offline": true,
+      "revocable": true
+    },
+    "encryption": {
+      "profile": "kdna-envelope-external-grant-v1",
+      "encrypted_entries": [
+        "payload.kdnab"
+      ],
+      "key_grant_profile": "kdna-key-grant-v1"
+    }
+  },
+  "plaintext_cbor": "uQACZ3Byb2ZpbGVzanVkZ21lbnQtcHJvZmlsZS12MWRjb3JluQACcGhpZ2hlc3RfcXVlc3Rpb254GENhbiB0aGlzIGRldmljZSBkZWNyeXB0P2ZheGlvbXOA",
+  "envelope": {
+    "profile": "kdna-envelope-external-grant-v1",
+    "alg": "A256GCM",
+    "cek_derivation": "HKDF-SHA256",
+    "key_ref": "assetkey:fixture:external-grant:1.0.0",
+    "issuer_key_id": "fixture-asset-root-v1",
+    "entry_path": "payload.kdnab",
+    "plaintext_digest": "sha256:fd83e17a49666ba3cf45f5eefbc91ef6a42f37e2ab0ba0969b8612254ea8fae2",
+    "iv": "JSUlJSUlJSUlJSUl",
+    "tag": "xxrUu4coOvc1OTQxZ12vWw",
+    "ciphertext": "iJbVjliBSYchQEu4L8YLhfZ866kpJVLFeeuFVgAGpSHuAB6qCYepU6b-BTET020QQh7kk6d_tQx2wJyNT7uqx6-F_ciyYaf7GeZoB5ei-llobSCNW7r4Bzx_"
+  },
+  "envelope_cbor": "uQAKZ3Byb2ZpbGV4H2tkbmEtZW52ZWxvcGUtZXh0ZXJuYWwtZ3JhbnQtdjFjYWxnZ0EyNTZHQ01uY2VrX2Rlcml2YXRpb25rSEtERi1TSEEyNTZna2V5X3JlZnglYXNzZXRrZXk6Zml4dHVyZTpleHRlcm5hbC1ncmFudDoxLjAuMG1pc3N1ZXJfa2V5X2lkdWZpeHR1cmUtYXNzZXQtcm9vdC12MWplbnRyeV9wYXRobXBheWxvYWQua2RuYWJwcGxhaW50ZXh0X2RpZ2VzdHhHc2hhMjU2OmZkODNlMTdhNDk2NjZiYTNjZjQ1ZjVlZWZiYzkxZWY2YTQyZjM3ZTJhYjBiYTA5NjliODYxMjI1NGVhOGZhZTJiaXZwSlNVbEpTVWxKU1VsSlNVbGN0YWd2eHhyVXU0Y29PdmMxT1RReFoxMnZXd2pjaXBoZXJ0ZXh0eHhpSmJWamxpQlNZY2hRRXU0TDhZTGhmWjg2NmtwSlZMRmVldUZWZ0FHcFNIdUFCNnFDWWVwVTZiLUJURVQwMjBRUWg3a2s2ZF90UXgyd0p5TlQ3dXF4Ni1GX2NpeVlhZjdHZVpvQjVlaS1sbG9iU0NOVzdyNEJ6eF8",
+  "checksums": {
+    "algorithm": "sha256",
+    "manifest_digest": "sha256:dadfa5b27f6bacc3c0348310266521ea59517a17e9edce8f92ad4fc3a5b60b89",
+    "payload_digest": "sha256:5f40f76a2d50c597dc95c6e9d2a41242a174c03a518c84415fd03a8e8821fe47",
+    "asset_digest": "sha256:81d53d4d7fd33ee7b9a33771f179a0dedaf32da4cebf3a279b0109cfe0abe608",
+    "entries": {
+      "kdna.json": {
+        "algorithm": "sha256",
+        "value": "dadfa5b27f6bacc3c0348310266521ea59517a17e9edce8f92ad4fc3a5b60b89"
+      },
+      "payload.kdnab": {
+        "algorithm": "sha256",
+        "value": "5f40f76a2d50c597dc95c6e9d2a41242a174c03a518c84415fd03a8e8821fe47"
+      }
+    }
+  },
+  "grant": {
+    "profile": "kdna-key-grant-v1",
+    "grant_id": "grt_fixture_01",
+    "issuer": "https://fixture.invalid",
+    "signing_key_id": "fixture-grant-signing-v1",
+    "entitlement_id": "ent_fixture_01",
+    "account_id": "acct_fixture_01",
+    "device_id": "dev_fixture_01",
+    "device_public_key": "x25519:fTSkgV-muYJTXmCvO9m0lVaBYIDxZB_4HSt8iugmikQ",
+    "device_signing_public_key": "ed25519:oJql9HpnWYAv-VX43C0qFKXJnSO-l_hkEn_5ODRVpPA",
+    "asset": {
+      "asset_id": "kdna:fixture:external-grant",
+      "asset_uid": "urn:uuid:00190000-0000-4000-8000-000000000001",
+      "version": "1.0.0",
+      "digest": "sha256:81d53d4d7fd33ee7b9a33771f179a0dedaf32da4cebf3a279b0109cfe0abe608",
+      "entry_path": "payload.kdnab",
+      "ciphertext_digest": "sha256:1aceead89e2b3af5c46710050bc1dd4bd3ee359038ff631539c6e28752b45b66",
+      "key_ref": "assetkey:fixture:external-grant:1.0.0",
+      "issuer_key_id": "fixture-asset-root-v1"
+    },
+    "issued_at": "2026-07-13T00:00:00.000Z",
+    "refresh_after": "2026-07-14T00:00:00.000Z",
+    "offline_grace_until": "2026-07-20T00:00:00.000Z",
+    "expires_at": "2026-07-21T00:00:00.000Z",
+    "status": "active",
+    "status_version": 1,
+    "wrap": {
+      "alg": "X25519-HKDF-SHA256+A256KW",
+      "ephemeral_public_key": "x25519:mkUDqYqxD-jTVMnELL0MnXlE9S59FNjqWXdefcnjv0s",
+      "salt": "JiYmJiYmJiYmJiYmJiYmJg",
+      "wrapped_cek": "ZhFBMG5YCAtMkTUA6bDzxiLtvviN-1iffaHlLL1MY5RGqvYI20F6Bw"
+    },
+    "signature": "ed25519:tA1HLRl2NqPzwN0j5Mv2Op-sLiyVtAJMz4TJbqHwFOZ6mrfRzk8e7SwD71iRpioA-Cbzn84PPi-GLpV9n9drCA"
+  },
+  "test_keys": {
+    "issuer_root": "GRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRk",
+    "issuer_signing_public_key": "ed25519:WJNmBKvaESvJSTNWnIL40MwN35Kj-DKfL0SPf0hKWUw",
+    "device_agreement_public_key": "x25519:fTSkgV-muYJTXmCvO9m0lVaBYIDxZB_4HSt8iugmikQ",
+    "device_agreement_private_key": "x25519:ISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISE",
+    "device_signing_public_key": "ed25519:oJql9HpnWYAv-VX43C0qFKXJnSO-l_hkEn_5ODRVpPA"
+  }
+}

--- a/conformance/kdna-external-grant-v1/golden.json
+++ b/conformance/kdna-external-grant-v1/golden.json
@@ -31,9 +31,7 @@
     },
     "encryption": {
       "profile": "kdna-envelope-external-grant-v1",
-      "encrypted_entries": [
-        "payload.kdnab"
-      ],
+      "encrypted_entries": ["payload.kdnab"],
       "key_grant_profile": "kdna-key-grant-v1"
     }
   },

--- a/conformance/kdna-external-grant-v1/negative/asset-digest-mismatch.json
+++ b/conformance/kdna-external-grant-v1/negative/asset-digest-mismatch.json
@@ -1,0 +1,53 @@
+{
+  "expected_error": "KDNA_GRANT_DIGEST_MISMATCH",
+  "checksums": {
+    "algorithm": "sha256",
+    "manifest_digest": "sha256:dadfa5b27f6bacc3c0348310266521ea59517a17e9edce8f92ad4fc3a5b60b89",
+    "payload_digest": "sha256:5f40f76a2d50c597dc95c6e9d2a41242a174c03a518c84415fd03a8e8821fe47",
+    "asset_digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+    "entries": {
+      "kdna.json": {
+        "algorithm": "sha256",
+        "value": "dadfa5b27f6bacc3c0348310266521ea59517a17e9edce8f92ad4fc3a5b60b89"
+      },
+      "payload.kdnab": {
+        "algorithm": "sha256",
+        "value": "5f40f76a2d50c597dc95c6e9d2a41242a174c03a518c84415fd03a8e8821fe47"
+      }
+    }
+  },
+  "grant": {
+    "profile": "kdna-key-grant-v1",
+    "grant_id": "grt_fixture_01",
+    "issuer": "https://fixture.invalid",
+    "signing_key_id": "fixture-grant-signing-v1",
+    "entitlement_id": "ent_fixture_01",
+    "account_id": "acct_fixture_01",
+    "device_id": "dev_fixture_01",
+    "device_public_key": "x25519:fTSkgV-muYJTXmCvO9m0lVaBYIDxZB_4HSt8iugmikQ",
+    "device_signing_public_key": "ed25519:oJql9HpnWYAv-VX43C0qFKXJnSO-l_hkEn_5ODRVpPA",
+    "asset": {
+      "asset_id": "kdna:fixture:external-grant",
+      "asset_uid": "urn:uuid:00190000-0000-4000-8000-000000000001",
+      "version": "1.0.0",
+      "digest": "sha256:81d53d4d7fd33ee7b9a33771f179a0dedaf32da4cebf3a279b0109cfe0abe608",
+      "entry_path": "payload.kdnab",
+      "ciphertext_digest": "sha256:1aceead89e2b3af5c46710050bc1dd4bd3ee359038ff631539c6e28752b45b66",
+      "key_ref": "assetkey:fixture:external-grant:1.0.0",
+      "issuer_key_id": "fixture-asset-root-v1"
+    },
+    "issued_at": "2026-07-13T00:00:00.000Z",
+    "refresh_after": "2026-07-14T00:00:00.000Z",
+    "offline_grace_until": "2026-07-20T00:00:00.000Z",
+    "expires_at": "2026-07-21T00:00:00.000Z",
+    "status": "active",
+    "status_version": 1,
+    "wrap": {
+      "alg": "X25519-HKDF-SHA256+A256KW",
+      "ephemeral_public_key": "x25519:mkUDqYqxD-jTVMnELL0MnXlE9S59FNjqWXdefcnjv0s",
+      "salt": "JiYmJiYmJiYmJiYmJiYmJg",
+      "wrapped_cek": "ZhFBMG5YCAtMkTUA6bDzxiLtvviN-1iffaHlLL1MY5RGqvYI20F6Bw"
+    },
+    "signature": "ed25519:tA1HLRl2NqPzwN0j5Mv2Op-sLiyVtAJMz4TJbqHwFOZ6mrfRzk8e7SwD71iRpioA-Cbzn84PPi-GLpV9n9drCA"
+  }
+}

--- a/conformance/kdna-external-grant-v1/negative/asset-version-mismatch.json
+++ b/conformance/kdna-external-grant-v1/negative/asset-version-mismatch.json
@@ -1,0 +1,74 @@
+{
+  "expected_error": "KDNA_GRANT_ASSET_MISMATCH",
+  "manifest": {
+    "kdna_version": "1.0",
+    "asset_id": "kdna:fixture:external-grant",
+    "asset_uid": "urn:uuid:00190000-0000-4000-8000-000000000001",
+    "name": "@fixture/external-grant",
+    "asset_type": "fixture",
+    "title": "External Grant Fixture",
+    "version": "1.0.1",
+    "judgment_version": "1.0.0",
+    "created_at": "2026-07-13T00:00:00Z",
+    "updated_at": "2026-07-13T00:00:00Z",
+    "creator": {
+      "name": "KDNA Conformance"
+    },
+    "compatibility": {
+      "min_loader_version": "0.16.0",
+      "profile": "judgment-profile-v1"
+    },
+    "payload": {
+      "path": "payload.kdnab",
+      "encoding": "cbor",
+      "encrypted": true
+    },
+    "access": "licensed",
+    "entitlement": {
+      "profile": "account",
+      "offline": true,
+      "revocable": true
+    },
+    "encryption": {
+      "profile": "kdna-envelope-external-grant-v1",
+      "encrypted_entries": [
+        "payload.kdnab"
+      ],
+      "key_grant_profile": "kdna-key-grant-v1"
+    }
+  },
+  "grant": {
+    "profile": "kdna-key-grant-v1",
+    "grant_id": "grt_fixture_01",
+    "issuer": "https://fixture.invalid",
+    "signing_key_id": "fixture-grant-signing-v1",
+    "entitlement_id": "ent_fixture_01",
+    "account_id": "acct_fixture_01",
+    "device_id": "dev_fixture_01",
+    "device_public_key": "x25519:fTSkgV-muYJTXmCvO9m0lVaBYIDxZB_4HSt8iugmikQ",
+    "device_signing_public_key": "ed25519:oJql9HpnWYAv-VX43C0qFKXJnSO-l_hkEn_5ODRVpPA",
+    "asset": {
+      "asset_id": "kdna:fixture:external-grant",
+      "asset_uid": "urn:uuid:00190000-0000-4000-8000-000000000001",
+      "version": "1.0.0",
+      "digest": "sha256:81d53d4d7fd33ee7b9a33771f179a0dedaf32da4cebf3a279b0109cfe0abe608",
+      "entry_path": "payload.kdnab",
+      "ciphertext_digest": "sha256:1aceead89e2b3af5c46710050bc1dd4bd3ee359038ff631539c6e28752b45b66",
+      "key_ref": "assetkey:fixture:external-grant:1.0.0",
+      "issuer_key_id": "fixture-asset-root-v1"
+    },
+    "issued_at": "2026-07-13T00:00:00.000Z",
+    "refresh_after": "2026-07-14T00:00:00.000Z",
+    "offline_grace_until": "2026-07-20T00:00:00.000Z",
+    "expires_at": "2026-07-21T00:00:00.000Z",
+    "status": "active",
+    "status_version": 1,
+    "wrap": {
+      "alg": "X25519-HKDF-SHA256+A256KW",
+      "ephemeral_public_key": "x25519:mkUDqYqxD-jTVMnELL0MnXlE9S59FNjqWXdefcnjv0s",
+      "salt": "JiYmJiYmJiYmJiYmJiYmJg",
+      "wrapped_cek": "ZhFBMG5YCAtMkTUA6bDzxiLtvviN-1iffaHlLL1MY5RGqvYI20F6Bw"
+    },
+    "signature": "ed25519:tA1HLRl2NqPzwN0j5Mv2Op-sLiyVtAJMz4TJbqHwFOZ6mrfRzk8e7SwD71iRpioA-Cbzn84PPi-GLpV9n9drCA"
+  }
+}

--- a/conformance/kdna-external-grant-v1/negative/asset-version-mismatch.json
+++ b/conformance/kdna-external-grant-v1/negative/asset-version-mismatch.json
@@ -31,9 +31,7 @@
     },
     "encryption": {
       "profile": "kdna-envelope-external-grant-v1",
-      "encrypted_entries": [
-        "payload.kdnab"
-      ],
+      "encrypted_entries": ["payload.kdnab"],
       "key_grant_profile": "kdna-key-grant-v1"
     }
   },

--- a/conformance/kdna-external-grant-v1/negative/device-mismatch.json
+++ b/conformance/kdna-external-grant-v1/negative/device-mismatch.json
@@ -1,0 +1,38 @@
+{
+  "expected_error": "KDNA_GRANT_DEVICE_MISMATCH",
+  "expected_device_id": "dev_other",
+  "grant": {
+    "profile": "kdna-key-grant-v1",
+    "grant_id": "grt_fixture_01",
+    "issuer": "https://fixture.invalid",
+    "signing_key_id": "fixture-grant-signing-v1",
+    "entitlement_id": "ent_fixture_01",
+    "account_id": "acct_fixture_01",
+    "device_id": "dev_fixture_01",
+    "device_public_key": "x25519:fTSkgV-muYJTXmCvO9m0lVaBYIDxZB_4HSt8iugmikQ",
+    "device_signing_public_key": "ed25519:oJql9HpnWYAv-VX43C0qFKXJnSO-l_hkEn_5ODRVpPA",
+    "asset": {
+      "asset_id": "kdna:fixture:external-grant",
+      "asset_uid": "urn:uuid:00190000-0000-4000-8000-000000000001",
+      "version": "1.0.0",
+      "digest": "sha256:81d53d4d7fd33ee7b9a33771f179a0dedaf32da4cebf3a279b0109cfe0abe608",
+      "entry_path": "payload.kdnab",
+      "ciphertext_digest": "sha256:1aceead89e2b3af5c46710050bc1dd4bd3ee359038ff631539c6e28752b45b66",
+      "key_ref": "assetkey:fixture:external-grant:1.0.0",
+      "issuer_key_id": "fixture-asset-root-v1"
+    },
+    "issued_at": "2026-07-13T00:00:00.000Z",
+    "refresh_after": "2026-07-14T00:00:00.000Z",
+    "offline_grace_until": "2026-07-20T00:00:00.000Z",
+    "expires_at": "2026-07-21T00:00:00.000Z",
+    "status": "active",
+    "status_version": 1,
+    "wrap": {
+      "alg": "X25519-HKDF-SHA256+A256KW",
+      "ephemeral_public_key": "x25519:mkUDqYqxD-jTVMnELL0MnXlE9S59FNjqWXdefcnjv0s",
+      "salt": "JiYmJiYmJiYmJiYmJiYmJg",
+      "wrapped_cek": "ZhFBMG5YCAtMkTUA6bDzxiLtvviN-1iffaHlLL1MY5RGqvYI20F6Bw"
+    },
+    "signature": "ed25519:tA1HLRl2NqPzwN0j5Mv2Op-sLiyVtAJMz4TJbqHwFOZ6mrfRzk8e7SwD71iRpioA-Cbzn84PPi-GLpV9n9drCA"
+  }
+}

--- a/conformance/kdna-external-grant-v1/negative/revoked.json
+++ b/conformance/kdna-external-grant-v1/negative/revoked.json
@@ -1,0 +1,37 @@
+{
+  "expected_error": "KDNA_GRANT_REVOKED",
+  "grant": {
+    "profile": "kdna-key-grant-v1",
+    "grant_id": "grt_fixture_revoked",
+    "issuer": "https://fixture.invalid",
+    "signing_key_id": "fixture-grant-signing-v1",
+    "entitlement_id": "ent_fixture_01",
+    "account_id": "acct_fixture_01",
+    "device_id": "dev_fixture_01",
+    "device_public_key": "x25519:fTSkgV-muYJTXmCvO9m0lVaBYIDxZB_4HSt8iugmikQ",
+    "device_signing_public_key": "ed25519:oJql9HpnWYAv-VX43C0qFKXJnSO-l_hkEn_5ODRVpPA",
+    "asset": {
+      "asset_id": "kdna:fixture:external-grant",
+      "asset_uid": "urn:uuid:00190000-0000-4000-8000-000000000001",
+      "version": "1.0.0",
+      "digest": "sha256:81d53d4d7fd33ee7b9a33771f179a0dedaf32da4cebf3a279b0109cfe0abe608",
+      "entry_path": "payload.kdnab",
+      "ciphertext_digest": "sha256:1aceead89e2b3af5c46710050bc1dd4bd3ee359038ff631539c6e28752b45b66",
+      "key_ref": "assetkey:fixture:external-grant:1.0.0",
+      "issuer_key_id": "fixture-asset-root-v1"
+    },
+    "issued_at": "2026-07-13T00:00:00.000Z",
+    "refresh_after": "2026-07-14T00:00:00.000Z",
+    "offline_grace_until": "2026-07-20T00:00:00.000Z",
+    "expires_at": "2026-07-21T00:00:00.000Z",
+    "status": "revoked",
+    "status_version": 1,
+    "wrap": {
+      "alg": "X25519-HKDF-SHA256+A256KW",
+      "ephemeral_public_key": "x25519:mkUDqYqxD-jTVMnELL0MnXlE9S59FNjqWXdefcnjv0s",
+      "salt": "JycnJycnJycnJycnJycnJw",
+      "wrapped_cek": "ao8NDVAdOTK7LSKsreI7sb-0_wsXmSwM_QZ5Nhi9_CvXdLge4jiU4Q"
+    },
+    "signature": "ed25519:-PCJQsewKjCF-32DQKGjgFdILhkzucTepmApK3TIVAXpD-31pPdl2yCbcGogB1MQ2yJ20mAYSAPlT3cDGbOgCQ"
+  }
+}

--- a/conformance/kdna-external-grant-v1/negative/tampered-signature.json
+++ b/conformance/kdna-external-grant-v1/negative/tampered-signature.json
@@ -1,0 +1,37 @@
+{
+  "expected_error": "KDNA_GRANT_SIGNATURE_INVALID",
+  "grant": {
+    "profile": "kdna-key-grant-v1",
+    "grant_id": "grt_fixture_01",
+    "issuer": "https://fixture.invalid",
+    "signing_key_id": "fixture-grant-signing-v1",
+    "entitlement_id": "ent_fixture_01",
+    "account_id": "acct_tampered",
+    "device_id": "dev_fixture_01",
+    "device_public_key": "x25519:fTSkgV-muYJTXmCvO9m0lVaBYIDxZB_4HSt8iugmikQ",
+    "device_signing_public_key": "ed25519:oJql9HpnWYAv-VX43C0qFKXJnSO-l_hkEn_5ODRVpPA",
+    "asset": {
+      "asset_id": "kdna:fixture:external-grant",
+      "asset_uid": "urn:uuid:00190000-0000-4000-8000-000000000001",
+      "version": "1.0.0",
+      "digest": "sha256:81d53d4d7fd33ee7b9a33771f179a0dedaf32da4cebf3a279b0109cfe0abe608",
+      "entry_path": "payload.kdnab",
+      "ciphertext_digest": "sha256:1aceead89e2b3af5c46710050bc1dd4bd3ee359038ff631539c6e28752b45b66",
+      "key_ref": "assetkey:fixture:external-grant:1.0.0",
+      "issuer_key_id": "fixture-asset-root-v1"
+    },
+    "issued_at": "2026-07-13T00:00:00.000Z",
+    "refresh_after": "2026-07-14T00:00:00.000Z",
+    "offline_grace_until": "2026-07-20T00:00:00.000Z",
+    "expires_at": "2026-07-21T00:00:00.000Z",
+    "status": "active",
+    "status_version": 1,
+    "wrap": {
+      "alg": "X25519-HKDF-SHA256+A256KW",
+      "ephemeral_public_key": "x25519:mkUDqYqxD-jTVMnELL0MnXlE9S59FNjqWXdefcnjv0s",
+      "salt": "JiYmJiYmJiYmJiYmJiYmJg",
+      "wrapped_cek": "ZhFBMG5YCAtMkTUA6bDzxiLtvviN-1iffaHlLL1MY5RGqvYI20F6Bw"
+    },
+    "signature": "ed25519:tA1HLRl2NqPzwN0j5Mv2Op-sLiyVtAJMz4TJbqHwFOZ6mrfRzk8e7SwD71iRpioA-Cbzn84PPi-GLpV9n9drCA"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,33 +51,6 @@
         "cbor-x": "^1.6.4"
       }
     },
-    "node_modules/@aikdna/kdna-cli/node_modules/@aikdna/kdna-core": {
-      "version": "0.15.12",
-      "resolved": "https://registry.npmjs.org/@aikdna/kdna-core/-/kdna-core-0.15.12.tgz",
-      "integrity": "sha512-5P5ccscpJmg4Ih1IjIDpfQ34rGdOMEOf57l2SNeUblN6hcrtNJFhCo/+0gjNxZ2YezccYqBpcRTHHVVgGY17lQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/hashes": "^1.8.0",
-        "ajv": "^8.20.0",
-        "ajv-formats": "^3.0.1",
-        "cbor-x": "^1.6.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        },
-        "ajv-formats": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@aikdna/kdna-core": {
       "resolved": "packages/kdna-core",
       "link": true
@@ -1854,33 +1827,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "packages/kdna/node_modules/@aikdna/kdna-core": {
-      "version": "0.15.12",
-      "resolved": "https://registry.npmjs.org/@aikdna/kdna-core/-/kdna-core-0.15.12.tgz",
-      "integrity": "sha512-5P5ccscpJmg4Ih1IjIDpfQ34rGdOMEOf57l2SNeUblN6hcrtNJFhCo/+0gjNxZ2YezccYqBpcRTHHVVgGY17lQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/hashes": "^1.8.0",
-        "ajv": "^8.20.0",
-        "ajv-formats": "^3.0.1",
-        "cbor-x": "^1.6.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        },
-        "ajv-formats": {
-          "optional": true
-        }
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,33 @@
         "cbor-x": "^1.6.4"
       }
     },
+    "node_modules/@aikdna/kdna-cli/node_modules/@aikdna/kdna-core": {
+      "version": "0.15.12",
+      "resolved": "https://registry.npmjs.org/@aikdna/kdna-core/-/kdna-core-0.15.12.tgz",
+      "integrity": "sha512-5P5ccscpJmg4Ih1IjIDpfQ34rGdOMEOf57l2SNeUblN6hcrtNJFhCo/+0gjNxZ2YezccYqBpcRTHHVVgGY17lQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/hashes": "^1.8.0",
+        "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1",
+        "cbor-x": "^1.6.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        },
+        "ajv-formats": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@aikdna/kdna-core": {
       "resolved": "packages/kdna-core",
       "link": true
@@ -1783,7 +1810,7 @@
     },
     "packages/kdna-core": {
       "name": "@aikdna/kdna-core",
-      "version": "0.15.12",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.8.0",
@@ -1827,6 +1854,33 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "packages/kdna/node_modules/@aikdna/kdna-core": {
+      "version": "0.15.12",
+      "resolved": "https://registry.npmjs.org/@aikdna/kdna-core/-/kdna-core-0.15.12.tgz",
+      "integrity": "sha512-5P5ccscpJmg4Ih1IjIDpfQ34rGdOMEOf57l2SNeUblN6hcrtNJFhCo/+0gjNxZ2YezccYqBpcRTHHVVgGY17lQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/hashes": "^1.8.0",
+        "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1",
+        "cbor-x": "^1.6.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        },
+        "ajv-formats": {
+          "optional": true
+        }
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,33 @@
         "cbor-x": "^1.6.4"
       }
     },
+    "node_modules/@aikdna/kdna-cli/node_modules/@aikdna/kdna-core": {
+      "version": "0.15.12",
+      "resolved": "https://registry.npmjs.org/@aikdna/kdna-core/-/kdna-core-0.15.12.tgz",
+      "integrity": "sha512-5P5ccscpJmg4Ih1IjIDpfQ34rGdOMEOf57l2SNeUblN6hcrtNJFhCo/+0gjNxZ2YezccYqBpcRTHHVVgGY17lQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/hashes": "^1.8.0",
+        "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1",
+        "cbor-x": "^1.6.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        },
+        "ajv-formats": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@aikdna/kdna-core": {
       "resolved": "packages/kdna-core",
       "link": true
@@ -1827,6 +1854,33 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "packages/kdna/node_modules/@aikdna/kdna-core": {
+      "version": "0.15.12",
+      "resolved": "https://registry.npmjs.org/@aikdna/kdna-core/-/kdna-core-0.15.12.tgz",
+      "integrity": "sha512-5P5ccscpJmg4Ih1IjIDpfQ34rGdOMEOf57l2SNeUblN6hcrtNJFhCo/+0gjNxZ2YezccYqBpcRTHHVVgGY17lQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/hashes": "^1.8.0",
+        "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1",
+        "cbor-x": "^1.6.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        },
+        "ajv-formats": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -69,12 +69,6 @@
     "prettier": "^3.9.4"
   },
   "overrides": {
-    "@aikdna/kdna-cli": {
-      "@aikdna/kdna-core": "0.16.0"
-    },
-    "@aikdna/kdna": {
-      "@aikdna/kdna-core": "0.16.0"
-    },
     "esbuild": "0.28.1",
     "js-yaml": "4.2.0"
   }

--- a/package.json
+++ b/package.json
@@ -69,6 +69,12 @@
     "prettier": "^3.9.4"
   },
   "overrides": {
+    "@aikdna/kdna-cli": {
+      "@aikdna/kdna-core": "0.16.0"
+    },
+    "@aikdna/kdna": {
+      "@aikdna/kdna-core": "0.16.0"
+    },
     "esbuild": "0.28.1",
     "js-yaml": "4.2.0"
   }

--- a/packages/kdna-core/CHANGELOG.md
+++ b/packages/kdna-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.16.0 (2026-07-13)
 
 ### Added
 

--- a/packages/kdna-core/CHANGELOG.md
+++ b/packages/kdna-core/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- RFC-0019 external account/device key grants, schemas, deterministic golden
+  and negative fixtures, and JS/Swift parity vectors.
+- JS Core helpers for external envelope encryption, per-device grant issuance,
+  signature/binding verification, in-memory decryption, and explicit zeroization.
+- LoadPlan accepts only a runtime-verified external entitlement for account/org
+  assets; structurally similar status objects no longer authorize loading.
+
+### Security
+
+- Account/device envelopes never fall back to the password profile.
+- Revoked, expired, tampered, digest/version/account/device mismatches fail
+  closed before Runtime Capsule projection.
+
 ## v0.15.12 (2026-07-12)
 
 **Single-format refactor + CBOR wire contract + Runtime Capsule.**

--- a/packages/kdna-core/README.md
+++ b/packages/kdna-core/README.md
@@ -97,6 +97,18 @@ A `.kdna` asset contains:
 encryption envelope in the same entry; authorized plaintext is decrypted in
 memory and projected into the Runtime Capsule.
 
+### Account/device external grants
+
+RFC-0019 licensed assets can keep the encrypted container publicly available
+while an issuer grants independent account/device access. `authorizeExternalKeyGrant()`
+verifies the issuer signature, lease, revocation state, account, device, asset
+UID/version/digest, and encrypted entry before returning a branded entitlement
+and in-memory decrypt hook. A plain `{status: "active"}` object is not accepted.
+
+Device private keys belong in the platform SecretStore. The returned session
+must be disposed after loading; Agent-facing callers should receive only the
+Runtime Capsule. Account grants never fall back to the password profile.
+
 ## Load Profiles
 
 `loadAuthorized()` supports:

--- a/packages/kdna-core/package.json
+++ b/packages/kdna-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aikdna/kdna-core",
-    "version": "0.15.12",
+    "version": "0.16.0",
     "description": "KDNA Core library for validating, planning, and loading local .kdna judgment assets.",
     "engines": {
         "node": ">=18.0.0"

--- a/packages/kdna-core/schema/kdna-envelope-external-grant-v1.schema.json
+++ b/packages/kdna-core/schema/kdna-envelope-external-grant-v1.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kdna.ai/specs/kdna-envelope-external-grant-v1.schema.json",
+  "title": "KDNA external grant envelope v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["profile", "alg", "cek_derivation", "key_ref", "issuer_key_id", "entry_path", "plaintext_digest", "iv", "tag", "ciphertext"],
+  "properties": {
+    "profile": { "const": "kdna-envelope-external-grant-v1" },
+    "alg": { "const": "A256GCM" },
+    "cek_derivation": { "const": "HKDF-SHA256" },
+    "key_ref": { "type": "string", "minLength": 1, "maxLength": 256 },
+    "issuer_key_id": { "type": "string", "minLength": 1, "maxLength": 128 },
+    "entry_path": { "type": "string", "pattern": "^[^/].*[^/]$|^[^/]$", "maxLength": 256 },
+    "plaintext_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "iv": { "type": "string", "pattern": "^[A-Za-z0-9_-]{16}$" },
+    "tag": { "type": "string", "pattern": "^[A-Za-z0-9_-]{22}$" },
+    "ciphertext": { "type": "string", "minLength": 1, "pattern": "^[A-Za-z0-9_-]+$" }
+  }
+}

--- a/packages/kdna-core/schema/kdna-key-grant-v1.schema.json
+++ b/packages/kdna-core/schema/kdna-key-grant-v1.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kdna.ai/specs/kdna-key-grant-v1.schema.json",
+  "title": "KDNA account/device external key grant v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["profile", "grant_id", "issuer", "signing_key_id", "entitlement_id", "account_id", "device_id", "device_public_key", "device_signing_public_key", "asset", "issued_at", "refresh_after", "offline_grace_until", "expires_at", "status", "status_version", "wrap", "signature"],
+  "properties": {
+    "profile": { "const": "kdna-key-grant-v1" },
+    "grant_id": { "$ref": "#/$defs/id" },
+    "issuer": { "type": "string", "format": "uri", "maxLength": 256 },
+    "signing_key_id": { "$ref": "#/$defs/id" },
+    "entitlement_id": { "$ref": "#/$defs/id" },
+    "account_id": { "$ref": "#/$defs/id" },
+    "device_id": { "$ref": "#/$defs/id" },
+    "device_public_key": { "type": "string", "pattern": "^x25519:[A-Za-z0-9_-]{43}$" },
+    "device_signing_public_key": { "type": "string", "pattern": "^ed25519:[A-Za-z0-9_-]{43}$" },
+    "asset": {
+      "type": "object", "additionalProperties": false,
+      "required": ["asset_id", "asset_uid", "version", "digest", "entry_path", "ciphertext_digest", "key_ref", "issuer_key_id"],
+      "properties": {
+        "asset_id": { "type": "string", "minLength": 1, "maxLength": 256 },
+        "asset_uid": { "type": "string", "minLength": 1, "maxLength": 512 },
+        "version": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "digest": { "$ref": "#/$defs/digest" },
+        "entry_path": { "type": "string", "minLength": 1, "maxLength": 256 },
+        "ciphertext_digest": { "$ref": "#/$defs/digest" },
+        "key_ref": { "type": "string", "minLength": 1, "maxLength": 256 },
+        "issuer_key_id": { "$ref": "#/$defs/id" }
+      }
+    },
+    "issued_at": { "type": "string", "format": "date-time" },
+    "refresh_after": { "type": "string", "format": "date-time" },
+    "offline_grace_until": { "type": "string", "format": "date-time" },
+    "expires_at": { "type": "string", "format": "date-time" },
+    "status": { "enum": ["active", "revoked", "expired"] },
+    "status_version": { "type": "integer", "minimum": 1 },
+    "wrap": {
+      "type": "object", "additionalProperties": false,
+      "required": ["alg", "ephemeral_public_key", "salt", "wrapped_cek"],
+      "properties": {
+        "alg": { "const": "X25519-HKDF-SHA256+A256KW" },
+        "ephemeral_public_key": { "type": "string", "pattern": "^x25519:[A-Za-z0-9_-]{43}$" },
+        "salt": { "type": "string", "pattern": "^[A-Za-z0-9_-]{22}$" },
+        "wrapped_cek": { "type": "string", "pattern": "^[A-Za-z0-9_-]{54}$" }
+      }
+    },
+    "signature": { "type": "string", "pattern": "^ed25519:[A-Za-z0-9_-]{86}$" }
+  },
+  "$defs": {
+    "id": { "type": "string", "pattern": "^[A-Za-z0-9._:@/-]{1,256}$" },
+    "digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" }
+  }
+}

--- a/packages/kdna-core/src/external-key-grant.js
+++ b/packages/kdna-core/src/external-key-grant.js
@@ -465,7 +465,17 @@ function authorizeExternalKeyGrant(options = {}) {
     kek.fill(0);
   }
 
-  const entitlement = {
+  const assetBinding = Object.freeze({
+    asset_id: grant.asset.asset_id,
+    asset_uid: grant.asset.asset_uid,
+    version: grant.asset.version,
+    digest: grant.asset.digest,
+    entry_path: grant.asset.entry_path,
+    ciphertext_digest: grant.asset.ciphertext_digest,
+    key_ref: grant.asset.key_ref,
+    issuer_key_id: grant.asset.issuer_key_id,
+  });
+  const entitlement = Object.freeze({
     status: state,
     profile: EXTERNAL_GRANT_PROFILE,
     grant_id: grant.grant_id,
@@ -475,7 +485,8 @@ function authorizeExternalKeyGrant(options = {}) {
     refresh_after: grant.refresh_after,
     offline_grace_until: grant.offline_grace_until,
     expires_at: grant.expires_at,
-  };
+    asset: assetBinding,
+  });
   verifiedEntitlements.add(entitlement);
 
   const decryptEntry = ({ entryName, ciphertext, manifest: runtimeManifest }) => {

--- a/packages/kdna-core/src/external-key-grant.js
+++ b/packages/kdna-core/src/external-key-grant.js
@@ -1,0 +1,549 @@
+/**
+ * Account/device external key grants (RFC-0019).
+ *
+ * This module deliberately has no password or license-key fallback. Asset CEKs
+ * are derived from an issuer root only in memory, then re-wrapped to one X25519
+ * device key by a signed, short-lived grant.
+ */
+
+const crypto = require('node:crypto');
+const path = require('node:path');
+const Ajv2020 = require('ajv/dist/2020');
+const addFormats = require('ajv-formats');
+const cbor = require('cbor-x');
+const { hkdfSha256, aesWrap, aesUnwrap } = require('./crypto-profile');
+
+const EXTERNAL_ENVELOPE_PROFILE = 'kdna-envelope-external-grant-v1';
+const EXTERNAL_GRANT_PROFILE = 'kdna-key-grant-v1';
+const EXTERNAL_AAD_PROFILE = 'kdna-external-asset-cek-v1';
+const DEVICE_KEK_PROFILE = 'kdna-device-grant-kek-v1';
+const ENVELOPE_ALG = 'A256GCM';
+const GRANT_WRAP_ALG = 'X25519-HKDF-SHA256+A256KW';
+
+const schemaRoot = path.join(__dirname, '..', 'schema');
+const ajv = new Ajv2020({ allErrors: true, strict: true });
+addFormats(ajv);
+const validateEnvelopeSchema = ajv.compile(
+  require(path.join(schemaRoot, 'kdna-envelope-external-grant-v1.schema.json')),
+);
+const validateGrantSchema = ajv.compile(
+  require(path.join(schemaRoot, 'kdna-key-grant-v1.schema.json')),
+);
+
+const verifiedEntitlements = new WeakSet();
+
+class KDNAExternalGrantError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.name = 'KDNAExternalGrantError';
+    this.code = code;
+  }
+}
+
+function fail(code, message) {
+  throw new KDNAExternalGrantError(code, message);
+}
+
+function sha256(value) {
+  return crypto.createHash('sha256').update(value).digest();
+}
+
+function digest(value) {
+  return `sha256:${sha256(value).toString('hex')}`;
+}
+
+function b64url(value) {
+  return Buffer.from(value).toString('base64url');
+}
+
+function decodeB64url(value, label, expectedLength) {
+  if (typeof value !== 'string' || !/^[A-Za-z0-9_-]+$/.test(value)) {
+    fail('KDNA_GRANT_FORMAT_INVALID', `${label} is not canonical base64url`);
+  }
+  const out = Buffer.from(value, 'base64url');
+  if (b64url(out) !== value || (expectedLength != null && out.length !== expectedLength)) {
+    fail('KDNA_GRANT_FORMAT_INVALID', `${label} has an invalid length or encoding`);
+  }
+  return out;
+}
+
+function prefixedKey(value, prefix, label, expectedLength = 32) {
+  if (typeof value !== 'string' || !value.startsWith(`${prefix}:`)) {
+    fail('KDNA_GRANT_FORMAT_INVALID', `${label} must use ${prefix}`);
+  }
+  return decodeB64url(value.slice(prefix.length + 1), label, expectedLength);
+}
+
+function canonicalJson(value) {
+  if (value === null || typeof value === 'boolean' || typeof value === 'number') {
+    return JSON.stringify(value);
+  }
+  if (typeof value === 'string') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  if (typeof value === 'object') {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
+      .join(',')}}`;
+  }
+  throw new TypeError(`unsupported canonical JSON value: ${typeof value}`);
+}
+
+function grantSigningPayload(grant) {
+  const unsigned = { ...grant };
+  delete unsigned.signature;
+  return Buffer.from(canonicalJson(unsigned), 'utf8');
+}
+
+function schemaProblems(validator) {
+  return (validator.errors || [])
+    .slice(0, 4)
+    .map((error) => `${error.instancePath || '<root>'} ${error.message}`)
+    .join('; ');
+}
+
+function validateExternalEnvelope(envelope) {
+  if (!validateEnvelopeSchema(envelope)) {
+    fail('KDNA_ENVELOPE_FORMAT_INVALID', `external envelope is invalid: ${schemaProblems(validateEnvelopeSchema)}`);
+  }
+  return envelope;
+}
+
+function validateExternalKeyGrant(grant) {
+  if (!validateGrantSchema(grant)) {
+    fail('KDNA_GRANT_FORMAT_INVALID', `external key grant is invalid: ${schemaProblems(validateGrantSchema)}`);
+  }
+  const issued = Date.parse(grant.issued_at);
+  const refresh = Date.parse(grant.refresh_after);
+  const grace = Date.parse(grant.offline_grace_until);
+  const expires = Date.parse(grant.expires_at);
+  if (!(issued <= refresh && refresh <= grace && grace <= expires)) {
+    fail('KDNA_GRANT_TIME_INVALID', 'grant time window is not monotonic');
+  }
+  return grant;
+}
+
+function externalEnvelopeAad({ manifest, entryName, plaintextDigest, keyRef, issuerKeyId }) {
+  const entitlementProfile = manifest?.entitlement?.profile || '';
+  const fields = [
+    EXTERNAL_ENVELOPE_PROFILE,
+    manifest?.asset_uid || '',
+    manifest?.asset_id || manifest?.name || '',
+    manifest?.version || '',
+    entryName,
+    plaintextDigest,
+    keyRef,
+    issuerKeyId,
+    manifest?.access || '',
+    entitlementProfile,
+  ];
+  if (fields.some((field) => typeof field !== 'string' || field.length === 0)) {
+    fail('KDNA_ENVELOPE_BINDING_INVALID', 'manifest is missing an external envelope binding');
+  }
+  if (manifest.access !== 'licensed' || !['account', 'org'].includes(entitlementProfile)) {
+    fail('KDNA_ENVELOPE_BINDING_INVALID', 'external grants require licensed account or org entitlement');
+  }
+  return Buffer.from(fields.join('\n'), 'utf8');
+}
+
+function normalizeIssuerRoot(value) {
+  const root = Buffer.isBuffer(value) ? Buffer.from(value) : decodeB64url(value, 'issuer root', 32);
+  if (root.length !== 32) fail('KDNA_ISSUER_ROOT_INVALID', 'issuer root must be 32 bytes');
+  return root;
+}
+
+function deriveExternalAssetCek({ issuerRootKey, manifest, entryName, plaintextDigest, keyRef, issuerKeyId }) {
+  const root = normalizeIssuerRoot(issuerRootKey);
+  const aad = externalEnvelopeAad({ manifest, entryName, plaintextDigest, keyRef, issuerKeyId });
+  try {
+    return hkdfSha256(
+      root,
+      sha256(aad),
+      Buffer.from(`${EXTERNAL_AAD_PROFILE}\n${keyRef}`, 'utf8'),
+      32,
+    );
+  } finally {
+    root.fill(0);
+  }
+}
+
+function encodeExternalEnvelope(envelope) {
+  validateExternalEnvelope(envelope);
+  return Buffer.from(cbor.encode(envelope));
+}
+
+function decodeExternalEnvelope(value) {
+  let envelope = value;
+  if (Buffer.isBuffer(value) || value instanceof Uint8Array) {
+    try {
+      envelope = cbor.decode(Buffer.from(value));
+    } catch {
+      fail('KDNA_ENVELOPE_FORMAT_INVALID', 'external envelope CBOR could not be decoded');
+    }
+  }
+  return validateExternalEnvelope(envelope);
+}
+
+function encryptExternalGrantEntry(plaintextValue, options = {}) {
+  const plaintext = Buffer.from(plaintextValue);
+  const {
+    manifest,
+    entryName = 'payload.kdnab',
+    issuerRootKey,
+    keyRef,
+    issuerKeyId,
+    iv = crypto.randomBytes(12),
+  } = options;
+  const plaintextDigest = digest(plaintext);
+  const aad = externalEnvelopeAad({ manifest, entryName, plaintextDigest, keyRef, issuerKeyId });
+  const cek = deriveExternalAssetCek({
+    issuerRootKey,
+    manifest,
+    entryName,
+    plaintextDigest,
+    keyRef,
+    issuerKeyId,
+  });
+  try {
+    const cipher = crypto.createCipheriv('aes-256-gcm', cek, Buffer.from(iv));
+    cipher.setAAD(aad);
+    const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+    return {
+      profile: EXTERNAL_ENVELOPE_PROFILE,
+      alg: ENVELOPE_ALG,
+      cek_derivation: 'HKDF-SHA256',
+      key_ref: keyRef,
+      issuer_key_id: issuerKeyId,
+      entry_path: entryName,
+      plaintext_digest: plaintextDigest,
+      iv: b64url(iv),
+      tag: b64url(cipher.getAuthTag()),
+      ciphertext: b64url(ciphertext),
+    };
+  } finally {
+    cek.fill(0);
+  }
+}
+
+function publicKeyFromRaw(crv, value) {
+  const x = value.includes(':') ? value.split(':', 2)[1] : value;
+  return crypto.createPublicKey({ key: { kty: 'OKP', crv, x }, format: 'jwk' });
+}
+
+function privateKeyFromBundle(crv, bundle) {
+  if (bundle && typeof bundle === 'object' && bundle.type === 'private') return bundle;
+  if (bundle && bundle.privateKey) return bundle.privateKey;
+  const privateValue = bundle?.private_key || bundle?.privateKeyRaw || bundle?.d;
+  const publicValue = bundle?.public_key || bundle?.publicKeyRaw || bundle?.x;
+  if (!privateValue || !publicValue) {
+    fail('KDNA_GRANT_DEVICE_KEY_INVALID', `${crv} private and public key material are required`);
+  }
+  const d = privateValue.includes(':') ? privateValue.split(':', 2)[1] : privateValue;
+  const x = publicValue.includes(':') ? publicValue.split(':', 2)[1] : publicValue;
+  decodeB64url(d, `${crv} private key`, 32);
+  decodeB64url(x, `${crv} public key`, 32);
+  return crypto.createPrivateKey({ key: { kty: 'OKP', crv, d, x }, format: 'jwk' });
+}
+
+function generateDeviceKeyPairs() {
+  const agreement = crypto.generateKeyPairSync('x25519');
+  const signing = crypto.generateKeyPairSync('ed25519');
+  const agreementPublic = agreement.publicKey.export({ format: 'jwk' });
+  const agreementPrivate = agreement.privateKey.export({ format: 'jwk' });
+  const signingPublic = signing.publicKey.export({ format: 'jwk' });
+  const signingPrivate = signing.privateKey.export({ format: 'jwk' });
+  return {
+    agreement: {
+      public_key: `x25519:${agreementPublic.x}`,
+      private_key: `x25519:${agreementPrivate.d}`,
+    },
+    signing: {
+      public_key: `ed25519:${signingPublic.x}`,
+      private_key: `ed25519:${signingPrivate.d}`,
+    },
+  };
+}
+
+function resolveIssuerPublicKey(issuerPublicKeys, keyId) {
+  const value = issuerPublicKeys instanceof Map ? issuerPublicKeys.get(keyId) : issuerPublicKeys?.[keyId];
+  if (!value) fail('KDNA_GRANT_ISSUER_UNKNOWN', 'grant signing key is not pinned');
+  if (value && typeof value === 'object' && value.type === 'public') return value;
+  if (typeof value === 'string' && value.startsWith('ed25519:')) {
+    try {
+      const raw = prefixedKey(value, 'ed25519', 'grant issuer public key');
+      return publicKeyFromRaw('Ed25519', `ed25519:${b64url(raw)}`);
+    } catch {
+      fail('KDNA_GRANT_ISSUER_UNKNOWN', 'grant signing key is invalid');
+    }
+  }
+  try {
+    return crypto.createPublicKey(value);
+  } catch {
+    fail('KDNA_GRANT_ISSUER_UNKNOWN', 'grant signing key is invalid');
+  }
+}
+
+function createExternalKeyGrant(options = {}) {
+  const {
+    issuerRootKey,
+    issuerSigningPrivateKey,
+    signingKeyId,
+    issuer,
+    entitlementId,
+    accountId,
+    deviceId,
+    devicePublicKey,
+    deviceSigningPublicKey,
+    manifest,
+    envelope: envelopeValue,
+    assetDigest,
+    status = 'active',
+    statusVersion = 1,
+    issuedAt = new Date(),
+    refreshAfter = new Date(issuedAt.getTime() + 24 * 60 * 60 * 1000),
+    offlineGraceUntil = new Date(issuedAt.getTime() + 7 * 24 * 60 * 60 * 1000),
+    expiresAt = new Date(issuedAt.getTime() + 8 * 24 * 60 * 60 * 1000),
+    grantId = `grt_${crypto.randomBytes(16).toString('base64url')}`,
+    ephemeralKeyPair = null,
+    wrapSalt = null,
+  } = options;
+  const envelope = decodeExternalEnvelope(envelopeValue);
+  const deviceRaw = prefixedKey(devicePublicKey, 'x25519', 'device public key');
+  prefixedKey(deviceSigningPublicKey, 'ed25519', 'device signing public key');
+  const cek = deriveExternalAssetCek({
+    issuerRootKey,
+    manifest,
+    entryName: envelope.entry_path,
+    plaintextDigest: envelope.plaintext_digest,
+    keyRef: envelope.key_ref,
+    issuerKeyId: envelope.issuer_key_id,
+  });
+  let shared = null;
+  let kek = null;
+  try {
+    const ephemeral = ephemeralKeyPair || crypto.generateKeyPairSync('x25519');
+    const ephemeralJwk = ephemeral.publicKey.export({ format: 'jwk' });
+    const deviceKey = publicKeyFromRaw('X25519', `x25519:${b64url(deviceRaw)}`);
+    shared = crypto.diffieHellman({ privateKey: ephemeral.privateKey, publicKey: deviceKey });
+    const salt = wrapSalt ? Buffer.from(wrapSalt) : crypto.randomBytes(16);
+    if (salt.length !== 16) fail('KDNA_GRANT_FORMAT_INVALID', 'grant wrap salt must be 16 bytes');
+    kek = hkdfSha256(shared, salt, Buffer.from(`${DEVICE_KEK_PROFILE}\n${grantId}`, 'utf8'), 32);
+    const grant = {
+      profile: EXTERNAL_GRANT_PROFILE,
+      grant_id: grantId,
+      issuer,
+      signing_key_id: signingKeyId,
+      entitlement_id: entitlementId,
+      account_id: accountId,
+      device_id: deviceId,
+      device_public_key: devicePublicKey,
+      device_signing_public_key: deviceSigningPublicKey,
+      asset: {
+        asset_id: manifest.asset_id || manifest.name,
+        asset_uid: manifest.asset_uid,
+        version: manifest.version,
+        digest: assetDigest,
+        entry_path: envelope.entry_path,
+        ciphertext_digest: digest(Buffer.from(envelope.ciphertext, 'base64url')),
+        key_ref: envelope.key_ref,
+        issuer_key_id: envelope.issuer_key_id,
+      },
+      issued_at: new Date(issuedAt).toISOString(),
+      refresh_after: new Date(refreshAfter).toISOString(),
+      offline_grace_until: new Date(offlineGraceUntil).toISOString(),
+      expires_at: new Date(expiresAt).toISOString(),
+      status,
+      status_version: statusVersion,
+      wrap: {
+        alg: GRANT_WRAP_ALG,
+        ephemeral_public_key: `x25519:${ephemeralJwk.x}`,
+        salt: b64url(salt),
+        wrapped_cek: b64url(aesWrap(kek, cek)),
+      },
+    };
+    validateExternalKeyGrant({ ...grant, signature: `ed25519:${'A'.repeat(86)}` });
+    const signature = crypto.sign(null, grantSigningPayload(grant), issuerSigningPrivateKey);
+    return { ...grant, signature: `ed25519:${b64url(signature)}` };
+  } finally {
+    cek.fill(0);
+    if (shared) shared.fill(0);
+    if (kek) kek.fill(0);
+  }
+}
+
+function grantState(grant, now, networkAvailable, allowOffline) {
+  const time = now instanceof Date ? now.getTime() : new Date(now || Date.now()).getTime();
+  const issued = Date.parse(grant.issued_at);
+  const refresh = Date.parse(grant.refresh_after);
+  const grace = Date.parse(grant.offline_grace_until);
+  const expires = Date.parse(grant.expires_at);
+  if (
+    ![time, issued, refresh, grace, expires].every(Number.isFinite) ||
+    issued > refresh || refresh > grace || grace > expires
+  ) fail('KDNA_GRANT_TIME_INVALID', 'external key grant time window is invalid');
+  if (time + 5 * 60 * 1000 < issued) fail('KDNA_GRANT_TIME_INVALID', 'external key grant is not valid yet');
+  if (grant.status === 'revoked') fail('KDNA_GRANT_REVOKED', 'external key grant is revoked');
+  if (grant.status !== 'active') fail('KDNA_GRANT_EXPIRED', 'external key grant is not active');
+  if (time > expires) fail('KDNA_GRANT_EXPIRED', 'external key grant has expired');
+  if (time <= refresh) return 'active';
+  if (networkAvailable) fail('KDNA_GRANT_SYNC_REQUIRED', 'external key grant must be synchronized');
+  if (!allowOffline || time > grace) {
+    fail('KDNA_GRANT_EXPIRED', 'external key grant offline grace has expired');
+  }
+  return 'offline_grace';
+}
+
+function expectEqual(actual, expected, code, label) {
+  if (expected == null || actual !== expected) fail(code, `${label} mismatch`);
+}
+
+function authorizeExternalKeyGrant(options = {}) {
+  const {
+    grant,
+    issuerPublicKeys,
+    manifest,
+    checksums,
+    envelope: envelopeValue,
+    deviceAgreementKey,
+    expectedAccountId,
+    expectedDeviceId,
+    expectedDeviceSigningPublicKey,
+    minimumStatusVersion = null,
+    now = new Date(),
+    networkAvailable = false,
+    allowOffline = true,
+  } = options;
+  validateExternalKeyGrant(grant);
+  if (minimumStatusVersion != null && (
+    !Number.isInteger(minimumStatusVersion) || grant.status_version < minimumStatusVersion
+  )) fail('KDNA_GRANT_ROLLBACK_DETECTED', 'external key grant status version rolled back');
+  const issuerKey = resolveIssuerPublicKey(issuerPublicKeys, grant.signing_key_id);
+  const signature = prefixedKey(grant.signature, 'ed25519', 'grant signature', 64);
+  if (signature.length !== 64 || !crypto.verify(null, grantSigningPayload(grant), issuerKey, signature)) {
+    fail('KDNA_GRANT_SIGNATURE_INVALID', 'external key grant signature is invalid');
+  }
+  const state = grantState(grant, now, networkAvailable, allowOffline);
+  const envelope = decodeExternalEnvelope(envelopeValue);
+
+  expectEqual(grant.account_id, expectedAccountId, 'KDNA_GRANT_ACCOUNT_MISMATCH', 'grant account');
+  expectEqual(grant.device_id, expectedDeviceId, 'KDNA_GRANT_DEVICE_MISMATCH', 'grant device');
+  expectEqual(
+    grant.device_signing_public_key,
+    expectedDeviceSigningPublicKey,
+    'KDNA_GRANT_DEVICE_MISMATCH',
+    'device signing key',
+  );
+  expectEqual(grant.asset.asset_id, manifest.asset_id || manifest.name, 'KDNA_GRANT_ASSET_MISMATCH', 'asset ID');
+  expectEqual(grant.asset.asset_uid, manifest.asset_uid, 'KDNA_GRANT_ASSET_MISMATCH', 'asset UID');
+  expectEqual(grant.asset.version, manifest.version, 'KDNA_GRANT_ASSET_MISMATCH', 'asset version');
+  expectEqual(grant.asset.digest, checksums?.asset_digest, 'KDNA_GRANT_DIGEST_MISMATCH', 'asset digest');
+  expectEqual(grant.asset.entry_path, envelope.entry_path, 'KDNA_GRANT_ASSET_MISMATCH', 'entry path');
+  expectEqual(grant.asset.key_ref, envelope.key_ref, 'KDNA_GRANT_ASSET_MISMATCH', 'key reference');
+  expectEqual(grant.asset.issuer_key_id, envelope.issuer_key_id, 'KDNA_GRANT_ASSET_MISMATCH', 'issuer asset key');
+  expectEqual(
+    grant.asset.ciphertext_digest,
+    digest(Buffer.from(envelope.ciphertext, 'base64url')),
+    'KDNA_GRANT_DIGEST_MISMATCH',
+    'ciphertext digest',
+  );
+
+  const privateKey = privateKeyFromBundle('X25519', deviceAgreementKey);
+  const localPublic = deviceAgreementKey.public_key || deviceAgreementKey.publicKeyRaw || deviceAgreementKey.x;
+  expectEqual(grant.device_public_key, localPublic, 'KDNA_GRANT_DEVICE_MISMATCH', 'device agreement key');
+  const ephemeralRaw = prefixedKey(grant.wrap.ephemeral_public_key, 'x25519', 'ephemeral public key');
+  const ephemeralKey = publicKeyFromRaw('X25519', `x25519:${b64url(ephemeralRaw)}`);
+  const shared = crypto.diffieHellman({ privateKey, publicKey: ephemeralKey });
+  const salt = decodeB64url(grant.wrap.salt, 'grant wrap salt', 16);
+  const kek = hkdfSha256(shared, salt, Buffer.from(`${DEVICE_KEK_PROFILE}\n${grant.grant_id}`, 'utf8'), 32);
+  let cek;
+  try {
+    cek = aesUnwrap(kek, decodeB64url(grant.wrap.wrapped_cek, 'wrapped CEK', 40));
+  } catch (error) {
+    fail('KDNA_GRANT_DEVICE_MISMATCH', 'device could not unwrap the external key grant');
+  } finally {
+    shared.fill(0);
+    kek.fill(0);
+  }
+
+  const entitlement = {
+    status: state,
+    profile: EXTERNAL_GRANT_PROFILE,
+    grant_id: grant.grant_id,
+    entitlement_id: grant.entitlement_id,
+    account_id: grant.account_id,
+    device_id: grant.device_id,
+    refresh_after: grant.refresh_after,
+    offline_grace_until: grant.offline_grace_until,
+    expires_at: grant.expires_at,
+  };
+  verifiedEntitlements.add(entitlement);
+
+  const decryptEntry = ({ entryName, ciphertext, manifest: runtimeManifest }) => {
+    const runtimeEnvelope = decodeExternalEnvelope(ciphertext);
+    if (entryName !== envelope.entry_path) fail('KDNA_GRANT_ASSET_MISMATCH', 'encrypted entry path mismatch');
+    if (digest(Buffer.from(runtimeEnvelope.ciphertext, 'base64url')) !== grant.asset.ciphertext_digest) {
+      fail('KDNA_GRANT_DIGEST_MISMATCH', 'encrypted entry digest mismatch');
+    }
+    const aad = externalEnvelopeAad({
+      manifest: runtimeManifest,
+      entryName,
+      plaintextDigest: runtimeEnvelope.plaintext_digest,
+      keyRef: runtimeEnvelope.key_ref,
+      issuerKeyId: runtimeEnvelope.issuer_key_id,
+    });
+    try {
+      const decipher = crypto.createDecipheriv(
+        'aes-256-gcm',
+        cek,
+        decodeB64url(runtimeEnvelope.iv, 'envelope IV', 12),
+      );
+      decipher.setAAD(aad);
+      decipher.setAuthTag(decodeB64url(runtimeEnvelope.tag, 'envelope tag', 16));
+      const plaintext = Buffer.concat([
+        decipher.update(decodeB64url(runtimeEnvelope.ciphertext, 'envelope ciphertext')),
+        decipher.final(),
+      ]);
+      if (digest(plaintext) !== runtimeEnvelope.plaintext_digest) {
+        fail('KDNA_GRANT_DIGEST_MISMATCH', 'decrypted entry digest mismatch');
+      }
+      return plaintext;
+    } catch (error) {
+      if (error instanceof KDNAExternalGrantError) throw error;
+      fail('KDNA_GRANT_TAMPERED', 'external envelope authentication failed');
+    }
+  };
+
+  return {
+    entitlement,
+    decryptEntry,
+    dispose() {
+      if (cek) cek.fill(0);
+      cek = null;
+    },
+  };
+}
+
+function isVerifiedExternalEntitlement(value) {
+  return !!value && verifiedEntitlements.has(value);
+}
+
+module.exports = {
+  EXTERNAL_ENVELOPE_PROFILE,
+  EXTERNAL_GRANT_PROFILE,
+  EXTERNAL_AAD_PROFILE,
+  DEVICE_KEK_PROFILE,
+  KDNAExternalGrantError,
+  canonicalJson,
+  grantSigningPayload,
+  validateExternalEnvelope,
+  validateExternalKeyGrant,
+  externalEnvelopeAad,
+  deriveExternalAssetCek,
+  encodeExternalEnvelope,
+  decodeExternalEnvelope,
+  encryptExternalGrantEntry,
+  generateDeviceKeyPairs,
+  createExternalKeyGrant,
+  authorizeExternalKeyGrant,
+  isVerifiedExternalEntitlement,
+};

--- a/packages/kdna-core/src/external-key-grant.js
+++ b/packages/kdna-core/src/external-key-grant.js
@@ -458,7 +458,7 @@ function authorizeExternalKeyGrant(options = {}) {
   let cek;
   try {
     cek = aesUnwrap(kek, decodeB64url(grant.wrap.wrapped_cek, 'wrapped CEK', 40));
-  } catch (error) {
+  } catch {
     fail('KDNA_GRANT_DEVICE_MISMATCH', 'device could not unwrap the external key grant');
   } finally {
     shared.fill(0);

--- a/packages/kdna-core/src/index.js
+++ b/packages/kdna-core/src/index.js
@@ -8,6 +8,7 @@ const render = require('./render');
 const compose = require('./compose');
 const assetReader = require('./asset-reader');
 const cryptoProfile = require('./crypto-profile');
+const externalKeyGrant = require('./external-key-grant');
 const publicApi = require('./public-api');
 const workpackPure = require('./workpack-pure');
 const v1 = require('./v1');
@@ -21,6 +22,7 @@ module.exports = {
   ...compose,
   ...assetReader,
   ...cryptoProfile,
+  ...externalKeyGrant,
   ...workpackPure,
   ...v1,
 };

--- a/packages/kdna-core/src/index.mjs
+++ b/packages/kdna-core/src/index.mjs
@@ -42,6 +42,7 @@ export { composeContext, composeContextWithAttribution, classifySignals, classif
 
 import assetReader from './asset-reader.js';
 import cryptoProfile from './crypto-profile.js';
+import externalKeyGrant from './external-key-grant.js';
 
 export const STANDARD_ENTRIES = assetReader.STANDARD_ENTRIES;
 export const createKdnaAssetReader = assetReader.createKdnaAssetReader;
@@ -50,3 +51,17 @@ export const deriveLicensedEntryKey = cryptoProfile.deriveLicensedEntryKey;
 export const encryptLicensedEntry = cryptoProfile.encryptLicensedEntry;
 export const decryptLicensedEntry = cryptoProfile.decryptLicensedEntry;
 export const createLicensedDecryptEntry = cryptoProfile.createLicensedDecryptEntry;
+export const EXTERNAL_ENVELOPE_PROFILE = externalKeyGrant.EXTERNAL_ENVELOPE_PROFILE;
+export const EXTERNAL_GRANT_PROFILE = externalKeyGrant.EXTERNAL_GRANT_PROFILE;
+export const KDNAExternalGrantError = externalKeyGrant.KDNAExternalGrantError;
+export const canonicalJson = externalKeyGrant.canonicalJson;
+export const grantSigningPayload = externalKeyGrant.grantSigningPayload;
+export const validateExternalEnvelope = externalKeyGrant.validateExternalEnvelope;
+export const validateExternalKeyGrant = externalKeyGrant.validateExternalKeyGrant;
+export const deriveExternalAssetCek = externalKeyGrant.deriveExternalAssetCek;
+export const encodeExternalEnvelope = externalKeyGrant.encodeExternalEnvelope;
+export const decodeExternalEnvelope = externalKeyGrant.decodeExternalEnvelope;
+export const encryptExternalGrantEntry = externalKeyGrant.encryptExternalGrantEntry;
+export const generateDeviceKeyPairs = externalKeyGrant.generateDeviceKeyPairs;
+export const createExternalKeyGrant = externalKeyGrant.createExternalKeyGrant;
+export const authorizeExternalKeyGrant = externalKeyGrant.authorizeExternalKeyGrant;

--- a/packages/kdna-core/src/types.d.ts
+++ b/packages/kdna-core/src/types.d.ts
@@ -485,6 +485,16 @@ export interface KDNAVerifiedExternalEntitlement {
   readonly refresh_after: string;
   readonly offline_grace_until: string;
   readonly expires_at: string;
+  readonly asset: {
+    readonly asset_id: string;
+    readonly asset_uid: string;
+    readonly version: string;
+    readonly digest: string;
+    readonly entry_path: string;
+    readonly ciphertext_digest: string;
+    readonly key_ref: string;
+    readonly issuer_key_id: string;
+  };
 }
 
 export interface KDNAExternalAuthorization {

--- a/packages/kdna-core/src/types.d.ts
+++ b/packages/kdna-core/src/types.d.ts
@@ -414,6 +414,155 @@ export function createLicensedDecryptEntry(options: {
   machineFingerprint: string;
 }): NonNullable<KdnaDecryptOptions['decryptEntry']>;
 
+export const EXTERNAL_ENVELOPE_PROFILE: 'kdna-envelope-external-grant-v1';
+export const EXTERNAL_GRANT_PROFILE: 'kdna-key-grant-v1';
+
+export class KDNAExternalGrantError extends Error {
+  code: string;
+}
+
+export interface KDNAExternalGrantEnvelope {
+  profile: 'kdna-envelope-external-grant-v1';
+  alg: 'A256GCM';
+  cek_derivation: 'HKDF-SHA256';
+  key_ref: string;
+  issuer_key_id: string;
+  entry_path: string;
+  plaintext_digest: string;
+  iv: string;
+  tag: string;
+  ciphertext: string;
+}
+
+export interface KDNAExternalKeyGrant {
+  profile: 'kdna-key-grant-v1';
+  grant_id: string;
+  issuer: string;
+  signing_key_id: string;
+  entitlement_id: string;
+  account_id: string;
+  device_id: string;
+  device_public_key: string;
+  device_signing_public_key: string;
+  asset: {
+    asset_id: string;
+    asset_uid: string;
+    version: string;
+    digest: string;
+    entry_path: string;
+    ciphertext_digest: string;
+    key_ref: string;
+    issuer_key_id: string;
+  };
+  issued_at: string;
+  refresh_after: string;
+  offline_grace_until: string;
+  expires_at: string;
+  status: 'active' | 'revoked' | 'expired';
+  status_version: number;
+  wrap: {
+    alg: 'X25519-HKDF-SHA256+A256KW';
+    ephemeral_public_key: string;
+    salt: string;
+    wrapped_cek: string;
+  };
+  signature: string;
+}
+
+export interface KDNADeviceKeyPairs {
+  agreement: { public_key: string; private_key: string };
+  signing: { public_key: string; private_key: string };
+}
+
+/** Runtime-branded by authorizeExternalKeyGrant; a structurally similar object is not accepted. */
+export interface KDNAVerifiedExternalEntitlement {
+  readonly status: 'active' | 'offline_grace';
+  readonly profile: 'kdna-key-grant-v1';
+  readonly grant_id: string;
+  readonly entitlement_id: string;
+  readonly account_id: string;
+  readonly device_id: string;
+  readonly refresh_after: string;
+  readonly offline_grace_until: string;
+  readonly expires_at: string;
+}
+
+export interface KDNAExternalAuthorization {
+  entitlement: KDNAVerifiedExternalEntitlement;
+  decryptEntry: NonNullable<KdnaDecryptOptions['decryptEntry']>;
+  dispose(): void;
+}
+
+export function canonicalJson(value: unknown): string;
+export function grantSigningPayload(grant: Omit<KDNAExternalKeyGrant, 'signature'> | KDNAExternalKeyGrant): Uint8Array;
+export function validateExternalEnvelope(value: unknown): KDNAExternalGrantEnvelope;
+export function validateExternalKeyGrant(value: unknown): KDNAExternalKeyGrant;
+export function externalEnvelopeAad(options: {
+  manifest: KDNAManifest;
+  entryName: string;
+  plaintextDigest: string;
+  keyRef: string;
+  issuerKeyId: string;
+}): Uint8Array;
+export function deriveExternalAssetCek(options: {
+  issuerRootKey: string | Uint8Array;
+  manifest: KDNAManifest;
+  entryName: string;
+  plaintextDigest: string;
+  keyRef: string;
+  issuerKeyId: string;
+}): Uint8Array;
+export function encodeExternalEnvelope(value: KDNAExternalGrantEnvelope): Uint8Array;
+export function decodeExternalEnvelope(value: KDNAExternalGrantEnvelope | Uint8Array): KDNAExternalGrantEnvelope;
+export function encryptExternalGrantEntry(plaintext: string | Uint8Array, options: {
+  manifest: KDNAManifest;
+  entryName?: string;
+  issuerRootKey: string | Uint8Array;
+  keyRef: string;
+  issuerKeyId: string;
+  iv?: Uint8Array;
+}): KDNAExternalGrantEnvelope;
+export function generateDeviceKeyPairs(): KDNADeviceKeyPairs;
+export function createExternalKeyGrant(options: {
+  issuerRootKey: string | Uint8Array;
+  issuerSigningPrivateKey: unknown;
+  signingKeyId: string;
+  issuer: string;
+  entitlementId: string;
+  accountId: string;
+  deviceId: string;
+  devicePublicKey: string;
+  deviceSigningPublicKey: string;
+  manifest: KDNAManifest;
+  envelope: KDNAExternalGrantEnvelope | Uint8Array;
+  assetDigest: string;
+  status?: 'active' | 'revoked' | 'expired';
+  statusVersion?: number;
+  issuedAt?: Date | string;
+  refreshAfter?: Date | string;
+  offlineGraceUntil?: Date | string;
+  expiresAt?: Date | string;
+  grantId?: string;
+  ephemeralKeyPair?: unknown;
+  wrapSalt?: Uint8Array;
+}): KDNAExternalKeyGrant;
+export function authorizeExternalKeyGrant(options: {
+  grant: KDNAExternalKeyGrant;
+  issuerPublicKeys: Map<string, unknown> | Record<string, unknown>;
+  manifest: KDNAManifest;
+  checksums: KDNAChecksums;
+  envelope: KDNAExternalGrantEnvelope | Uint8Array;
+  deviceAgreementKey: KDNADeviceKeyPairs['agreement'] | unknown;
+  expectedAccountId: string;
+  expectedDeviceId: string;
+  expectedDeviceSigningPublicKey: string;
+  minimumStatusVersion?: number;
+  now?: Date | string;
+  networkAvailable?: boolean;
+  allowOffline?: boolean;
+}): KDNAExternalAuthorization;
+export function isVerifiedExternalEntitlement(value: unknown): value is KDNAVerifiedExternalEntitlement;
+
 // Stable public API — preferred entry points for third-party integrations.
 export type KDNAAssetInput = string | Uint8Array | KdnaAsset;
 
@@ -553,7 +702,7 @@ export interface KDNALoadPlan {
     path: string;
   };
 }
-export function planLoad(inputPath: string, options?: { password?: string; hasPassword?: boolean; entitlement?: Record<string, any> }): KDNALoadPlan;
+export function planLoad(inputPath: string, options?: { password?: string; hasPassword?: boolean; entitlement?: KDNAVerifiedExternalEntitlement | Record<string, any> }): KDNALoadPlan;
 export function buildChecksums(sourceDir: string): KDNAChecksums;
 export function pack(sourceDir: string, outputPath: string): void;
 export function unpack(inputPath: string, outputDir: string): void;

--- a/packages/kdna-core/src/v1/index.js
+++ b/packages/kdna-core/src/v1/index.js
@@ -1292,6 +1292,36 @@ function planLoad(inputPath, opts = {}) {
 
   const manifest = v1.manifest;
 
+  function externalEntitlementMatchesCurrentAsset(entitlement) {
+    if (!isVerifiedExternalEntitlement(entitlement) || !entitlement.asset) return false;
+    let checksums = null;
+    try {
+      checksums = v1.map['checksums.json']
+        ? parseJsonEntry('checksums.json', v1.map['checksums.json'])
+        : null;
+    } catch {
+      return false;
+    }
+    return entitlement.asset.asset_id === (manifest.asset_id || manifest.name)
+      && entitlement.asset.asset_uid === manifest.asset_uid
+      && entitlement.asset.version === manifest.version
+      && entitlement.asset.digest === checksums?.asset_digest
+      && entitlement.asset.entry_path === manifest.payload?.path;
+  }
+
+  function rejectExternalEntitlementMismatch() {
+    plan.state = 'invalid';
+    plan.required_action = 'block';
+    plan.can_load_now = false;
+    plan.projection_policy = 'none';
+    plan.issues.push(buildLoadPlanIssue(
+      'KDNA_GRANT_ASSET_MISMATCH',
+      'blocking',
+      'The verified account/device grant is bound to a different asset, version, digest, or encrypted entry.',
+    ));
+    return finalizeLoadPlan(plan);
+  }
+
   // Resolve dependencies if declared (Story 6)
   const resolvedDeps = [];
   if (manifest.dependencies && typeof manifest.dependencies === 'object' && Object.keys(manifest.dependencies).length > 0) {
@@ -1464,6 +1494,9 @@ function planLoad(inputPath, opts = {}) {
 
     if (plan.entitlement_profile === 'account') {
       if (isVerifiedExternalEntitlement(opts.entitlement)) {
+        if (!externalEntitlementMatchesCurrentAsset(opts.entitlement)) {
+          return rejectExternalEntitlementMismatch();
+        }
         plan.state = opts.entitlement.status === 'offline_grace' ? 'offline_grace' : 'ready';
         plan.required_action = opts.entitlement.status === 'offline_grace' ? 'sync' : 'load';
         plan.can_load_now = true;
@@ -1491,6 +1524,9 @@ function planLoad(inputPath, opts = {}) {
 
     if (plan.entitlement_profile === 'org') {
       if (isVerifiedExternalEntitlement(opts.entitlement)) {
+        if (!externalEntitlementMatchesCurrentAsset(opts.entitlement)) {
+          return rejectExternalEntitlementMismatch();
+        }
         plan.state = opts.entitlement.status === 'offline_grace' ? 'offline_grace' : 'ready';
         plan.required_action = opts.entitlement.status === 'offline_grace' ? 'sync' : 'load';
         plan.can_load_now = true;

--- a/packages/kdna-core/src/v1/index.js
+++ b/packages/kdna-core/src/v1/index.js
@@ -1294,7 +1294,7 @@ function planLoad(inputPath, opts = {}) {
 
   function externalEntitlementMatchesCurrentAsset(entitlement) {
     if (!isVerifiedExternalEntitlement(entitlement) || !entitlement.asset) return false;
-    let checksums = null;
+    let checksums;
     try {
       checksums = v1.map['checksums.json']
         ? parseJsonEntry('checksums.json', v1.map['checksums.json'])

--- a/packages/kdna-core/src/v1/index.js
+++ b/packages/kdna-core/src/v1/index.js
@@ -39,6 +39,11 @@ const path = require('node:path');
 const zlib = require('node:zlib');
 const crypto = require('node:crypto');
 const cbor = require('cbor-x');
+const {
+  EXTERNAL_ENVELOPE_PROFILE,
+  validateExternalEnvelope,
+  isVerifiedExternalEntitlement,
+} = require('../external-key-grant');
 
 const { readAsset } = (() => {
   try {
@@ -758,7 +763,16 @@ function runValidate(v1) {
       result.payload_valid = false;
       problems.push(`payload: encrypted envelope profile ${payload.profile || 'unknown'} does not match manifest encryption profile ${encProfile}`);
     }
-    const hasKeyMaterial = !!payload.wrapped_key || (Array.isArray(payload.key_slots) && payload.key_slots.length > 0);
+    let hasKeyMaterial = !!payload.wrapped_key || (Array.isArray(payload.key_slots) && payload.key_slots.length > 0);
+    if (payload.profile === EXTERNAL_ENVELOPE_PROFILE) {
+      try {
+        validateExternalEnvelope(payload);
+        hasKeyMaterial = true;
+      } catch (error) {
+        result.payload_valid = false;
+        problems.push(`payload: ${error.message}`);
+      }
+    }
     if (!payload.profile || !payload.ciphertext || !hasKeyMaterial) {
       result.payload_valid = false;
       problems.push('payload: encrypted envelope missing required fields (profile/ciphertext/key material)');
@@ -1449,6 +1463,20 @@ function planLoad(inputPath, opts = {}) {
     }
 
     if (plan.entitlement_profile === 'account') {
+      if (isVerifiedExternalEntitlement(opts.entitlement)) {
+        plan.state = opts.entitlement.status === 'offline_grace' ? 'offline_grace' : 'ready';
+        plan.required_action = opts.entitlement.status === 'offline_grace' ? 'sync' : 'load';
+        plan.can_load_now = true;
+        plan.projection_policy = 'minimal';
+        if (opts.entitlement.status === 'offline_grace') {
+          plan.issues.push(buildLoadPlanIssue(
+            'KDNA_AUTH_OFFLINE_GRACE_ACTIVE',
+            'warning',
+            'The verified device grant can load offline but must sync before grace expires.',
+          ));
+        }
+        return finalizeLoadPlan(plan);
+      }
       plan.state = 'needs_account';
       plan.required_action = 'sign_in_or_activate';
       plan.can_load_now = false;
@@ -1462,6 +1490,13 @@ function planLoad(inputPath, opts = {}) {
     }
 
     if (plan.entitlement_profile === 'org') {
+      if (isVerifiedExternalEntitlement(opts.entitlement)) {
+        plan.state = opts.entitlement.status === 'offline_grace' ? 'offline_grace' : 'ready';
+        plan.required_action = opts.entitlement.status === 'offline_grace' ? 'sync' : 'load';
+        plan.can_load_now = true;
+        plan.projection_policy = 'minimal';
+        return finalizeLoadPlan(plan);
+      }
       plan.state = 'needs_org_auth';
       plan.required_action = 'sign_in_or_activate';
       plan.can_load_now = false;
@@ -1828,7 +1863,7 @@ function loadV1Unsafe(inputPath, opts = {}) {
         payload = parsePayloadEntry('payload.kdnab', decryptedBuf);
       } catch (e) {
         const err = new Error(`Decryption failed: ${e.message}`);
-        err.code = 'KDNA_DECRYPT_FAILED';
+        err.code = e.code || 'KDNA_DECRYPT_FAILED';
         throw err;
       }
     } else if (opts.password) {
@@ -1859,8 +1894,13 @@ function loadV1Unsafe(inputPath, opts = {}) {
         throw err;
       }
     } else {
-      const err = new Error('payload is encrypted and cannot be decrypted without a password or license key');
-      err.code = 'KDNA_AUTH_PASSWORD_REQUIRED';
+      const isExternal = payload.profile === EXTERNAL_ENVELOPE_PROFILE;
+      const err = new Error(
+        isExternal
+          ? 'payload requires a verified account/device external key grant'
+          : 'payload is encrypted and cannot be decrypted without an authorized credential',
+      );
+      err.code = isExternal ? 'KDNA_AUTH_ACCOUNT_REQUIRED' : 'KDNA_AUTH_PASSWORD_REQUIRED';
       throw err;
     }
   }

--- a/packages/kdna-core/test/external-key-grant.test.js
+++ b/packages/kdna-core/test/external-key-grant.test.js
@@ -14,16 +14,16 @@ function fixture() {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kdna-external-grant-'));
   const manifest = {
     kdna_version: '1.0',
-    asset_id: 'kdna:atomspeak:minimal-communication',
+    asset_id: 'kdna:fixture:external-grant',
     asset_uid: 'urn:uuid:18a3b84e-d8a9-4e22-b486-3d15132d389e',
-    name: '@atomspeak/minimal-communication',
+    name: '@fixture/external-grant',
     asset_type: 'domain',
-    title: 'AtomSpeak Minimal Communication',
-    version: '3.0.0',
-    judgment_version: '3.0.0',
+    title: 'External Grant Fixture',
+    version: '1.0.0',
+    judgment_version: '1.0.0',
     created_at: '2026-07-13T00:00:00Z',
     updated_at: '2026-07-13T00:00:00Z',
-    creator: { name: 'AtomSpeak' },
+    creator: { name: 'Fixture Publisher' },
     compatibility: { min_loader_version: '0.16.0', profile: 'judgment-profile-v1' },
     payload: { path: 'payload.kdnab', encoding: 'cbor', encrypted: true },
     access: 'licensed',
@@ -52,8 +52,8 @@ function fixture() {
     manifest,
     entryName: 'payload.kdnab',
     issuerRootKey: issuerRoot,
-    keyRef: 'assetkey:atomspeak:minimal-communication:3.0.0',
-    issuerKeyId: 'atomspeak-asset-root-test-v1',
+    keyRef: 'assetkey:fixture:external-grant:1.0.0',
+    issuerKeyId: 'fixture-asset-root-test-v1',
     iv: Buffer.alloc(12, 0x24),
   });
   const encodedEnvelope = core.encodeExternalEnvelope(envelope);
@@ -69,8 +69,8 @@ function fixture() {
   const grant = core.createExternalKeyGrant({
     issuerRootKey: issuerRoot,
     issuerSigningPrivateKey: signing.privateKey,
-    signingKeyId: 'atomspeak-grant-test-v1',
-    issuer: 'https://atomspeak.com',
+    signingKeyId: 'fixture-grant-test-v1',
+    issuer: 'https://issuer.example',
     entitlementId: 'ent_test_01',
     accountId: 'acct_test_01',
     deviceId: 'dev_test_01',
@@ -96,7 +96,7 @@ function fixture() {
     device,
     grant,
     signing,
-    issuerPublicKeys: { 'atomspeak-grant-test-v1': `ed25519:${signingPublic.x}` },
+    issuerPublicKeys: { 'fixture-grant-test-v1': `ed25519:${signingPublic.x}` },
   };
 }
 
@@ -190,8 +190,8 @@ test('invalid time windows and status rollback fail closed', () => {
       () => core.createExternalKeyGrant({
         issuerRootKey: f.issuerRoot,
         issuerSigningPrivateKey: f.signing.privateKey,
-        signingKeyId: 'atomspeak-grant-test-v1',
-        issuer: 'https://atomspeak.com',
+        signingKeyId: 'fixture-grant-test-v1',
+        issuer: 'https://issuer.example',
         entitlementId: 'ent_test_01',
         accountId: 'acct_test_01',
         deviceId: 'dev_test_01',
@@ -218,8 +218,8 @@ test('tampered, revoked, digest, version, and device mismatches fail closed', ()
     const revokedGrant = core.createExternalKeyGrant({
       issuerRootKey: f.issuerRoot,
       issuerSigningPrivateKey: f.signing.privateKey,
-      signingKeyId: 'atomspeak-grant-test-v1',
-      issuer: 'https://atomspeak.com',
+      signingKeyId: 'fixture-grant-test-v1',
+      issuer: 'https://issuer.example',
       entitlementId: 'ent_test_01',
       accountId: 'acct_test_01',
       deviceId: 'dev_test_01',
@@ -252,7 +252,7 @@ test('tampered, revoked, digest, version, and device mismatches fail closed', ()
       },
       {
         expected: 'KDNA_GRANT_ASSET_MISMATCH',
-        overrides: { manifest: { ...f.manifest, version: '3.0.1' } },
+        overrides: { manifest: { ...f.manifest, version: '1.0.1' } },
       },
       {
         expected: 'KDNA_GRANT_DEVICE_MISMATCH',

--- a/packages/kdna-core/test/external-key-grant.test.js
+++ b/packages/kdna-core/test/external-key-grant.test.js
@@ -123,6 +123,8 @@ test('external grant decrypts only after signed account/device authorization', (
   try {
     const session = authorize(f);
     assert.equal(session.entitlement.status, 'active');
+    assert.equal(Object.isFrozen(session.entitlement), true);
+    assert.equal(Object.isFrozen(session.entitlement.asset), true);
     assert.deepEqual(
       session.decryptEntry({
         entryName: 'payload.kdnab',
@@ -149,6 +151,37 @@ test('external grant decrypts only after signed account/device authorization', (
     session.dispose();
   } finally {
     fs.rmSync(f.tmp, { recursive: true, force: true });
+  }
+});
+
+test('a verified entitlement cannot make a different asset plan ready', () => {
+  const f = fixture();
+  const other = fs.mkdtempSync(path.join(os.tmpdir(), 'kdna-external-other-'));
+  try {
+    for (const name of fs.readdirSync(f.tmp)) {
+      fs.copyFileSync(path.join(f.tmp, name), path.join(other, name));
+    }
+    const manifestPath = path.join(other, 'kdna.json');
+    const otherManifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    otherManifest.asset_id = 'kdna:fixture:different-external-grant';
+    otherManifest.asset_uid = 'urn:uuid:18a3b84e-d8a9-4e22-b486-3d15132d3999';
+    otherManifest.name = '@fixture/different-external-grant';
+    otherManifest.version = '2.0.0';
+    fs.writeFileSync(manifestPath, JSON.stringify(otherManifest));
+    fs.writeFileSync(
+      path.join(other, 'checksums.json'),
+      JSON.stringify(core.buildChecksums(other)),
+    );
+
+    const session = authorize(f);
+    const plan = core.planLoad(other, { entitlement: session.entitlement });
+    assert.equal(plan.state, 'invalid');
+    assert.equal(plan.can_load_now, false);
+    assert.ok(plan.issues.some((issue) => issue.code === 'KDNA_GRANT_ASSET_MISMATCH'));
+    session.dispose();
+  } finally {
+    fs.rmSync(f.tmp, { recursive: true, force: true });
+    fs.rmSync(other, { recursive: true, force: true });
   }
 });
 

--- a/packages/kdna-core/test/external-key-grant.test.js
+++ b/packages/kdna-core/test/external-key-grant.test.js
@@ -1,0 +1,272 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const cbor = require('cbor-x');
+
+const core = require('../src');
+
+const NOW = new Date('2026-07-13T00:00:00Z');
+
+function fixture() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kdna-external-grant-'));
+  const manifest = {
+    kdna_version: '1.0',
+    asset_id: 'kdna:atomspeak:minimal-communication',
+    asset_uid: 'urn:uuid:18a3b84e-d8a9-4e22-b486-3d15132d389e',
+    name: '@atomspeak/minimal-communication',
+    asset_type: 'domain',
+    title: 'AtomSpeak Minimal Communication',
+    version: '3.0.0',
+    judgment_version: '3.0.0',
+    created_at: '2026-07-13T00:00:00Z',
+    updated_at: '2026-07-13T00:00:00Z',
+    creator: { name: 'AtomSpeak' },
+    compatibility: { min_loader_version: '0.16.0', profile: 'judgment-profile-v1' },
+    payload: { path: 'payload.kdnab', encoding: 'cbor', encrypted: true },
+    access: 'licensed',
+    entitlement: { profile: 'account', offline: true, revocable: true },
+    encryption: {
+      profile: core.EXTERNAL_ENVELOPE_PROFILE,
+      encrypted_entries: ['payload.kdnab'],
+      key_grant_profile: core.EXTERNAL_GRANT_PROFILE,
+    },
+  };
+  const payload = {
+    profile: 'judgment-profile-v1',
+    core: {
+      highest_question: 'How can I create room to choose before reacting?',
+      axioms: [{ id: 'A1', one_sentence: 'Pause before choosing.' }],
+      boundaries: ['Not medical care.'],
+    },
+    patterns: [],
+    scenarios: [],
+    cases: [],
+    reasoning: { self_check: ['Am I trying to control another person?'], failure_modes: [] },
+  };
+  const plaintext = Buffer.from(cbor.encode(payload));
+  const issuerRoot = Buffer.alloc(32, 0x42);
+  const envelope = core.encryptExternalGrantEntry(plaintext, {
+    manifest,
+    entryName: 'payload.kdnab',
+    issuerRootKey: issuerRoot,
+    keyRef: 'assetkey:atomspeak:minimal-communication:3.0.0',
+    issuerKeyId: 'atomspeak-asset-root-test-v1',
+    iv: Buffer.alloc(12, 0x24),
+  });
+  const encodedEnvelope = core.encodeExternalEnvelope(envelope);
+  fs.writeFileSync(path.join(tmp, 'mimetype'), core.MIMETYPE);
+  fs.writeFileSync(path.join(tmp, 'kdna.json'), JSON.stringify(manifest));
+  fs.writeFileSync(path.join(tmp, 'payload.kdnab'), encodedEnvelope);
+  const checksums = core.buildChecksums(tmp);
+  fs.writeFileSync(path.join(tmp, 'checksums.json'), JSON.stringify(checksums));
+
+  const device = core.generateDeviceKeyPairs();
+  const signing = crypto.generateKeyPairSync('ed25519');
+  const signingPublic = signing.publicKey.export({ format: 'jwk' });
+  const grant = core.createExternalKeyGrant({
+    issuerRootKey: issuerRoot,
+    issuerSigningPrivateKey: signing.privateKey,
+    signingKeyId: 'atomspeak-grant-test-v1',
+    issuer: 'https://atomspeak.com',
+    entitlementId: 'ent_test_01',
+    accountId: 'acct_test_01',
+    deviceId: 'dev_test_01',
+    devicePublicKey: device.agreement.public_key,
+    deviceSigningPublicKey: device.signing.public_key,
+    manifest,
+    envelope,
+    assetDigest: checksums.asset_digest,
+    issuedAt: NOW,
+    refreshAfter: new Date('2026-07-14T00:00:00Z'),
+    offlineGraceUntil: new Date('2026-07-20T00:00:00Z'),
+    expiresAt: new Date('2026-07-21T00:00:00Z'),
+    grantId: 'grt_test_01',
+  });
+  return {
+    tmp,
+    manifest,
+    plaintext,
+    envelope,
+    encodedEnvelope,
+    issuerRoot,
+    checksums,
+    device,
+    grant,
+    signing,
+    issuerPublicKeys: { 'atomspeak-grant-test-v1': `ed25519:${signingPublic.x}` },
+  };
+}
+
+function authorize(f, overrides = {}) {
+  return core.authorizeExternalKeyGrant({
+    grant: f.grant,
+    issuerPublicKeys: f.issuerPublicKeys,
+    manifest: f.manifest,
+    checksums: f.checksums,
+    envelope: f.encodedEnvelope,
+    deviceAgreementKey: f.device.agreement,
+    expectedAccountId: 'acct_test_01',
+    expectedDeviceId: 'dev_test_01',
+    expectedDeviceSigningPublicKey: f.device.signing.public_key,
+    now: NOW,
+    networkAvailable: false,
+    allowOffline: true,
+    ...overrides,
+  });
+}
+
+test('external grant decrypts only after signed account/device authorization', () => {
+  const f = fixture();
+  try {
+    const session = authorize(f);
+    assert.equal(session.entitlement.status, 'active');
+    assert.deepEqual(
+      session.decryptEntry({
+        entryName: 'payload.kdnab',
+        ciphertext: f.encodedEnvelope,
+        manifest: f.manifest,
+      }),
+      f.plaintext,
+    );
+
+    const plan = core.planLoad(f.tmp, { entitlement: session.entitlement });
+    assert.equal(plan.state, 'ready');
+    assert.equal(plan.can_load_now, true);
+
+    const capsule = core.loadAuthorized(f.tmp, {
+      profile: 'compact',
+      as: 'json',
+      entitlement: session.entitlement,
+      decryptEntry: session.decryptEntry,
+    });
+    assert.equal(capsule.type, 'kdna.context.capsule');
+    assert.equal(capsule.version, '1.0');
+    assert.equal(capsule.domain, f.manifest.name);
+    assert.equal(JSON.stringify(capsule).includes('wrapped_cek'), false);
+    session.dispose();
+  } finally {
+    fs.rmSync(f.tmp, { recursive: true, force: true });
+  }
+});
+
+test('plain active status cannot authorize an account asset', () => {
+  const f = fixture();
+  try {
+    const plan = core.planLoad(f.tmp, { entitlement: { status: 'active' } });
+    assert.equal(plan.state, 'needs_account');
+    assert.equal(plan.can_load_now, false);
+  } finally {
+    fs.rmSync(f.tmp, { recursive: true, force: true });
+  }
+});
+
+test('offline grace is explicit and hard expiry fails closed', () => {
+  const f = fixture();
+  try {
+    const offline = authorize(f, { now: new Date('2026-07-16T00:00:00Z') });
+    assert.equal(offline.entitlement.status, 'offline_grace');
+    assert.equal(core.planLoad(f.tmp, { entitlement: offline.entitlement }).state, 'offline_grace');
+    offline.dispose();
+    assert.throws(
+      () => authorize(f, { now: new Date('2026-07-22T00:00:00Z') }),
+      (error) => error.code === 'KDNA_GRANT_EXPIRED',
+    );
+  } finally {
+    fs.rmSync(f.tmp, { recursive: true, force: true });
+  }
+});
+
+test('invalid time windows and status rollback fail closed', () => {
+  const f = fixture();
+  try {
+    assert.throws(
+      () => authorize(f, { minimumStatusVersion: 2 }),
+      (error) => error.code === 'KDNA_GRANT_ROLLBACK_DETECTED',
+    );
+    assert.throws(
+      () => core.createExternalKeyGrant({
+        issuerRootKey: f.issuerRoot,
+        issuerSigningPrivateKey: f.signing.privateKey,
+        signingKeyId: 'atomspeak-grant-test-v1',
+        issuer: 'https://atomspeak.com',
+        entitlementId: 'ent_test_01',
+        accountId: 'acct_test_01',
+        deviceId: 'dev_test_01',
+        devicePublicKey: f.device.agreement.public_key,
+        deviceSigningPublicKey: f.device.signing.public_key,
+        manifest: f.manifest,
+        envelope: f.envelope,
+        assetDigest: f.checksums.asset_digest,
+        issuedAt: NOW,
+        refreshAfter: new Date('2026-07-16T00:00:00Z'),
+        offlineGraceUntil: new Date('2026-07-15T00:00:00Z'),
+        expiresAt: new Date('2026-07-21T00:00:00Z'),
+      }),
+      (error) => error.code === 'KDNA_GRANT_TIME_INVALID',
+    );
+  } finally {
+    fs.rmSync(f.tmp, { recursive: true, force: true });
+  }
+});
+
+test('tampered, revoked, digest, version, and device mismatches fail closed', () => {
+  const f = fixture();
+  try {
+    const revokedGrant = core.createExternalKeyGrant({
+      issuerRootKey: f.issuerRoot,
+      issuerSigningPrivateKey: f.signing.privateKey,
+      signingKeyId: 'atomspeak-grant-test-v1',
+      issuer: 'https://atomspeak.com',
+      entitlementId: 'ent_test_01',
+      accountId: 'acct_test_01',
+      deviceId: 'dev_test_01',
+      devicePublicKey: f.device.agreement.public_key,
+      deviceSigningPublicKey: f.device.signing.public_key,
+      manifest: f.manifest,
+      envelope: f.envelope,
+      assetDigest: f.checksums.asset_digest,
+      status: 'revoked',
+      issuedAt: NOW,
+      refreshAfter: new Date('2026-07-14T00:00:00Z'),
+      offlineGraceUntil: new Date('2026-07-20T00:00:00Z'),
+      expiresAt: new Date('2026-07-21T00:00:00Z'),
+      grantId: 'grt_revoked_01',
+    });
+    const cases = [
+      {
+        expected: 'KDNA_GRANT_SIGNATURE_INVALID',
+        overrides: { grant: { ...f.grant, account_id: 'acct_attacker' } },
+      },
+      {
+        expected: 'KDNA_GRANT_REVOKED',
+        overrides: { grant: revokedGrant },
+      },
+      {
+        expected: 'KDNA_GRANT_DIGEST_MISMATCH',
+        overrides: {
+          checksums: { ...f.checksums, asset_digest: `sha256:${'0'.repeat(64)}` },
+        },
+      },
+      {
+        expected: 'KDNA_GRANT_ASSET_MISMATCH',
+        overrides: { manifest: { ...f.manifest, version: '3.0.1' } },
+      },
+      {
+        expected: 'KDNA_GRANT_DEVICE_MISMATCH',
+        overrides: { deviceAgreementKey: core.generateDeviceKeyPairs().agreement },
+      },
+    ];
+    for (const item of cases) {
+      assert.throws(
+        () => authorize(f, item.overrides),
+        (error) => error.code === item.expected,
+        item.expected,
+      );
+    }
+  } finally {
+    fs.rmSync(f.tmp, { recursive: true, force: true });
+  }
+});

--- a/rfcs/RFC-0019-account-device-external-key-grant.md
+++ b/rfcs/RFC-0019-account-device-external-key-grant.md
@@ -1,0 +1,208 @@
+# RFC-0019: Account/device external key grants
+
+- Status: Draft
+- Profile: `kdna-envelope-external-grant-v1`
+- Grant: `kdna-key-grant-v1`
+- Applies to: `access: "licensed"` with `entitlement.profile: "account"` or `"org"`
+
+## 1. Problem and non-goals
+
+An immutable encrypted KDNA asset may be downloaded by many independent
+accounts. Each approved account and device needs a revocable authorization,
+without publishing one shared password or storing a content-encryption key
+(CEK) in the asset, application database, object metadata, logs, or traces.
+
+RFC-0018 derives a key-encryption key from a credential carried by a key slot.
+An account/device grant is not such a credential. Encoding it as a password
+slot would be a compatibility fiction and would permit unsafe fallback.
+Therefore this RFC defines a distinct envelope profile. A conforming runtime
+MUST NOT fall back from this profile to any password, recovery, license-key, or
+local-receipt profile.
+
+This RFC does not define account registration, application review policy, or
+password storage. Those belong to an identity provider and entitlement service.
+
+## 2. Threat model and invariants
+
+The issuer controls:
+
+1. a 256-bit asset root secret in a managed Secrets Store;
+2. an Ed25519 grant-signing key in a managed Secrets Store; and
+3. the entitlement and revocation database, which stores metadata only.
+
+The following are protocol invariants:
+
+- a raw or wrapped asset CEK MUST NOT be stored in the `.kdna` asset, ordinary
+  databases, R2 metadata, logs, traces, receipts, or CLI metadata files;
+- a device private key MUST remain in a platform SecretStore;
+- a grant MUST bind account, entitlement, device, asset UID, asset ID, content
+  version, canonical asset digest, encrypted entry, ciphertext digest, key
+  reference, and issuer key IDs;
+- every authorization or cryptographic mismatch MUST fail closed;
+- decrypted source exists only in process memory and MUST NOT be written to a
+  canonical or diagnostic file;
+- an agent receives only the normal Runtime Capsule.
+
+Compromise of a device private key exposes only grants issued to that device.
+Compromise of the application database does not expose CEKs or device private
+keys. Compromise of the issuer asset root can expose every asset derived under
+that root key ID and requires asset-root rotation plus asset re-encryption.
+
+## 3. Asset envelope
+
+The encrypted entry is deterministic CBOR containing the JSON presentation
+described by `specs/kdna-envelope-external-grant-v1.schema.json`.
+
+Required cryptographic values are:
+
+- `profile`: `kdna-envelope-external-grant-v1`
+- `alg`: `A256GCM`
+- `cek_derivation`: `HKDF-SHA256`
+- `key_ref`: opaque, non-secret asset key reference
+- `issuer_key_id`: selects the issuer asset root secret
+- `iv`: 12 random bytes, base64url without padding
+- `tag`: 16 bytes, base64url without padding
+- `ciphertext`: base64url without padding
+- `plaintext_digest`: `sha256:<lowercase hex>`
+
+### 3.1 CEK derivation
+
+Let `root` be the 32-byte issuer asset root secret. Let `binding` be the UTF-8
+bytes of the exact AAD in section 3.2.
+
+```text
+salt = SHA-256(binding)
+info = UTF-8("kdna-external-asset-cek-v1\n" + key_ref)
+CEK  = HKDF-SHA256(root, salt, info, 32)
+```
+
+The root and CEK are memory-only. `key_ref` and `issuer_key_id` are not secrets.
+
+### 3.2 AAD
+
+The exact UTF-8 AAD, with no trailing newline, is:
+
+```text
+kdna-envelope-external-grant-v1
+<asset_uid>
+<asset_id>
+<asset_version>
+<entry_path>
+<plaintext_digest>
+<key_ref>
+<issuer_key_id>
+licensed
+<entitlement_profile>
+```
+
+The canonical package `asset_digest` cannot appear in this AAD because it
+includes the encrypted entry and would create a digest cycle. The signed grant
+binds that final digest after packaging. The AAD instead binds immutable asset
+identity and the plaintext digest.
+
+## 4. Device keys and proof of possession
+
+Each CLI installation creates two independent key pairs:
+
+- X25519 key agreement, used only to unwrap a device grant;
+- Ed25519 signing, used for activation and sync proof of possession.
+
+Public keys use raw 32-byte base64url values prefixed with `x25519:` or
+`ed25519:`. Private keys MUST be non-exportable where the platform supports it;
+otherwise their encoded value MUST be held only by the platform SecretStore.
+Machine fingerprints are not cryptographic device identity for this profile.
+
+An activation or sync endpoint MUST issue a single-use random challenge and
+verify an Ed25519 signature over the endpoint-defined canonical request before
+issuing a grant. Challenges MUST expire, be transaction-bound, and be consumed
+atomically.
+
+## 5. Signed key grant
+
+`kdna-key-grant-v1` uses the schema in
+`specs/kdna-key-grant-v1.schema.json`. The signature input is UTF-8 canonical
+JSON with recursively lexicographically sorted object keys, no insignificant
+whitespace, and the `signature` member omitted. Array order is preserved.
+
+The issuer:
+
+1. verifies the account entitlement is active and the device is authorized;
+2. derives the asset CEK in memory using section 3.1;
+3. generates an ephemeral X25519 key pair;
+4. computes `shared = X25519(ephemeral_private, device_public)`;
+5. derives `KEK = HKDF-SHA256(shared, wrap.salt,
+   UTF-8("kdna-device-grant-kek-v1\n" + grant_id), 32)`;
+6. wraps the 32-byte CEK using AES-256-KW (RFC 3394);
+7. destroys the CEK, KEK, shared secret, and ephemeral private key; and
+8. signs the grant with Ed25519.
+
+The grant contains `refresh_after`, `offline_grace_until`, and `expires_at`.
+Before `refresh_after`, an active grant is loadable. After `refresh_after`, an
+online runtime MUST sync. An offline runtime MAY load only when offline use was
+requested and the current time is no later than both `offline_grace_until` and
+`expires_at`. `expires_at` is a hard stop.
+
+`status` MUST be `active` to load. `revoked`, `expired`, unknown status, invalid
+signature, unknown issuer key ID, stale status version, or any binding mismatch
+MUST fail closed. A service SHOULD keep grants short-lived and revocation checks
+more frequent than the maximum offline grace.
+
+`status_version` is a per-entitlement monotonic counter. A client MUST retain
+the greatest verified value in its platform SecretStore and reject any later
+grant with a smaller value. Resetting or removing that state requires an
+explicit local entitlement removal and a new device activation. A client MUST
+also retain the greatest verified local time and reject a material clock
+rollback; implementations MAY allow at most five minutes of clock skew. These
+checks prevent replay of an older, otherwise correctly signed grant.
+
+## 6. Runtime verification order
+
+A runtime MUST perform these checks before plaintext parsing:
+
+1. validate envelope and grant schemas with unknown fields rejected;
+2. resolve a pinned issuer public key by `signing_key_id`;
+3. verify the Ed25519 grant signature;
+4. verify grant status, time window, monotonic status version, and local clock;
+5. compare account/device expectations, including both device public keys;
+6. compare manifest asset ID, UID, version, access, entitlement profile, entry
+   path, `checksums.json.asset_digest`, and ciphertext SHA-256;
+7. derive the device KEK and AES-KW unwrap the CEK;
+8. verify the envelope AAD and AES-GCM tag;
+9. verify `plaintext_digest`; and
+10. parse the payload and emit a Runtime Capsule.
+
+No step may be skipped because a caller supplies `status: active`. A LoadPlan may
+report `ready` for an account profile only when produced from a verified,
+in-memory external-grant session. A plain status string is diagnostic only and
+MUST NOT authorize account assets.
+
+## 7. Rotation and revocation
+
+Credential rotation invalidates the old activation credential immediately and
+does not reveal the replacement after its one-time response. Device grants are
+independent of that credential and remain bounded by their signed refresh and
+expiry window.
+
+Entitlement or device revocation prevents new grants immediately. A successful
+sync installs a signed `revoked` status response or removes the local grant. An
+offline device can continue only inside an already-issued offline window; this
+is the explicit availability/revocation trade-off and MUST be visible to the
+reviewer when configuring policy.
+
+Issuer grant-signing keys rotate by publishing a new pinned public key ID while
+retaining old public keys until all grants they signed expire. Asset-root
+rotation is separate: it changes `issuer_key_id`, re-encrypts the asset, changes
+the canonical asset digest, and requires new grants.
+
+## 8. Privacy and observability
+
+Logs and traces may include opaque account, entitlement, device, grant, and
+asset IDs, status, timestamps, and error codes. They MUST NOT include activation
+credentials, challenges, proof signatures, private keys, CEKs, KEKs, shared
+secrets, wrapped CEKs, envelope plaintext, or full grants.
+
+Implementations SHOULD expose stable error codes such as
+`KDNA_GRANT_SIGNATURE_INVALID`, `KDNA_GRANT_REVOKED`, `KDNA_GRANT_EXPIRED`,
+`KDNA_GRANT_DEVICE_MISMATCH`, `KDNA_GRANT_ASSET_MISMATCH`, and
+`KDNA_GRANT_DIGEST_MISMATCH`, while keeping cryptographic provider error bodies
+out of public output.

--- a/scripts/generate-external-grant-fixtures.js
+++ b/scripts/generate-external-grant-fixtures.js
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+
+/** Generates deterministic, public test-only RFC-0019 fixtures. */
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+const cbor = require('cbor-x');
+const core = require('../packages/kdna-core/src');
+
+const outDir = path.join(__dirname, '..', 'conformance', 'kdna-external-grant-v1');
+const negativeDir = path.join(outDir, 'negative');
+
+function privateKeyFromSeed(type, seedByte) {
+  const oid = type === 'ed25519' ? '2b6570' : '2b656e';
+  const prefix = Buffer.from(`302e02010030050603${oid}04220420`, 'hex');
+  return crypto.createPrivateKey({
+    key: Buffer.concat([prefix, Buffer.alloc(32, seedByte)]),
+    format: 'der',
+    type: 'pkcs8',
+  });
+}
+
+function keyPair(type, seedByte) {
+  const privateKey = privateKeyFromSeed(type, seedByte);
+  return { privateKey, publicKey: crypto.createPublicKey(privateKey) };
+}
+
+function write(name, value) {
+  fs.writeFileSync(path.join(outDir, name), `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function writeNegative(name, value) {
+  fs.writeFileSync(path.join(negativeDir, name), `${JSON.stringify(value, null, 2)}\n`);
+}
+
+fs.mkdirSync(negativeDir, { recursive: true });
+
+const manifest = {
+  kdna_version: '1.0',
+  asset_id: 'kdna:fixture:external-grant',
+  asset_uid: 'urn:uuid:00190000-0000-4000-8000-000000000001',
+  name: '@fixture/external-grant',
+  asset_type: 'fixture',
+  title: 'External Grant Fixture',
+  version: '1.0.0',
+  judgment_version: '1.0.0',
+  created_at: '2026-07-13T00:00:00Z',
+  updated_at: '2026-07-13T00:00:00Z',
+  creator: { name: 'KDNA Conformance' },
+  compatibility: { min_loader_version: '0.16.0', profile: 'judgment-profile-v1' },
+  payload: { path: 'payload.kdnab', encoding: 'cbor', encrypted: true },
+  access: 'licensed',
+  entitlement: { profile: 'account', offline: true, revocable: true },
+  encryption: {
+    profile: core.EXTERNAL_ENVELOPE_PROFILE,
+    encrypted_entries: ['payload.kdnab'],
+    key_grant_profile: core.EXTERNAL_GRANT_PROFILE,
+  },
+};
+const plaintext = Buffer.from(cbor.encode({
+  profile: 'judgment-profile-v1',
+  core: { highest_question: 'Can this device decrypt?', axioms: [] },
+}));
+const root = Buffer.alloc(32, 0x19);
+const deviceAgreement = keyPair('x25519', 0x21);
+const deviceSigning = keyPair('ed25519', 0x22);
+const ephemeral = keyPair('x25519', 0x23);
+const issuerSigning = keyPair('ed25519', 0x24);
+const agreementPublic = deviceAgreement.publicKey.export({ format: 'jwk' }).x;
+const agreementPrivate = deviceAgreement.privateKey.export({ format: 'jwk' }).d;
+const deviceSigningPublic = deviceSigning.publicKey.export({ format: 'jwk' }).x;
+const issuerSigningPublic = issuerSigning.publicKey.export({ format: 'jwk' }).x;
+const envelope = core.encryptExternalGrantEntry(plaintext, {
+  manifest,
+  issuerRootKey: root,
+  keyRef: 'assetkey:fixture:external-grant:1.0.0',
+  issuerKeyId: 'fixture-asset-root-v1',
+  iv: Buffer.alloc(12, 0x25),
+});
+const encodedEnvelope = core.encodeExternalEnvelope(envelope);
+const manifestBytes = Buffer.from(JSON.stringify(manifest));
+const entries = {
+  'kdna.json': crypto.createHash('sha256').update(manifestBytes).digest('hex'),
+  'payload.kdnab': crypto.createHash('sha256').update(encodedEnvelope).digest('hex'),
+};
+const combined = Object.keys(entries).sort().map((name) => `${name}:${entries[name]}`).join('\n');
+const checksums = {
+  algorithm: 'sha256',
+  manifest_digest: `sha256:${entries['kdna.json']}`,
+  payload_digest: `sha256:${entries['payload.kdnab']}`,
+  asset_digest: `sha256:${crypto.createHash('sha256').update(combined).digest('hex')}`,
+  entries: Object.fromEntries(Object.entries(entries).map(([name, value]) => [name, { algorithm: 'sha256', value }])),
+};
+
+function makeGrant(overrides = {}) {
+  return core.createExternalKeyGrant({
+    issuerRootKey: root,
+    issuerSigningPrivateKey: issuerSigning.privateKey,
+    signingKeyId: 'fixture-grant-signing-v1',
+    issuer: 'https://fixture.invalid',
+    entitlementId: 'ent_fixture_01',
+    accountId: 'acct_fixture_01',
+    deviceId: 'dev_fixture_01',
+    devicePublicKey: `x25519:${agreementPublic}`,
+    deviceSigningPublicKey: `ed25519:${deviceSigningPublic}`,
+    manifest,
+    envelope,
+    assetDigest: checksums.asset_digest,
+    issuedAt: new Date('2026-07-13T00:00:00Z'),
+    refreshAfter: new Date('2026-07-14T00:00:00Z'),
+    offlineGraceUntil: new Date('2026-07-20T00:00:00Z'),
+    expiresAt: new Date('2026-07-21T00:00:00Z'),
+    grantId: overrides.grantId || 'grt_fixture_01',
+    status: overrides.status || 'active',
+    ephemeralKeyPair: ephemeral,
+    wrapSalt: Buffer.alloc(16, overrides.saltByte || 0x26),
+  });
+}
+
+const grant = makeGrant();
+write('golden.json', {
+  note: 'All key material in this fixture is deterministic and test-only.',
+  manifest,
+  plaintext_cbor: plaintext.toString('base64url'),
+  envelope,
+  envelope_cbor: encodedEnvelope.toString('base64url'),
+  checksums,
+  grant,
+  test_keys: {
+    issuer_root: root.toString('base64url'),
+    issuer_signing_public_key: `ed25519:${issuerSigningPublic}`,
+    device_agreement_public_key: `x25519:${agreementPublic}`,
+    device_agreement_private_key: `x25519:${agreementPrivate}`,
+    device_signing_public_key: `ed25519:${deviceSigningPublic}`,
+  },
+});
+
+writeNegative('tampered-signature.json', {
+  expected_error: 'KDNA_GRANT_SIGNATURE_INVALID',
+  grant: { ...grant, account_id: 'acct_tampered' },
+});
+writeNegative('revoked.json', {
+  expected_error: 'KDNA_GRANT_REVOKED',
+  grant: makeGrant({ status: 'revoked', grantId: 'grt_fixture_revoked', saltByte: 0x27 }),
+});
+writeNegative('asset-version-mismatch.json', {
+  expected_error: 'KDNA_GRANT_ASSET_MISMATCH',
+  manifest: { ...manifest, version: '1.0.1' },
+  grant,
+});
+writeNegative('asset-digest-mismatch.json', {
+  expected_error: 'KDNA_GRANT_DIGEST_MISMATCH',
+  checksums: { ...checksums, asset_digest: `sha256:${'0'.repeat(64)}` },
+  grant,
+});
+writeNegative('device-mismatch.json', {
+  expected_error: 'KDNA_GRANT_DEVICE_MISMATCH',
+  expected_device_id: 'dev_other',
+  grant,
+});

--- a/scripts/generate-external-grant-fixtures.js
+++ b/scripts/generate-external-grant-fixtures.js
@@ -58,10 +58,12 @@ const manifest = {
     key_grant_profile: core.EXTERNAL_GRANT_PROFILE,
   },
 };
-const plaintext = Buffer.from(cbor.encode({
-  profile: 'judgment-profile-v1',
-  core: { highest_question: 'Can this device decrypt?', axioms: [] },
-}));
+const plaintext = Buffer.from(
+  cbor.encode({
+    profile: 'judgment-profile-v1',
+    core: { highest_question: 'Can this device decrypt?', axioms: [] },
+  }),
+);
 const root = Buffer.alloc(32, 0x19);
 const deviceAgreement = keyPair('x25519', 0x21);
 const deviceSigning = keyPair('ed25519', 0x22);
@@ -84,13 +86,18 @@ const entries = {
   'kdna.json': crypto.createHash('sha256').update(manifestBytes).digest('hex'),
   'payload.kdnab': crypto.createHash('sha256').update(encodedEnvelope).digest('hex'),
 };
-const combined = Object.keys(entries).sort().map((name) => `${name}:${entries[name]}`).join('\n');
+const combined = Object.keys(entries)
+  .sort()
+  .map((name) => `${name}:${entries[name]}`)
+  .join('\n');
 const checksums = {
   algorithm: 'sha256',
   manifest_digest: `sha256:${entries['kdna.json']}`,
   payload_digest: `sha256:${entries['payload.kdnab']}`,
   asset_digest: `sha256:${crypto.createHash('sha256').update(combined).digest('hex')}`,
-  entries: Object.fromEntries(Object.entries(entries).map(([name, value]) => [name, { algorithm: 'sha256', value }])),
+  entries: Object.fromEntries(
+    Object.entries(entries).map(([name, value]) => [name, { algorithm: 'sha256', value }]),
+  ),
 };
 
 function makeGrant(overrides = {}) {

--- a/scripts/run-node-tests.js
+++ b/scripts/run-node-tests.js
@@ -31,6 +31,15 @@ if (files.length === 0) {
 
 const result = spawnSync(process.execPath, ['--test', ...files], {
   stdio: 'inherit',
+  env: {
+    ...process.env,
+    NODE_OPTIONS: [
+      process.env.NODE_OPTIONS,
+      `--require=${path.join(__dirname, 'use-workspace-core.js')}`,
+    ]
+      .filter(Boolean)
+      .join(' '),
+  },
 });
 
 process.exit(result.status === null ? 1 : result.status);

--- a/scripts/use-workspace-core.js
+++ b/scripts/use-workspace-core.js
@@ -1,0 +1,27 @@
+'use strict';
+
+// Monorepo end-to-end tests exercise the candidate Core workspace even when
+// an already-published CLI package still declares the previous Core version.
+// This avoids circular release ordering without changing any published
+// consumer dependency or accepting a local file dependency in a package.
+
+const Module = require('node:module');
+const path = require('node:path');
+
+const packageName = '@aikdna/kdna-core';
+const packageRoot = path.join(__dirname, '..', 'packages', 'kdna-core');
+const originalResolveFilename = Module._resolveFilename;
+
+Module._resolveFilename = function resolveWorkspaceCore(request, parent, isMain, options) {
+  if (request === packageName) {
+    return path.join(packageRoot, 'src', 'index.js');
+  }
+  if (request === `${packageName}/package.json`) {
+    return path.join(packageRoot, 'package.json');
+  }
+  if (request.startsWith(`${packageName}/`)) {
+    const localRequest = path.join(packageRoot, request.slice(packageName.length + 1));
+    return originalResolveFilename.call(this, localRequest, parent, isMain, options);
+  }
+  return originalResolveFilename.call(this, request, parent, isMain, options);
+};

--- a/specs/kdna-authorization-contract.md
+++ b/specs/kdna-authorization-contract.md
@@ -1,7 +1,7 @@
 # KDNA Authorization Contract
 
-Status: Candidate — normative for the implemented JS Core/CLI subset.
-Swift Core and Chat implementations are pending.
+Status: Candidate — normative for the implemented JS Core/CLI/Swift subset.
+Chat implementation is pending.
 Normative: Yes  
 Related schema: `../schema/load-plan.schema.json`  
 Related specs: `kdna-crypto-profiles.md`, `kdna-secret-store.md`,
@@ -46,10 +46,10 @@ permission and decryption material.
 |---|---|---|
 | `password` | Implemented (JS Core/CLI) | User passphrase unlocks a protected local asset. |
 | `local_receipt` | Implemented (JS Core; CLI delegates to Core) | Signed local receipt authorizes loading. |
-| `account` | Future | Account entitlement service authorizes loading. |
+| `account` | Implemented (JS Core/CLI/Swift) | Account service authorizes a device-bound external key grant under RFC-0019. |
 | `org` | Future | Organization or SSO claims authorize loading. |
 | `purchase_receipt` | Future | Third-party purchase receipt is exchanged for entitlement. |
-| `device_bound` | Future | Receipt/key grant is bound to a device keypair. |
+| `device_bound` | Superseded as a standalone profile | Device binding is a required mechanism of the RFC-0019 `account` flow, not a password fallback or separate entitlement identity. |
 
 Unknown entitlement profiles MUST fail closed with
 `KDNA_ENTITLEMENT_PROFILE_UNKNOWN`.
@@ -108,6 +108,11 @@ Minimum required actions:
 Current JS Core may expose a narrower v0.1 subset while the full schema is
 expanded. It MUST remain fail-closed for states it cannot evaluate.
 
+For RFC-0019 account assets, a plain object that claims `status: active` is not
+authorization. Only a grant whose signature, time bounds, account, device,
+asset identity, version, digest, encrypted entry, and key wrapping have been
+verified by Core can move a LoadPlan to `ready` or `offline_grace`.
+
 ## 6. Stable Issue Codes
 
 Implementations MUST use stable issue codes for localization, diagnostics, and
@@ -158,6 +163,11 @@ Entitlement records SHOULD include:
 
 Entitlement secrets MUST NOT be logged, included in traces, exported reports,
 screenshots, or debug diagnostics.
+
+An external grant MUST NOT contain the issuer root or the asset CEK. Core MUST
+unwrap the CEK only in memory, zeroize it when the authorization session is
+disposed, and return only a Runtime Capsule to Agent-facing consumers. The
+account flow MUST NOT fall back to the password profile.
 
 ## 8. Revocation
 

--- a/specs/kdna-entitlement-api.md
+++ b/specs/kdna-entitlement-api.md
@@ -1,7 +1,7 @@
 # KDNA Entitlement API
 
-Version: 0.1
-Status: Draft / CLI MVP implemented
+Version: 0.2
+Status: Draft / legacy receipt and RFC-0019 account-device subsets implemented
 
 This specification defines the production contract for activating, syncing,
 revoking, and auditing licensed KDNA assets.
@@ -33,6 +33,11 @@ outside the asset, for example:
 ~/.kdna/licenses/<scope-name>.json
 ```
 
+The legacy receipt contract below remains supported for existing license-key
+assets. Account/device encrypted assets use the separate RFC-0019 external key
+grant flow in Section 11. The two flows are not wire-compatible, and account
+assets MUST NOT silently fall back to the legacy password/receipt profile.
+
 ## 2. Security Rules
 
 Clients and servers MUST follow these rules:
@@ -61,6 +66,12 @@ kdna license install <license.json>
 
 `--server <url>` is an exact activation or sync endpoint URL. For local testing,
 the CLI MAY also accept a `file://` entitlement fixture.
+
+For RFC-0019 account/device assets, the preferred activation command opens the
+issuer's browser flow and keeps device private keys in the platform
+SecretStore. A headless client may read a one-time activation credential from
+standard input. It MUST NOT accept that credential as an ordinary command-line
+argument.
 
 ## 4. Activation Request
 
@@ -169,6 +180,12 @@ Local fixture files MAY contain:
 | `offline_grace_days` | Yes if online check required | Number of days after successful sync before fail-closed. |
 | `allowed_agents` | Recommended | Agent/client allowlist. |
 | `activation_server` | Recommended | Endpoint used for future activation refresh. |
+
+For `kdna-key-grant-v1`, clients persist the highest verified
+`status_version` and greatest verified wall-clock value in their platform
+SecretStore. A lower status version or material clock rollback fails closed;
+removing the local entitlement is the only supported reset before a new device
+activation.
 | `sync_server` | Recommended | Endpoint used for entitlement sync. |
 
 If `require_online_check` is missing in a production response, clients SHOULD
@@ -411,3 +428,37 @@ kdna license sync @aikdna/writing_pro \
   --server https://license.example.com/v1/entitlements/sync
 ```
 
+## 13. Account/Device External Key Grant
+
+An account/device issuer exposes a device authorization flow under its versioned
+API namespace:
+
+```text
+POST device-activations
+→ user verifies the displayed code in a signed-in browser
+→ POST device-activations/{id}/poll with a signed device proof
+→ signed kdna-key-grant-v1
+```
+
+Subsequent synchronization uses a server challenge and a signed proof from the
+same device signing key. A successful response returns a replacement signed
+grant. A revoked account, entitlement, device, expired challenge, device-limit
+violation, or mismatched proof MUST fail closed.
+
+The grant and encrypted asset contracts are defined by RFC-0019 and:
+
+- `kdna-key-grant-v1.schema.json`;
+- `kdna-envelope-external-grant-v1.schema.json`;
+- `../conformance/kdna-external-grant-v1/`.
+
+The issuer derives the asset CEK only inside its trusted key boundary and wraps
+it to the requesting device's public agreement key. The CEK MUST NOT be stored
+in the asset, entitlement database, object metadata, audit event, log, or
+Trace. The client stores device private keys and the current grant in a secure
+SecretStore; public status metadata may contain only identifiers, public keys,
+time bounds, and secret references.
+
+Core verifies the signed grant and every account/device/asset binding before it
+unwraps in memory. Revoked, expired, tampered, digest-mismatched,
+version-mismatched, or device-mismatched grants MUST fail closed. Agent-facing
+integrations receive only the Runtime Capsule.

--- a/specs/kdna-envelope-external-grant-v1.schema.json
+++ b/specs/kdna-envelope-external-grant-v1.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kdna.ai/specs/kdna-envelope-external-grant-v1.schema.json",
+  "title": "KDNA external grant envelope v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "profile",
+    "alg",
+    "cek_derivation",
+    "key_ref",
+    "issuer_key_id",
+    "entry_path",
+    "plaintext_digest",
+    "iv",
+    "tag",
+    "ciphertext"
+  ],
+  "properties": {
+    "profile": { "const": "kdna-envelope-external-grant-v1" },
+    "alg": { "const": "A256GCM" },
+    "cek_derivation": { "const": "HKDF-SHA256" },
+    "key_ref": { "type": "string", "minLength": 1, "maxLength": 256 },
+    "issuer_key_id": { "type": "string", "minLength": 1, "maxLength": 128 },
+    "entry_path": { "type": "string", "pattern": "^[^/].*[^/]$|^[^/]$", "maxLength": 256 },
+    "plaintext_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "iv": { "type": "string", "pattern": "^[A-Za-z0-9_-]{16}$" },
+    "tag": { "type": "string", "pattern": "^[A-Za-z0-9_-]{22}$" },
+    "ciphertext": { "type": "string", "minLength": 1, "pattern": "^[A-Za-z0-9_-]+$" }
+  }
+}

--- a/specs/kdna-key-grant-v1.schema.json
+++ b/specs/kdna-key-grant-v1.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kdna.ai/specs/kdna-key-grant-v1.schema.json",
+  "title": "KDNA account/device external key grant v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "profile", "grant_id", "issuer", "signing_key_id", "entitlement_id",
+    "account_id", "device_id", "device_public_key", "device_signing_public_key",
+    "asset", "issued_at", "refresh_after", "offline_grace_until", "expires_at",
+    "status", "status_version", "wrap", "signature"
+  ],
+  "properties": {
+    "profile": { "const": "kdna-key-grant-v1" },
+    "grant_id": { "$ref": "#/$defs/id" },
+    "issuer": { "type": "string", "format": "uri", "maxLength": 256 },
+    "signing_key_id": { "$ref": "#/$defs/id" },
+    "entitlement_id": { "$ref": "#/$defs/id" },
+    "account_id": { "$ref": "#/$defs/id" },
+    "device_id": { "$ref": "#/$defs/id" },
+    "device_public_key": { "type": "string", "pattern": "^x25519:[A-Za-z0-9_-]{43}$" },
+    "device_signing_public_key": { "type": "string", "pattern": "^ed25519:[A-Za-z0-9_-]{43}$" },
+    "asset": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "asset_id", "asset_uid", "version", "digest", "entry_path",
+        "ciphertext_digest", "key_ref", "issuer_key_id"
+      ],
+      "properties": {
+        "asset_id": { "type": "string", "minLength": 1, "maxLength": 256 },
+        "asset_uid": { "type": "string", "minLength": 1, "maxLength": 512 },
+        "version": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "digest": { "$ref": "#/$defs/digest" },
+        "entry_path": { "type": "string", "minLength": 1, "maxLength": 256 },
+        "ciphertext_digest": { "$ref": "#/$defs/digest" },
+        "key_ref": { "type": "string", "minLength": 1, "maxLength": 256 },
+        "issuer_key_id": { "$ref": "#/$defs/id" }
+      }
+    },
+    "issued_at": { "type": "string", "format": "date-time" },
+    "refresh_after": { "type": "string", "format": "date-time" },
+    "offline_grace_until": { "type": "string", "format": "date-time" },
+    "expires_at": { "type": "string", "format": "date-time" },
+    "status": { "enum": ["active", "revoked", "expired"] },
+    "status_version": { "type": "integer", "minimum": 1 },
+    "wrap": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["alg", "ephemeral_public_key", "salt", "wrapped_cek"],
+      "properties": {
+        "alg": { "const": "X25519-HKDF-SHA256+A256KW" },
+        "ephemeral_public_key": { "type": "string", "pattern": "^x25519:[A-Za-z0-9_-]{43}$" },
+        "salt": { "type": "string", "pattern": "^[A-Za-z0-9_-]{22}$" },
+        "wrapped_cek": { "type": "string", "pattern": "^[A-Za-z0-9_-]{54}$" }
+      }
+    },
+    "signature": { "type": "string", "pattern": "^ed25519:[A-Za-z0-9_-]{86}$" }
+  },
+  "$defs": {
+    "id": { "type": "string", "pattern": "^[A-Za-z0-9._:@/-]{1,256}$" },
+    "digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" }
+  }
+}

--- a/specs/kdna-key-grant-v1.schema.json
+++ b/specs/kdna-key-grant-v1.schema.json
@@ -5,10 +5,24 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "profile", "grant_id", "issuer", "signing_key_id", "entitlement_id",
-    "account_id", "device_id", "device_public_key", "device_signing_public_key",
-    "asset", "issued_at", "refresh_after", "offline_grace_until", "expires_at",
-    "status", "status_version", "wrap", "signature"
+    "profile",
+    "grant_id",
+    "issuer",
+    "signing_key_id",
+    "entitlement_id",
+    "account_id",
+    "device_id",
+    "device_public_key",
+    "device_signing_public_key",
+    "asset",
+    "issued_at",
+    "refresh_after",
+    "offline_grace_until",
+    "expires_at",
+    "status",
+    "status_version",
+    "wrap",
+    "signature"
   ],
   "properties": {
     "profile": { "const": "kdna-key-grant-v1" },
@@ -24,8 +38,14 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "asset_id", "asset_uid", "version", "digest", "entry_path",
-        "ciphertext_digest", "key_ref", "issuer_key_id"
+        "asset_id",
+        "asset_uid",
+        "version",
+        "digest",
+        "entry_path",
+        "ciphertext_digest",
+        "key_ref",
+        "issuer_key_id"
       ],
       "properties": {
         "asset_id": { "type": "string", "minLength": 1, "maxLength": 256 },


### PR DESCRIPTION
## Summary
- define RFC-0019 as a distinct account/device external-grant profile
- add strict envelope/grant schemas, golden and negative fixtures
- implement JS verification, in-memory unwrap/decrypt, rollback checks, and LoadPlan gating
- provide no password, receipt, or shared-secret fallback

## Verification
- Core: 30 total, 24 passed, 6 existing gated skips, 0 failed
- RFC-0019 focused: 5/5 passed
- package dry run includes the implementation and both schemas

## Release note
Draft only. The package still carries the released version and must receive a new reviewed version before publication. Merge/publish Core before dependent CLI and Swift consumers.