### PR TITLE
fix: align public truth and privacy boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # KDNA
 
-> **Skills give agents hands. KDNA gives them judgment.**
+> **KDNA gives reusable judgment its own identity and lifecycle.**
 >
-> KDNA is an open judgment-asset protocol. It lets individuals, creators,
-> professionals, teams, organizations, Agents, and tools turn judgment, taste,
-> values, standards, boundaries, stance, and personality into portable `.kdna`
-> assets that can be used across models and runtimes.
+> KDNA is an open judgment-asset format and protocol. Individuals, teams,
+> Agents, and tools can create bounded judgment assets whose versions,
+> provenance, access, projections, and evidence can be managed independently
+> from any one Prompt, Skill, model, or application.
 
 Anyone can create a KDNA asset. KDNA Core validates structure, integrity,
 provenance, and authorization facts; it does not decide whether the judgment is
@@ -53,10 +53,12 @@ kdna plan-load ./judgment.kdna --json
 kdna load ./judgment.kdna --profile=compact --as=json
 ```
 
-The AIKDNA asset repository is a historical archive of pre-CBOR demonstrations;
-it is not the current onboarding path or an official content catalog.
+The AIKDNA asset repository currently displays two current-format technical
+reference assets and zero Clusters. Listing is not an endorsement or a claim of
+behavioral value, and the local demonstration above remains the recommended
+first-run path.
 
-→ [Full 5-minute guide](./docs/try-kdna.md) · [Historical reference archive](https://github.com/aikdna/kdna-assets)
+→ [Full 5-minute guide](./docs/try-kdna.md) · [Public reference display](https://github.com/aikdna/kdna-assets)
 
 ## What is a KDNA file?
 

--- a/docs/apple-native-runtime-integration.md
+++ b/docs/apple-native-runtime-integration.md
@@ -7,9 +7,10 @@ Normative source: `specs/kdna-authorization-contract.md`,
 
 ## Purpose
 
-This document is the execution contract for native Apple apps and Swift
-packages. It prevents KDNAChat, KDNA Studio, `kdna-app-shared`, and Swift
-runtime packages from each defining their own `.kdna` authorization behavior.
+This document is the execution contract for native Apple host applications and
+Swift packages. It prevents consumer apps, authoring apps, `kdna-app-shared`,
+and Swift runtime packages from each defining their own `.kdna` authorization
+behavior.
 
 ## Package Roles
 
@@ -18,8 +19,8 @@ runtime packages from each defining their own `.kdna` authorization behavior.
 | `kdna-core-swift` | Swift runtime implementation: validate, inspect, plan, authorize, project. | Product UI state or Studio authoring rules. |
 | `kdna-studio-swift` | Swift authoring kernel: project, cards, compile, runtime export. | Chat load behavior or app-private `.kdna` formats. |
 | `kdna-app-shared` | Shared app presentation/adapters after Core exposes stable types. | Access values, entitlement profiles, LoadPlan states, crypto profiles. |
-| KDNAChat | Consumer app: import local `.kdna`, render LoadPlan, request credentials, load projections. | Manifest-based authorization decisions. |
-| KDNA Studio app | Producer app: call Studio export and validate through Core. | Runtime container variants that Core/CLI cannot inspect. |
+| Native consumer app | Import local `.kdna`, render LoadPlan, request credentials, load projections. | Manifest-based authorization decisions. |
+| Native authoring app | Call Studio export and validate through Core. | Runtime container variants that Core/CLI cannot inspect. |
 
 ## Runtime Container Requirement
 
@@ -36,9 +37,9 @@ Top-level authoring/source entries such as `KDNA_Core.json`,
 `KDNA_Patterns.json`, reports, and `source_cards` MUST NOT be emitted as
 runtime distribution entries.
 
-## Chat Consumption Flow
+## Native Consumer Flow
 
-KDNAChat MUST follow this sequence:
+A native consumer app MUST follow this sequence:
 
 1. Import or reference a local `.kdna` file.
 2. Ask Swift Core for a LoadPlan.
@@ -47,7 +48,7 @@ KDNAChat MUST follow this sequence:
 5. Ask Swift Core to load an authorized runtime projection.
 6. Pass only the projection to the model context.
 
-KDNAChat MUST NOT infer `ready`, `needs_password`, `needs_license`,
+A native consumer app MUST NOT infer `ready`, `needs_password`, `needs_license`,
 `expired`, `revoked`, or `invalid` from raw manifest fields.
 
 ## Shared App Layer
@@ -73,15 +74,15 @@ The expected implementation direction is:
   `KDNAJudgmentProjection` for authorized minimal runtime projection.
 - `kdna-studio-core`, `kdna-studio-cli`, and `kdna-studio-swift` export runtime
   containers using the canonical four-entry shape.
-- KDNAChat should next replace app-side authorization parsing with Swift Core
-  LoadPlan rendering.
+- Native consumer apps should replace app-side authorization parsing with Swift
+  Core LoadPlan rendering.
 
 ## Remaining Native Work
 
 Before a native Chat/Studio release claims authorization compatibility:
 
 1. `kdna-app-shared` should add LoadPlan and projection presentation types.
-2. KDNAChat should import `.kdna` through Swift Core, not raw ZIP parsing.
-3. KDNAChat should render LoadPlan states and pass only
+2. Native consumer apps should import `.kdna` through Swift Core, not raw ZIP parsing.
+3. Native consumer apps should render LoadPlan states and pass only
    `KDNAJudgmentProjection` content to model context.
-4. KDNA Studio should validate exported assets with Swift Core and CLI.
+4. Native authoring apps should validate exported assets with Swift Core and CLI.

--- a/docs/core-narrative-and-boundaries.md
+++ b/docs/core-narrative-and-boundaries.md
@@ -8,11 +8,12 @@ the KDNA open protocol. Protocol implementers should read this document alongsid
 
 ## 1. One-Sentence Definition
 
-> KDNA is an open judgment-asset protocol. Anyone, any Agent, or any tool can
-> create a `.kdna` asset containing judgment, taste, values, standards, stance,
-> and personality. KDNA Core does not judge whether content is correct, good, or
-> worthy of existence. Assets are created, validated, authorized, loaded, and
-> projected through the KDNA toolchain and consumed by Agents across runtimes.
+> KDNA is an open judgment-asset format and protocol that gives reusable,
+> bounded judgment an independent identity and lifecycle. People, teams,
+> Agents, and tools can create assets whose judgment, versions, provenance,
+> access, projections, and evidence are managed independently from any one
+> Prompt, Skill, model, or application. KDNA Core validates the protocol; it
+> does not judge whether the content is correct, good, or worthy of existence.
 
 ## 2. Ten Immutable Boundaries
 
@@ -159,13 +160,13 @@ MUST NOT redefine:
 ### 2.10 Protocol Versioning
 
 The KDNA Core protocol version refers to the logical specification, not the wire
-format. The current logical specification is **Core GA**. The current wire
+format. The current public protocol and toolchain are **Beta**. The current wire
 container format is the **KDNA Asset Container** (`kdna_version: "1.0"`,
-`application/vnd.kdna.asset`), which implements the Core GA logical model.
+`application/vnd.kdna.asset`), which implements the current Core logical model.
 
 | Layer | Current Version | Meaning |
 |---|---|---|
-| Protocol (logical) | Core GA | What KDNA assets are, how they load |
+| Protocol (logical) | Beta | What KDNA assets are, how they load |
 | Container (wire) | `kdna_version: "1.0"` | KDNA Asset Container encoding |
 | Capsule (agent interface) | `kdna.context.capsule` v1.0 | What Agents receive |
 
@@ -314,4 +315,3 @@ validated MUST be four distinct concepts. Registry inclusion MUST NOT imply any
 of the others.
 
 ---
-

--- a/docs/core/load-profiles.md
+++ b/docs/core/load-profiles.md
@@ -39,7 +39,7 @@ judgment content — only identity and metadata.
 {
   "asset_id": "kdna:example:writing-core",
   "asset_uid": "urn:uuid:00000000-0000-4000-8000-000000000001",
-  "title": "Atomspeak Core",
+  "title": "Editorial Review",
   "version": "1.0.0",
   "profiles_available": ["index", "compact", "scenario", "full"]
 }
@@ -66,7 +66,7 @@ and failure modes.
 **Example output** (`--as=prompt`):
 
 ```
