### PR TITLE
fix: preserve scoped judgment core projection

### DIFF
--- a/docs/core/load-profiles.md
+++ b/docs/core/load-profiles.md
@@ -49,16 +49,19 @@ judgment content — only identity and metadata.
 
 **Purpose**: the **default profile for Agent invocation**. Supplies the
 minimum judgment surface that a loader needs to apply the domain's
-reasoning frame: the highest question, axioms, boundaries, self-checks,
-and failure modes.
+reasoning frame: the highest question, scoped worldview, value order,
+judgment role, axioms, boundaries, self-checks, and failure modes.
 
 **Suitable as an Agent prompt**: yes. This is the recommended default.
 
 **Output fields**:
 - `highest_question` — from `payload.core`
+- `worldview` — from `payload.core.worldview`, preserving every declared string
+- `value_order` — from `payload.core.value_order`, preserving declared order
+- `judgment_role` — from `payload.core.judgment_role`, preserving its declared shape
 - `axioms` — from `payload.core.axioms` (one-sentence form if available)
 - `boundaries` — from `payload.core.boundaries`
-- `self_checks` — from `payload.reasoning.self_checks`
+- `self_checks` — Runtime Capsule projection of `payload.reasoning.self_check`
 - `failure_modes` — from `payload.reasoning.failure_modes`
 - `patterns` — from `payload.patterns` (first 3, truncated)
 - Default max_tokens_hint from `load_contract.profiles.compact.max_tokens_hint`

--- a/docs/core/payload-profile.md
+++ b/docs/core/payload-profile.md
@@ -23,6 +23,9 @@ A `judgment-profile-v1` payload is a single JSON object with the following secti
 ```json
 {
   "highest_question": "",
+  "worldview": [],
+  "value_order": [],
+  "judgment_role": {},
   "axioms": [],
   "boundaries": [],
   "risk_model": {}
@@ -30,6 +33,9 @@ A `judgment-profile-v1` payload is a single JSON object with the following secti
 ```
 
 - `highest_question` (string, required): the single most important question this judgment system answers. Producers SHOULD populate it. Phase 1 does not enforce non-empty.
+- `worldview` (array of strings, optional): scoped assumptions used for qualitative tradeoffs; these are not general facts.
+- `value_order` (ordered array of strings, optional): qualitative priorities in descending order. This is not a deterministic policy table.
+- `judgment_role` (object, optional): what authority the asset acts as, what it does not act as, and its responsibility.
 - `axioms` (array, required): the list of axioms. Phase 1 accepts an empty array.
 - `boundaries` (array, optional): explicit out-of-scope statements.
 - `risk_model` (object, optional): structural risk metadata.
