### PR TITLE
Release compatibility package 0.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@aikdna/kdna-cli": "^0.30.4",
+        "@aikdna/kdna-cli": "^0.31.0",
         "@eslint/js": "^10.0.1",
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
@@ -29,12 +29,12 @@
       "link": true
     },
     "node_modules/@aikdna/kdna-cli": {
-      "version": "0.30.4",
-      "resolved": "https://registry.npmjs.org/@aikdna/kdna-cli/-/kdna-cli-0.30.4.tgz",
-      "integrity": "sha512-DqXyLAG28ZEGSpjvgYF5rOA1Kqpe1XDzfNv2H+uODxzuR7U9F7Ng3Nc7g3V06OC2lFNtebXD/kOsRg765GD7XA==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@aikdna/kdna-cli/-/kdna-cli-0.31.0.tgz",
+      "integrity": "sha512-r1P3YHDaaFJjUVVm2un5u44LWBgkLEX1KwS6nF8DsKypC2lis+SYVKUzYvK8tdh7DXhu2TSuY152P+KuSv8CyA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aikdna/kdna-core": "0.15.12",
+        "@aikdna/kdna-core": "0.16.0",
         "@aikdna/kdna-eval": "0.3.1"
       },
       "bin": {
@@ -49,33 +49,6 @@
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
         "cbor-x": "^1.6.4"
-      }
-    },
-    "node_modules/@aikdna/kdna-cli/node_modules/@aikdna/kdna-core": {
-      "version": "0.15.12",
-      "resolved": "https://registry.npmjs.org/@aikdna/kdna-core/-/kdna-core-0.15.12.tgz",
-      "integrity": "sha512-5P5ccscpJmg4Ih1IjIDpfQ34rGdOMEOf57l2SNeUblN6hcrtNJFhCo/+0gjNxZ2YezccYqBpcRTHHVVgGY17lQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/hashes": "^1.8.0",
-        "ajv": "^8.20.0",
-        "ajv-formats": "^3.0.1",
-        "cbor-x": "^1.6.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        },
-        "ajv-formats": {
-          "optional": true
-        }
       }
     },
     "node_modules/@aikdna/kdna-core": {
@@ -1794,11 +1767,11 @@
     },
     "packages/kdna": {
       "name": "@aikdna/kdna",
-      "version": "0.10.6",
+      "version": "0.11.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aikdna/kdna-cli": "^0.30.4",
-        "@aikdna/kdna-core": "^0.15.12"
+        "@aikdna/kdna-cli": "^0.31.0",
+        "@aikdna/kdna-core": "^0.16.0"
       },
       "bin": {
         "kdna-lint": "bin/kdna-lint.js",
@@ -1854,33 +1827,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "packages/kdna/node_modules/@aikdna/kdna-core": {
-      "version": "0.15.12",
-      "resolved": "https://registry.npmjs.org/@aikdna/kdna-core/-/kdna-core-0.15.12.tgz",
-      "integrity": "sha512-5P5ccscpJmg4Ih1IjIDpfQ34rGdOMEOf57l2SNeUblN6hcrtNJFhCo/+0gjNxZ2YezccYqBpcRTHHVVgGY17lQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/hashes": "^1.8.0",
-        "ajv": "^8.20.0",
-        "ajv-formats": "^3.0.1",
-        "cbor-x": "^1.6.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        },
-        "ajv-formats": {
-          "optional": true
-        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "packages/*"
   ],
   "devDependencies": {
-    "@aikdna/kdna-cli": "^0.30.4",
+    "@aikdna/kdna-cli": "^0.31.0",
     "@eslint/js": "^10.0.1",
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",

--- a/packages/kdna/CHANGELOG.md
+++ b/packages/kdna/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.11.0 (2026-07-13)
+
+- Track KDNA Core 0.16.0 and CLI 0.31.0 so compatibility installs use the
+  account/device entitlement runtime and current Runtime Capsule contract.
+- Preserve the package as executable-name compatibility only; it does not
+  introduce another KDNA format or direct container-consumption path.
+
 ## 0.10.6 (2026-07-13)
 
 - Make the legacy `kdna-validate` executable delegate to the current

--- a/packages/kdna/package.json
+++ b/packages/kdna/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aikdna/kdna",
-  "version": "0.10.6",
+  "version": "0.11.0",
   "description": "KDNA toolkit compatibility package. The kdna CLI binary has moved to @aikdna/kdna-cli \u2014 use npm install -g @aikdna/kdna-cli.",
   "type": "commonjs",
   "bin": {
@@ -38,7 +38,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@aikdna/kdna-cli": "^0.30.4",
-    "@aikdna/kdna-core": "^0.15.12"
+    "@aikdna/kdna-cli": "^0.31.0",
+    "@aikdna/kdna-core": "^0.16.0"
   }
 }

--- a/tests/cli-v1/v1-cli-subprocess.test.js
+++ b/tests/cli-v1/v1-cli-subprocess.test.js
@@ -112,11 +112,9 @@ test('cli: kdna validate --runtime exits 3 when LoadPlan cannot load now', () =>
 
 test('cli: kdna plan-load rejects an authoring source directory', () => {
   const r = runCli(['plan-load', exampleMinimal]);
-  assert.equal(r.status, 1, `stdout=${r.stdout}\nstderr=${r.stderr}`);
-  const out = JSON.parse(r.stdout);
-  assert.equal(out.state, 'invalid');
-  assert.equal(out.can_load_now, false);
-  assert.equal(out.issues[0].code, 'KDNA_ASSET_FILE_REQUIRED');
+  assert.equal(r.status, 2, `stdout=${r.stdout}\nstderr=${r.stderr}`);
+  assert.equal(r.stdout, '');
+  assert.match(r.stderr, /requires a packaged \.kdna asset file or installed package name/);
 });
 
 test('cli: kdna plan-load accepts a packaged .kdna asset', () => {


### PR DESCRIPTION
Updates the @aikdna/kdna compatibility package and monorepo test dependency to KDNA Core 0.16.0 / CLI 0.31.0. Aligns the packaged-runtime rejection assertion with the current CLI input-error contract.\n\nValidated locally: full monorepo tests, 15/15 canonical conformance, 18/18 ecosystem conformance, AEAD conformance, format check, workspace package dry-run.