-KDNA Judgment Asset: Atomspeak Core
+KDNA Judgment Asset: Editorial Review
 Asset ID: kdna:example:writing-core
 Profile: compact
 Max tokens hint: 500

--- a/docs/core/manifest.md
+++ b/docs/core/manifest.md
@@ -86,7 +86,7 @@ Phase 1 **does not** implement fork/adapt behaviour. The `type` enum covers the 
   "asset_id": "kdna:example:writing-core",
   "asset_uid": "urn:uuid:00000000-0000-4000-8000-000000000001",
   "asset_type": "domain",
-  "title": "Atomspeak Core",
+  "title": "Editorial Review",
   "version": "1.0.0",
   "judgment_version": "1.0.0",
   "created_at": "2026-06-16T00:00:00Z",

--- a/docs/phase2-architecture.md
+++ b/docs/phase2-architecture.md
@@ -185,11 +185,11 @@ Product Runtime ──→ Deliver ──→ Observe ──→ Adapt
 |-----------|----------|----------|-------------|
 | Artifact Contract | KDNA SPEC | ArtifactEnvelope, StageDefinition | SDK, Pipeline, Product Runtime |
 | Fidelity Protocol | Artifact Contract, KDNA Trace | FidelityResult | Registry, Product Runtime |
-| artifact-engine SDK | Artifact Contract | Typed API, Zod schemas | Pipeline, xplan |
+| artifact-engine SDK | Artifact Contract | Typed API, Zod schemas | Pipeline, downstream consumer runtimes |
 | fidelity-core SDK | Fidelity Protocol | Pure functions | Pipeline, assay, CLI |
 | Evidence Trace | KDNA Trace, Artifact Contract | Unified trace records | All components |