@@ -79,6 +85,13 @@ This is the **smallest** payload that conforms to the schema. The conformance su
   "profile": "judgment-profile-v1",
   "core": {
     "highest_question": "What is the central question this judgment system answers?",
+    "worldview": ["A scoped assumption used for this domain's tradeoffs."],
+    "value_order": ["first priority", "second priority"],
+    "judgment_role": {
+      "acts_as": "a scoped judgment authority",
+      "does_not_act_as": ["a fact source", "a policy engine"],
+      "responsibility": "Resolve qualitative tradeoffs inside the declared scope."
+    },
     "axioms": [
       {
         "id": "a1",

--- a/packages/kdna-core/CHANGELOG.md
+++ b/packages/kdna-core/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Structurally validate optional payload `worldview`, ordered `value_order`,
+  and `judgment_role`, then preserve their declared values in the compact
+  Runtime Capsule instead of silently dropping them. Compact prompt projection
+  renders worldview, value order, and the standard role fields `acts_as`,
+  `does_not_act_as`, and `responsibility`; role extension fields remain
+  available in the JSON Capsule without an unsupported prompt claim.
+- Add a synthetic Golden Single-Asset Core fixture. It proves schema,
+  validation, content-neutral inspect, and exact compact projection only; it
+  does not claim author quality, task applicability, model consumption, or
+  conformance.
+
 ## v0.16.0 (2026-07-13)
 
 ### Added

--- a/packages/kdna-core/README.md
+++ b/packages/kdna-core/README.md
@@ -64,6 +64,12 @@ if (capsule.type !== 'kdna.context.capsule') {
 → Agent/runtime context
 ```
 
+The default compact Capsule preserves the asset's scoped judgment context:
+`highest_question`, `worldview`, ordered `value_order`, `judgment_role`,
+applicability-aware axioms, boundaries, self-checks, failure modes, and a
+bounded pattern set. Core copies the three optional scoped fields without
+trimming, reordering, or treating them as facts, policy, or quality evidence.
+
 For authoring and test fixtures, `pack()` can turn a local working folder into
 a `.kdna` file before validation:
 

--- a/packages/kdna-core/schema/payload-profile-v1.schema.json
+++ b/packages/kdna-core/schema/payload-profile-v1.schema.json
@@ -21,6 +21,31 @@
           "type": "string",
           "description": "The single most important question this judgment system answers."
         },
+        "worldview": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Scoped assumptions used at qualitative judgment forks; not general facts or deterministic policy."
+        },
+        "value_order": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Ordered qualitative priorities, highest priority first."
+        },
+        "judgment_role": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "acts_as": { "type": "string" },
+            "does_not_act_as": {
+              "oneOf": [
+                { "type": "string" },
+                { "type": "array", "items": { "type": "string" } }
+              ]
+            },
+            "responsibility": { "type": "string" }
+          },
+          "description": "The authority this asset exercises and the responsibilities explicitly outside it."
+        },
         "axioms": {
           "type": "array",
           "description": "The list of axioms. Phase 1 accepts an empty array."

--- a/packages/kdna-core/src/v1/index.js
+++ b/packages/kdna-core/src/v1/index.js
@@ -1866,6 +1866,34 @@ function normalizeCompactAxiom(axiom) {
   };
 }
 
+function judgmentRoleExclusions(role) {
+  if (!role || typeof role !== 'object' || Array.isArray(role)) return [];
+  if (Array.isArray(role.does_not_act_as)) return role.does_not_act_as;
+  return role.does_not_act_as ? [role.does_not_act_as] : [];
+}
+
+function hasStandardJudgmentRoleContent(role) {
+  if (!role || typeof role !== 'object' || Array.isArray(role)) return false;
+  return Boolean(
+    role.acts_as || judgmentRoleExclusions(role).length || role.responsibility,
+  );
+}
+
+function hasCompactPromptContent(content) {
+  if (!content) return false;
+  return Boolean(
+    content.highest_question ||
+      (Array.isArray(content.worldview) && content.worldview.length > 0) ||
+      (Array.isArray(content.value_order) && content.value_order.length > 0) ||
+      hasStandardJudgmentRoleContent(content.judgment_role) ||
+      (Array.isArray(content.axioms) && content.axioms.length > 0) ||
+      (Array.isArray(content.boundaries) && content.boundaries.length > 0) ||
+      (Array.isArray(content.self_checks) && content.self_checks.length > 0) ||
+      (Array.isArray(content.failure_modes) && content.failure_modes.length > 0) ||
+      (Array.isArray(content.patterns) && content.patterns.length > 0)
+  );
+}
+
 function loadV1Unsafe(inputPath, opts = {}) {
   const v1 = readV1Layout(path.resolve(inputPath));
   const m = v1.manifest;
@@ -1964,6 +1992,10 @@ function loadV1Unsafe(inputPath, opts = {}) {
     const core = payload.core || {};
     const hasJudgment = (core.axioms && core.axioms.length > 0)
       || (core.boundaries && core.boundaries.length > 0)
+      || Boolean(core.highest_question)
+      || (Array.isArray(core.worldview) && core.worldview.length > 0)
+      || (Array.isArray(core.value_order) && core.value_order.length > 0)
+      || hasStandardJudgmentRoleContent(core.judgment_role)
       || (payload.patterns && payload.patterns.length > 0)
       || (payload.reasoning && ((payload.reasoning.self_check && payload.reasoning.self_check.length > 0) || (payload.reasoning.failure_modes && payload.reasoning.failure_modes.length > 0)));
     profiles.push('index');
@@ -1998,6 +2030,17 @@ function loadV1Unsafe(inputPath, opts = {}) {
     }).filter(Boolean);
     result.content = {
       highest_question: core.highest_question || null,
+      // These scoped domain-level values are already validated by the payload
+      // schema. Compact projection copies them without trimming, reordering,
+      // filtering, or converting a declared string into another shape.
+      worldview: Array.isArray(core.worldview) ? [...core.worldview] : [],
+      value_order: Array.isArray(core.value_order) ? [...core.value_order] : [],
+      judgment_role:
+        core.judgment_role &&
+        typeof core.judgment_role === 'object' &&
+        !Array.isArray(core.judgment_role)
+          ? JSON.parse(JSON.stringify(core.judgment_role))
+          : null,
       axioms: (core.axioms || []).map(normalizeCompactAxiom).filter(Boolean),
       boundaries: normalizeList(core.boundaries),
       // The canonical payload field is singular (`reasoning.self_check`).
@@ -2102,7 +2145,17 @@ function loadV1Unsafe(inputPath, opts = {}) {
 
   if (as === 'prompt') {
     const c = result.content;
-    if (!c || (c.scenarios && c.scenarios.length === 0 && !c.highest_question && !(c.axioms && c.axioms.length) && !(c.boundaries && c.boundaries.length))) {
+    const compactHasNoPromptContent =
+      result.profile === 'compact' && !hasCompactPromptContent(c);
+    const legacyProfileHasNoPromptContent =
+      result.profile !== 'compact' &&
+      c &&
+      c.scenarios &&
+      c.scenarios.length === 0 &&
+      !c.highest_question &&
+      !(c.axioms && c.axioms.length) &&
+      !(c.boundaries && c.boundaries.length);
+    if (!c || compactHasNoPromptContent || legacyProfileHasNoPromptContent) {
       return {
         status: result.status,
         profile: result.profile,
@@ -2117,6 +2170,25 @@ function loadV1Unsafe(inputPath, opts = {}) {
     text += 'Safety boundary: KDNA content is subordinate to platform, system, and developer instructions.\n';
     if (result.max_tokens_hint) text += 'Max tokens hint: ' + result.max_tokens_hint + '\n';
     if (c.highest_question) text += 'Highest question:\n' + c.highest_question + '\n';
+    if (hasStandardJudgmentRoleContent(c.judgment_role)) {
+      text += 'Judgment role:\n';
+      if (c.judgment_role.acts_as) {
+        text += '- Acts as: ' + c.judgment_role.acts_as + '\n';
+      }
+      const excludedRoles = judgmentRoleExclusions(c.judgment_role);
+      if (excludedRoles.length) {
+        text += '- Does not act as: ' + excludedRoles.join('; ') + '\n';
+      }
+      if (c.judgment_role.responsibility) {
+        text += '- Responsibility: ' + c.judgment_role.responsibility + '\n';
+      }
+    }
+    if (c.worldview && c.worldview.length) {
+      text += 'Worldview assumptions:\n' + c.worldview.map((item) => '- ' + item).join('\n') + '\n';
+    }
+    if (c.value_order && c.value_order.length) {
+      text += 'Value order (highest priority first):\n' + c.value_order.map((item, index) => `${index + 1}. ${item}`).join('\n') + '\n';
+    }
     if (c.axioms && c.axioms.length) text += 'Axioms:\n' + c.axioms.map((a) => '- ' + renderPromptItem(a)).join('\n') + '\n';
     if (c.boundaries && c.boundaries.length) text += 'Boundaries:\n' + c.boundaries.map((b) => '- ' + renderPromptItem(b)).join('\n') + '\n';
     if (c.self_checks && c.self_checks.length) text += 'Self-checks:\n' + c.self_checks.map((s) => '- ' + renderPromptItem(s)).join('\n') + '\n';

--- a/packages/kdna-core/test/fixtures/golden-single-asset.json
+++ b/packages/kdna-core/test/fixtures/golden-single-asset.json
@@ -1,0 +1,114 @@
+{
+  "contract_id": "kdna.golden-single-asset/1",
+  "manifest": {
+    "kdna_version": "1.0",
+    "asset_id": "kdna:fixture:release-decision-golden",
+    "asset_uid": "urn:uuid:00000000-0000-4000-8000-000000000401",
+    "asset_type": "domain",
+    "title": "Golden Release Decision",
+    "version": "1.0.0",
+    "judgment_version": "1.0.0",
+    "created_at": "2026-07-14T00:00:00Z",
+    "updated_at": "2026-07-14T00:00:00Z",
+    "creator": {
+      "name": "KDNA Protocol Test Fixture",
+      "id": "synthetic_protocol_fixture"
+    },
+    "compatibility": {
+      "min_loader_version": "0.16.0",
+      "profile": "judgment-profile-v1"
+    },
+    "payload": {
+      "path": "payload.kdnab",
+      "encoding": "cbor",
+      "encrypted": false
+    },
+    "access": "public",
+    "summary": "Synthetic Golden fixture for KDNA value-preservation tests.",
+    "language": "en",
+    "license": "Apache-2.0",
+    "keywords": ["synthetic", "release-decision", "golden"],
+    "load_contract": {
+      "default_profile": "compact",
+      "profiles": {
+        "index": {
+          "requires_decryption": false,
+          "max_tokens_hint": 200
+        },
+        "compact": {
+          "requires_decryption": false,
+          "max_tokens_hint": 800
+        },
+        "scenario": {
+          "requires_decryption": false,
+          "selection": "triggered_sections_only"
+        },
+        "full": {
+          "requires_decryption": false,
+          "intended_for": ["audit", "reference"]
+        }
+      }
+    }
+  },
+  "payload": {
+    "profile": "judgment-profile-v1",
+    "core": {
+      "highest_question": "Which rollout choice preserves the safest verified recovery path?",
+      "worldview": [
+        "The asset supplies a scoped release-decision prior, not operational facts.",
+        "Observed test, incident, and rollback evidence remains authoritative."
+      ],
+      "value_order": [
+        "prevent unrecoverable user harm",
+        "preserve a verified rollback path",
+        "reduce release delay"
+      ],
+      "judgment_role": {
+        "acts_as": "a scoped release-decision authority",
+        "does_not_act_as": [
+          "an operational fact source",
+          "an automated deployment controller"
+        ],
+        "responsibility": "Order qualitative rollout tradeoffs after observed facts are supplied."
+      },
+      "axioms": [
+        {
+          "id": "ax_reversible_rollout",
+          "one_sentence": "Prefer a reversible limited rollout when recovery evidence is incomplete.",
+          "full_statement": "When required checks have passed but rollback evidence remains incomplete, choose the smallest reversible rollout that can produce the missing evidence.",
+          "why": "Without this rule, rollout speed can outrank a verified recovery path.",
+          "confidence": "high",
+          "applies_when": [
+            "choosing rollout scope after required checks pass"
+          ],
+          "does_not_apply_when": [
+            "determining whether required checks actually passed"
+          ],
+          "failure_risk": "The release may expand before its recovery path is verified."
+        }
+      ],
+      "boundaries": [
+        {
+          "id": "bd_observed_release_facts",
+          "scope": "qualitative rollout tradeoffs after release facts are supplied",
+          "out_of_scope": "inventing test results, incident state, or rollback evidence",
+          "acceptable_exceptions": []
+        }
+      ],
+      "risk_model": {}
+    },
+    "patterns": [],
+    "scenarios": [],
+    "cases": [],
+    "reasoning": {
+      "self_check": [
+        "Did I preserve the verified recovery path without inventing release facts?"
+      ],
+      "failure_modes": []
+    },
+    "evolution": {
+      "changelog": [],
+      "version_notes": []
+    }
+  }
+}

--- a/packages/kdna-core/test/golden-single-asset.test.js
+++ b/packages/kdna-core/test/golden-single-asset.test.js
@@ -1,0 +1,250 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const cbor = require('cbor-x');
+const Ajv2020 = require('ajv/dist/2020.js');
+
+const core = require('../src');
+const fixture = require('./fixtures/golden-single-asset.json');
+const canonicalPayloadSchema = require('../../../schema/payload-profile-v1.schema.json');
+const packagedPayloadSchema = require('../schema/payload-profile-v1.schema.json');
+
+const SCOPED_FIELDS = ['worldview', 'value_order', 'judgment_role'];
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function compileSchema(schema) {
+  return new Ajv2020({ allErrors: true, strict: false }).compile(schema);
+}
+
+function createAsset(payload = fixture.payload) {
+  const temporary = fs.mkdtempSync(path.join(os.tmpdir(), 'kdna-golden-core-'));
+  const source = path.join(temporary, 'source');
+  const asset = path.join(temporary, 'golden.kdna');
+  fs.mkdirSync(source, { recursive: true });
+  fs.writeFileSync(path.join(source, 'mimetype'), core.MIMETYPE);
+  fs.writeFileSync(path.join(source, 'kdna.json'), JSON.stringify(fixture.manifest));
+  fs.writeFileSync(path.join(source, 'payload.kdnab'), cbor.encode(payload));
+  fs.writeFileSync(
+    path.join(source, 'checksums.json'),
+    JSON.stringify(core.buildChecksums(source)),
+  );
+  core.pack(source, asset);
+  return { temporary, asset };
+}
+
+test('canonical and packaged payload schemas constrain the same scoped judgment fields', () => {
+  const canonicalCore = canonicalPayloadSchema.properties.core.properties;
+  const packagedCore = packagedPayloadSchema.properties.core.properties;
+
+  for (const field of SCOPED_FIELDS) {
+    assert.deepEqual(packagedCore[field], canonicalCore[field]);
+  }
+
+  for (const [name, schema] of [
+    ['canonical', canonicalPayloadSchema],
+    ['packaged', packagedPayloadSchema],
+  ]) {
+    const validate = compileSchema(schema);
+    assert.equal(validate(fixture.payload), true, `${name}: ${JSON.stringify(validate.errors)}`);
+  }
+});
+
+test('payload schemas reject malformed scoped judgment field shapes', () => {
+  const invalidCases = [
+    ['worldview is not an array', (payload) => { payload.core.worldview = 'facts'; }],
+    ['worldview contains a non-string', (payload) => { payload.core.worldview[1] = 4; }],
+    ['value_order is not an array', (payload) => { payload.core.value_order = {}; }],
+    ['value_order contains a non-string', (payload) => { payload.core.value_order[1] = false; }],
+    ['judgment_role is not an object', (payload) => { payload.core.judgment_role = []; }],
+    ['acts_as is not a string', (payload) => { payload.core.judgment_role.acts_as = 3; }],
+    [
+      'does_not_act_as contains a non-string',
+      (payload) => { payload.core.judgment_role.does_not_act_as[1] = false; },
+    ],
+    [
+      'responsibility is not a string',
+      (payload) => { payload.core.judgment_role.responsibility = []; },
+    ],
+  ];
+
+  for (const [schemaName, schema] of [
+    ['canonical', canonicalPayloadSchema],
+    ['packaged', packagedPayloadSchema],
+  ]) {
+    const validate = compileSchema(schema);
+    for (const [caseName, mutate] of invalidCases) {
+      const payload = clone(fixture.payload);
+      mutate(payload);
+      assert.equal(
+        validate(payload),
+        false,
+        `${schemaName} schema accepted invalid case: ${caseName}`,
+      );
+    }
+  }
+});
+
+test('Golden asset validates, inspects content-neutrally, and loads exact compact semantics', () => {
+  const { temporary, asset } = createAsset();
+  try {
+    const validation = core.validate(asset);
+    assert.deepEqual(validation, {
+      format_valid: true,
+      schema_valid: true,
+      payload_valid: true,
+      checksums_valid: true,
+      load_contract_valid: true,
+      overall_valid: true,
+      problems: [],
+    });
+
+    const inspected = core.inspect(asset);
+    assert.deepEqual(inspected, {
+      kdna_version: '1.0',
+      asset_id: fixture.manifest.asset_id,
+      asset_uid: fixture.manifest.asset_uid,
+      asset_type: fixture.manifest.asset_type,
+      title: fixture.manifest.title,
+      version: fixture.manifest.version,
+      judgment_version: fixture.manifest.judgment_version,
+      payload: 'payload.kdnab',
+      payload_encrypted: false,
+      profile: 'judgment-profile-v1',
+      load_contract_default_profile: 'compact',
+      checksums_present: true,
+    });
+    for (const field of ['highest_question', ...SCOPED_FIELDS, 'axioms']) {
+      assert.equal(Object.hasOwn(inspected, field), false);
+    }
+
+    const capsule = core.loadAuthorized(asset, { profile: 'compact', as: 'json' });
+    const [axiom] = fixture.payload.core.axioms;
+    assert.deepEqual(capsule.context, {
+      highest_question: fixture.payload.core.highest_question,
+      worldview: fixture.payload.core.worldview,
+      value_order: fixture.payload.core.value_order,
+      judgment_role: fixture.payload.core.judgment_role,
+      axioms: [
+        {
+          type: 'axiom_applicability',
+          id: axiom.id,
+          statement: axiom.one_sentence,
+          one_sentence: axiom.one_sentence,
+          applies_when: axiom.applies_when,
+          does_not_apply_when: axiom.does_not_apply_when,
+          failure_risk: axiom.failure_risk,
+        },
+      ],
+      boundaries: fixture.payload.core.boundaries,
+      self_checks: [
+        {
+          type: 'text',
+          text: fixture.payload.reasoning.self_check[0],
+        },
+      ],
+      failure_modes: [],
+      patterns: [],
+    });
+    assert.equal(capsule.type, 'kdna.context.capsule');
+    assert.equal(capsule.domain, fixture.manifest.asset_id);
+    assert.equal(capsule.judgment_version, fixture.manifest.judgment_version);
+    assert.equal(capsule.trace.schema_valid, true);
+
+    const full = core.loadAuthorized(asset, { profile: 'full', as: 'json' });
+    assert.deepEqual(full.context.payload, fixture.payload);
+
+    const prompt = core.loadAuthorized(asset, { profile: 'compact', as: 'prompt' });
+    assert.ok(prompt.text.includes(fixture.payload.core.highest_question));
+    for (const value of [
+      ...fixture.payload.core.worldview,
+      ...fixture.payload.core.value_order,
+      fixture.payload.core.judgment_role.acts_as,
+      ...fixture.payload.core.judgment_role.does_not_act_as,
+      fixture.payload.core.judgment_role.responsibility,
+    ]) {
+      assert.ok(prompt.text.includes(value), `prompt omitted declared value: ${value}`);
+    }
+  } finally {
+    fs.rmSync(temporary, { recursive: true, force: true });
+  }
+});
+
+test('compact projection does not trim strings, reorder values, or normalize role shape', () => {
+  const payload = clone(fixture.payload);
+  payload.core.worldview = ['  Preserve declared spacing.  '];
+  payload.core.value_order = [
+    'second-looking value remains first',
+    'first-looking value remains second',
+  ];
+  payload.core.judgment_role = {
+    acts_as: '  a deliberately spaced authority  ',
+    does_not_act_as: '  a single declared exclusion  ',
+    responsibility: '  retain exact declared strings  ',
+  };
+
+  const { temporary, asset } = createAsset(payload);
+  try {
+    assert.equal(core.validate(asset).overall_valid, true);
+    const capsule = core.loadAuthorized(asset, { profile: 'compact', as: 'json' });
+    assert.deepEqual(capsule.context.worldview, payload.core.worldview);
+    assert.deepEqual(capsule.context.value_order, payload.core.value_order);
+    assert.deepEqual(capsule.context.judgment_role, payload.core.judgment_role);
+  } finally {
+    fs.rmSync(temporary, { recursive: true, force: true });
+  }
+});
+
+test('prompt treats each scoped field as content but does not render an empty role', () => {
+  const variants = [
+    [
+      'worldview',
+      { worldview: ['Scoped worldview remains available.'] },
+      'Scoped worldview remains available.',
+    ],
+    [
+      'value_order',
+      { value_order: ['first declared value', 'second declared value'] },
+      'first declared value',
+    ],
+    [
+      'judgment_role',
+      { judgment_role: { responsibility: 'Resolve the scoped tradeoff.' } },
+      'Resolve the scoped tradeoff.',
+    ],
+  ];
+
+  for (const [name, scopedCore, expectedText] of variants) {
+    const payload = {
+      profile: 'judgment-profile-v1',
+      core: { highest_question: '', axioms: [], ...scopedCore },
+    };
+    const { temporary, asset } = createAsset(payload);
+    try {
+      assert.equal(core.validate(asset).overall_valid, true, name);
+      const prompt = core.loadAuthorized(asset, { profile: 'compact', as: 'prompt' });
+      assert.equal(prompt.text.includes('No content available'), false, name);
+      assert.ok(prompt.text.includes(expectedText), name);
+    } finally {
+      fs.rmSync(temporary, { recursive: true, force: true });
+    }
+  }
+
+  const emptyRolePayload = {
+    profile: 'judgment-profile-v1',
+    core: { highest_question: '', axioms: [], judgment_role: {} },
+  };
+  const { temporary, asset } = createAsset(emptyRolePayload);
+  try {
+    assert.equal(core.validate(asset).overall_valid, true);
+    const prompt = core.loadAuthorized(asset, { profile: 'compact', as: 'prompt' });
+    assert.ok(prompt.text.includes('No content available'));
+    assert.equal(prompt.text.includes('Judgment role:'), false);
+  } finally {
+    fs.rmSync(temporary, { recursive: true, force: true });
+  }
+});

--- a/schema/payload-profile-v1.schema.json
+++ b/schema/payload-profile-v1.schema.json
@@ -21,6 +21,31 @@
           "type": "string",
           "description": "The single most important question this judgment system answers."
         },
+        "worldview": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Scoped assumptions used at qualitative judgment forks; not general facts or deterministic policy."
+        },
+        "value_order": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Ordered qualitative priorities, highest priority first."
+        },
+        "judgment_role": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "acts_as": { "type": "string" },
+            "does_not_act_as": {
+              "oneOf": [
+                { "type": "string" },
+                { "type": "array", "items": { "type": "string" } }
+              ]
+            },
+            "responsibility": { "type": "string" }
+          },
+          "description": "The authority this asset exercises and the responsibilities explicitly outside it."
+        },
         "axioms": {
           "type": "array",
           "description": "The list of axioms. Phase 1 accepts an empty array."

--- a/specs/runtime-capsule.md
+++ b/specs/runtime-capsule.md
@@ -31,6 +31,15 @@ were actually completed.
   "profile": "compact",
   "context": {
     "highest_question": "What editorial decision should be made?",
+    "worldview": [
+      "Observed task facts remain authoritative."
+    ],
+    "value_order": ["prevent irreversible harm", "preserve reversibility"],
+    "judgment_role": {
+      "acts_as": "a scoped editorial authority",
+      "does_not_act_as": ["a fact source", "a policy engine"],
+      "responsibility": "Resolve qualitative editorial tradeoffs."
+    },
     "axioms": [
       {
         "type": "axiom_applicability",
@@ -73,7 +82,7 @@ Field presence alone MUST NOT produce `verified`.
 | Profile | Context | Intended use |
 |---|---|---|
 | `index` | Public identity and discovery metadata; no judgment | discovery and routing |
-| `compact` | Highest question, applicability-aware axioms, boundaries, self-checks, failure modes, and a bounded pattern set | default Agent judgment loading |
+| `compact` | Highest question, scoped worldview, ordered values, judgment role, applicability-aware axioms, boundaries, self-checks, failure modes, and a bounded pattern set | default Agent judgment loading |
 | `scenario` | Scenario cards | situation-specific loading |
 | `full` | Authorized manifest and decoded payload | audit, migration, and deep inspection through trusted applications |
 
@@ -87,10 +96,12 @@ A consuming Agent or application must:
 1. obtain the Capsule from Core or an official toolchain adapter;
 2. respect the asset's applicability and boundary fields;
 3. use the loaded axioms and patterns as judgment context, not as truth claims;
-4. run relevant self-checks and account for declared failure risks;
-5. keep technical validity, signature state, evidence, maturity, and content
+4. treat `worldview`, `value_order`, and `judgment_role` as scoped judgment
+   context, not as general facts, hard policy, or a replacement for model capability;
+5. run relevant self-checks and account for declared failure risks;
+6. keep technical validity, signature state, evidence, maturity, and content
    quality as separate concepts;
-6. avoid logging or persisting decrypted full context from licensed assets.
+7. avoid logging or persisting decrypted full context from licensed assets.
 
 Single-asset loading is the default foundation. Cluster execution composes
 multiple authorized asset Capsules through the explicit Cluster runtime; it


### PR DESCRIPTION
## Summary

- structurally constrain optional `worldview`, ordered `value_order`, and `judgment_role` fields in both canonical and packaged runtime payload schemas
- preserve all declared scoped values exactly in compact JSON Runtime Capsules, including role extension fields, without trimming, reordering, filtering, or shape normalization
- render exact worldview and value-order entries plus the three standard role fields `acts_as`, `does_not_act_as`, and `responsibility` in compact prompt projection; role extensions remain JSON-only
- add a synthetic Golden Single-Asset fixture covering public validate, content-neutral inspect, full load, exact compact projection, malformed-schema rejection, scoped-fields-only prompt rendering, and empty-role handling
- keep compact axiom projection on its existing documented one-sentence contract

## Truth boundary

This proves structural validation and exact projection of an explicitly selected synthetic asset. It does not prove author quality, task applicability, model consumption, behavioral conformance, or release state. It adds no routing heuristic, Cluster behavior, inheritance policy, or executable checks.

## Verification

- Golden Core suite — 5 passed
- Core package — 31 passed, 6 existing skips
- CLI-v1 — 106 passed
- Eval suite — passed
- canonical conformance — 15 passed
- lint, format, examples, runtime/app schemas, protocol fixtures, public truth, and package-content checks — passed
- public-surface scan — 742 tracked text files, 0 violations

## Dependency

The current `main` ecosystem-manifest check still reports the four public version drifts already addressed by #199. This branch does not modify version or manifest files. Rebase and rerun the complete gate after #199 is approved and merged; do not treat this draft as release evidence.