-| WorkPack Pipeline | WorkPack, Artifact Contract | Staged execution | Product Runtime, xplan |
-| Product Runtime | Pipeline, Artifact Contract, Fidelity Protocol | Long-running delivery | CoachLettersAI, gvjl |
+| WorkPack Pipeline | WorkPack, Artifact Contract | Staged execution | Product Runtime, downstream consumer runtimes |
+| Product Runtime | Pipeline, Artifact Contract, Fidelity Protocol | Long-running delivery | Scheduled host application |
 
 ---
 

--- a/docs/product-runtime.md
+++ b/docs/product-runtime.md
@@ -24,10 +24,10 @@ This RFC defines the **Product Runtime Pattern**: a protocol contract for schedu
 
 | Runtime Mode | Cycle | Example | KDNA Contract |
 |-------------|-------|---------|---------------|
-| **Chat** | Request → Load KDNA → Response | KDNAChat, agent conversation | `kdna route` + `kdna load` |
+| **Chat** | Request → Load KDNA → Response | Consumer app, agent conversation | `kdna route` + `kdna load` |
 | **Pipeline** | Stage 1 → Stage 2 → ... → Stage N → Finalize | Course generation | WorkPack Pipeline + RFC-0012 |
 | **Agent** | Observe → Decide → Act → Observe → ... | Codex, Claude Code | kdna-loader skill |
-| **Product** | Schedule → Select → Generate → Deliver → **Observe → Adapt** → Schedule → ... | CoachLettersAI, daily coaching | **This RFC** |
+| **Product** | Schedule → Select → Generate → Deliver → **Observe → Adapt** → Schedule → ... | Scheduled coaching application | **This RFC** |
 
 ### 1.2 What makes Product Runtime different
 
@@ -37,9 +37,11 @@ This RFC defines the **Product Runtime Pattern**: a protocol contract for schedu
 - **Adaptive:** User response to artifact N informs artifact N+1
 - **Governed:** KDNA judgment governs WHAT to select, HOW to generate, and WHEN to adapt
 
-### 1.3 Real example: CoachLettersAI
+### 1.3 Example: scheduled coaching application
 
-A daily coaching app: every morning, the system selects a coaching KDNA domain (conflict, EQ, expression, intimacy), generates a personalized daily letter and micro-practice, delivers it via notification, observes the user's reply, extracts observations, and uses them to improve tomorrow's letter.
+A daily coaching application can select a relevant coaching judgment asset,
+generate a personalized letter and practice, deliver it, observe the user's
+reply, and use bounded observations to inform the next cycle.
 
 This is not a chatbot. It is a product loop governed by KDNA judgment.
 
@@ -339,7 +341,7 @@ Long-running products are the strongest test of fidelity: does judgment consiste
 
 ## 7. Implementation Notes
 
-A reference implementation (e.g. CoachLettersAI / gvjl) would implement:
+A reference host application would implement:
 
 1. **Scheduler** — reads `schedule` from manifest, triggers cycles
 2. **Selector** — reads `selection` from manifest, runs `kdna route` for domain matching

--- a/docs/releases/kdna-core-v1-global-cli-baseline.md
+++ b/docs/releases/kdna-core-v1-global-cli-baseline.md
@@ -43,7 +43,7 @@ The following are **not** part of KDNA Core v1 active path:
 - Registry surface
 - Quality-badge system (untested / tested / validated / expert_reviewed / production_ready)
 - Marketplace / public registry framing
-- KDNAChat / KDNAStudio as named product surfaces
+- private applications as named public product surfaces
 - KDNA Viewer (deleted from docs)
 
 ## Current positioning

--- a/docs/strategy/KDNA_ASSET_AUTHORIZATION_STRATEGY.md
+++ b/docs/strategy/KDNA_ASSET_AUTHORIZATION_STRATEGY.md
@@ -11,9 +11,9 @@ This strategy explains how KDNA should protect, authorize, distribute, revoke,
 and commercially use `.kdna` judgment assets without turning Chat, Studio, CLI,
 or any other product into a separate protocol source.
 
-The immediate product pressure comes from KDNAChat, but Chat is only the first
-consumer runtime. The authorization model must be shared by Core, CLI, Swift
-Core, Studio, agent adapters, KDNA Work, and future runtimes.
+The immediate product pressure comes from consumer applications, but any one
+application is only one runtime. The authorization model must be shared by
+Core, CLI, Swift Core, Studio, Agent adapters, and future runtimes.
 
 ## Thesis
 

--- a/docs/tool-status-matrix.md
+++ b/docs/tool-status-matrix.md
@@ -59,11 +59,8 @@
 
 ## Native Apps
 
-| App | Status |
-|---|---|
-| KDNAChat (macOS) | In development |
-| KDNaStudio (macOS) | In development |
-| KDNAChat iOS / KDNaStudio iOS | Early development |
+Application products have independent release and maturity lifecycles. Their
+private development status is not part of the open protocol's tool matrix.
 
 ## Archived / Removed
 

--- a/fixtures/v1/invalid-bad-checksum/kdna.json
+++ b/fixtures/v1/invalid-bad-checksum/kdna.json
@@ -3,7 +3,7 @@
   "asset_id": "kdna:example:invalid-bad-checksum",
   "asset_uid": "urn:uuid:00000000-0000-4000-8000-000000000001",
   "asset_type": "domain",
-  "title": "Atomspeak Core",
+  "title": "Editorial Review",
   "version": "1.0.0",
   "judgment_version": "1.0.0",
   "created_at": "2026-06-16T00:00:00Z",

--- a/fixtures/v1/invalid-missing-payload/kdna.json
+++ b/fixtures/v1/invalid-missing-payload/kdna.json
@@ -3,7 +3,7 @@
   "asset_id": "kdna:example:invalid-missing-payload",
   "asset_uid": "urn:uuid:00000000-0000-4000-8000-000000000001",
   "asset_type": "domain",
-  "title": "Atomspeak Core",
+  "title": "Editorial Review",
   "version": "1.0.0",
   "judgment_version": "1.0.0",
   "created_at": "2026-06-16T00:00:00Z",

--- a/scripts/check-public-surface.mjs
+++ b/scripts/check-public-surface.mjs
@@ -17,27 +17,15 @@
 //      allowlisted audit/history files. Public docs must describe public
 //      evidence, not point readers at inaccessible workspace paths.
 //
-// Allowlist rationale: RFC files (specs/RFC-*) are technical documents that
-// legitimately reference private repos as test fixtures and worked examples.
-// CHANGELOG.md is historical and may mention names that have since been
-// redacted. This script itself contains the strings it scans for, so it
-// self-exempts.
+// Historical, audit, fixture, and test files are still public surface. They are
+// scanned under the same privacy policy as current documentation. This script
+// contains the strings it scans for, so it self-exempts.
 
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 
 const ALLOWLIST_PATHS = new Set([
   'scripts/check-public-surface.mjs', // self (contains scanned strings)
-  'scripts/validate-public-truth.js', // sibling check; references kdna-website in comments + lookup
-  'CHANGELOG.md', // historical references
-  'specs/RFC-0012-artifact-contract.md', // references kdna-workpack (public) and kdna-lab fixtures
-  'specs/RFC-0013-judgment-asset-lifecycle.md', // uses atomspeak as worked example
-  'specs/RFC-0017-kdna-card-v2.md', // references kdna-lab PRs as audit anchors
-  // PR notes and audit packs are audit-internal; they predate the
-  // structural-deletion policy and reference the historical private-repo
-  // names. They live under docs/audits/ and docs/rfc-status.md.
-  'docs/audits/',
-  'docs/rfc-status.md',
 ]);
 
 const REDACTED_PATTERN = /\bREDACTED\b/;
@@ -45,6 +33,9 @@ const PRIVATE_PATH_PATTERN = new RegExp(`\\b${'PRIVATE'}[\\\\/]`);
 const FORBIDDEN_PATTERNS = [
   { name: 'aikdna/kdna-website', pattern: /\baikdna\/kdna-website\b|kdna-website\b/ },
   { name: 'atomspeak', pattern: /\batomspeak\b|@atomspeak\b/ },
+  { name: 'private consumer app', pattern: /\bKDNAChat\b/i },
+  { name: 'private scheduled product', pattern: /\bCoachLettersAI\b|\bgvjl\b/i },
+  { name: 'private pipeline codename', pattern: /\bxplan\b/i },
 ];
 
 function listTrackedFiles() {
@@ -118,10 +109,7 @@ if (allFailures.length > 0) {
   console.error(
     '  - Internal workspace paths: describe the public evidence or delete the reference.',
   );
-  console.error('  - forbidden names:  move references to an allowlisted path (specs/RFC-*,');
-  console.error(
-    '                       docs/audits/, docs/rfc-status.md, CHANGELOG.md) or delete.',
-  );
+  console.error('  - Forbidden names: replace with a public-safe generic example or delete.');
   console.error('  - To update the forbidden-name set, edit scripts/check-public-surface.mjs.');
   process.exit(1);
 }

--- a/scripts/validate-public-truth.js
+++ b/scripts/validate-public-truth.js
@@ -3,7 +3,6 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-const { spawnSync } = require('node:child_process');
 
 const repoRoot = path.resolve(__dirname, '..');
 const manifest = JSON.parse(
@@ -49,103 +48,9 @@ function readJson(filePath) {
   return JSON.parse(readText(filePath));
 }
 
-function requireText(label, text, expected) {
-  if (!text.includes(expected)) fail(label, `missing "${expected}"`);
-}
-
-function rejectText(label, text, pattern, reason) {
-  if (pattern.test(text)) fail(label, reason);
-}
-
 function packageVersion(repository) {
   const entry = component(repository);
   return entry && entry.current_version;
-}
-
-function checkWebsite() {
-  // The aikdna/kdna-website component was structurally removed from
-  // ecosystem-manifest.json on 2026-06-27 (it is a private commercial
-  // repo and must not appear in the public manifest). The website
-  // itself is maintained by the marketing side; its public-surface
-  // consistency is enforced by check-public-docs.mjs inside that repo,
-  // not by this script. If the manifest is ever re-introduced with a
-  // kdna-website entry, that entry must point at a publicly checkable
-  // path. Until then, skip.
-  const website = component('aikdna/kdna-website');
-  if (!website) return;
-  const websiteRoot = componentPath('aikdna/kdna-website');
-  if (!websiteRoot) {
-    fail('aikdna/kdna-website', 'website local_path is not available');
-    return;
-  }
-
-  const productPath = path.join(websiteRoot, 'src', 'pages', 'product.js');
-  const ecosystemPath = path.join(websiteRoot, 'src', 'pages', 'ecosystem.js');
-  const indexPath = path.join(websiteRoot, 'src', 'index.js');
-  const registryPath = path.join(websiteRoot, 'src', 'registry-data.js');
-
-  const product = readText(productPath);
-  const ecosystem = readText(ecosystemPath);
-  const index = readText(indexPath);
-  const registry = readText(registryPath);
-
-  requireText('website product', product, `@aikdna/kdna-cli@${packageVersion('aikdna/kdna-cli')}`);
-  requireText(
-    'website product',
-    product,
-    `@aikdna/kdna-mcp-server@${packageVersion('aikdna/kdna-skills')}`,
-  );
-  requireText(
-    'website product',
-    product,
-    `@aikdna/kdna-studio-cli@${packageVersion('aikdna/kdna-studio-cli')}`,
-  );
-
-  for (const [label, text] of [
-    ['website product', product],
-    ['website ecosystem', ecosystem],
-    ['website registry data', registry],
-  ]) {
-    requireText(label, text, 'plan-load');
-    rejectText(
-      label,
-      text,
-      /@aikdna\/kdna-cli@0\.25\.[01]|@aikdna\/kdna-mcp-server@0\.1\.0|@aikdna\/kdna-studio-cli@0\.5\.[23]/,
-      'contains stale public package version',
-    );
-    rejectText(
-      label,
-      text,
-      /registry marketplace|marketplace registry/i,
-      'must not imply registry or marketplace is part of the current stable baseline',
-    );
-  }
-
-  requireText('website retired registry route', index, 'url.pathname === "/registry/domains.json"');
-  requireText('website retired registry route', index, 'url.pathname === "/registry/publish"');
-  requireText('website retired registry route', index, 'return notFound();');
-  rejectText(
-    'website retired registry route',
-    index,
-    /registry_disabled|registry_publish_disabled|registry endpoint|publish endpoint/i,
-    'retired registry routes should not explain the old registry surface',
-  );
-
-  const publicDocsCheck = path.join(websiteRoot, 'scripts', 'check-public-docs.mjs');
-  if (!fs.existsSync(publicDocsCheck)) {
-    fail('website public docs', 'missing scripts/check-public-docs.mjs');
-  } else {
-    const result = spawnSync(process.execPath, [publicDocsCheck], {
-      cwd: websiteRoot,
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-    if (result.status !== 0) {
-      if (result.stdout) process.stdout.write(result.stdout);
-      if (result.stderr) process.stderr.write(result.stderr);
-      fail('website public docs', `check-public-docs exited ${result.status}`);
-    }
-  }
 }
 
 function checkVSCodeBoundary() {
@@ -172,7 +77,6 @@ function checkVSCodeBoundary() {
   }
 }
 
-checkWebsite();
 checkVSCodeBoundary();
 
 if (failures.length > 0) {

--- a/specs/RFC-0012-artifact-contract.md
+++ b/specs/RFC-0012-artifact-contract.md
@@ -32,7 +32,8 @@ When an agent or engine generates a course, a daily letter, or an assessment rep
 
 ### 1.2 What happens in practice
 
-In the xplan course-engine pipeline (13 stages, 12 artifact types), every stage produces structured outputs. But without a standard envelope:
+In a multi-stage course-generation pipeline, every stage produces structured
+outputs. But without a standard envelope:
 
 - Each artifact type invents its own identity and metadata format
 - Quality results are stored inconsistently
@@ -417,7 +418,7 @@ The App Runtime Contract defines: `KDNA Asset → Route Result → Judgment Trac
 - Merge `artifact-envelope.schema.json` and `stage-definition.schema.json` into kdna spec
 - Add reference from kdna-workpack docs
 
-### Phase 2b: xplan adoption
+### Phase 2b: host-application adoption
 - Wrap all 12 course-engine artifact types in ArtifactEnvelope
 - Convert course-engine 13-stage config to StageDefinition array
 - Run a full pipeline with envelope-wrapped artifacts and verify trace linkage
@@ -440,7 +441,10 @@ The App Runtime Contract defines: `KDNA Asset → Route Result → Judgment Trac
 
 3. Should `source_kdna[].role` use the same 5-role enum as Cluster SPEC §13.3 (`primary`, `advisor`, `risk_guard`, `style_and_trust`, `evaluator`) or the simpler 3-role enum from WorkPack (`primary`, `constraint`, `fallback`)? Recommendation: use the 6-role Cluster enum for richer semantics.
 
-4. Where should business-specific artifact schemas live? In their engine repositories (xplan, daily-letter-engine), in a shared artifact-schema registry, or linked from the Artifact Contract spec? Recommendation: engine repositories first, aggregated registry later.
+4. Where should business-specific artifact schemas live? In their host engine
+repositories, in a shared artifact-schema registry, or linked from the Artifact
+Contract spec? Recommendation: engine repositories first, aggregated registry
+later.
 
 ---
 


### PR DESCRIPTION
## Summary

- align public documentation and fixtures with content-neutral, creator-neutral terminology
- make the public-surface audit scan all tracked text files instead of a narrow extension list
- remove obsolete example-specific assertions from the public-truth validator

## Validation

- `npm run audit:public-confidence` (766 tracked text files, 0 violations)
- `npm run validate:public-truth`
- `npm run format:check`
- `npm run lint`
- `npm test`

## Dependency

This is stacked on #199 so reviewers see only the privacy-boundary delta. Retarget it to `main` after #199 merges.