### PR TITLE
ci: enforce exact npm release health

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
         run: |
           node scripts/core-release-authority.js trusted-npm run test:post-cutover
           node scripts/core-release-authority.js trusted-npm run test:release-scopes
+          node scripts/core-release-authority.js trusted-npm run test:release-health
           node --test scripts/core-release-authority.test.js
           node scripts/core-release-authority.js trusted-npm run audit:post-cutover
       - run: node scripts/core-release-authority.js trusted-npm test

--- a/.github/workflows/publish-health-cron.yml
+++ b/.github/workflows/publish-health-cron.yml
@@ -1,15 +1,15 @@
 # publish-health-cron.yml — Daily drift check for the npm pipeline.
 #
-# Verifies that for every tracked package, four fields agree:
+# Verifies that for every tracked package, the public release surfaces agree:
 #   1. main HEAD version (from package.json on main)
-#   2. latest exact package tag
-#   3. npm latest version (from registry.npmjs.org)
-#   4. GitHub Release existence (for the npm-latest version)
+#   2. npm latest version and SLSA provenance
+#   3. exact canonical package tag (or one version-bound historical coordinate)
+#   4. package.json version at the tagged commit
+#   5. npm gitHead binding when the registry exposes it
+#   6. published, non-prerelease GitHub Release existence
 #
-# Delegates the actual work to scripts/ecosystem-version-lock.js (which
-# already enforces cross-repo version consistency in the kdna monorepo)
-# and scripts/validate-public-truth.js (which validates ecosystem manifest
-# + public/private boundaries).
+# Delegates the public package audit to scripts/publish-health.mjs and keeps
+# ecosystem-version-lock plus validate-public-truth as independent gates.
 #
 # On drift detection, fails the job so a notification can be wired up
 # (e.g. via the repository's notification settings / Slack webhook).
@@ -51,66 +51,10 @@ jobs:
 
       - name: Run publish-health (all tracked npm packages)
         id: cross
-        # Keep the public package/release audit in-tree so CI can run it with
-        # npm and GitHub CLI access.
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          PACKAGES=(
-            "kdna-cli:kdna-cli:package.json:v:@aikdna/kdna-cli"
-            "kdna-mcp-server:kdna-skills:mcp-server/package.json:v:@aikdna/kdna-mcp-server"
-            "kdna-studio-cli:kdna-studio-cli:package.json:v:@aikdna/kdna-studio-cli"
-            "kdna-studio-core:kdna-studio-core:package.json:v:@aikdna/kdna-studio-core"
-            "kdna-activation-server:kdna-activation-server:package.json:v:@aikdna/kdna-activation-server"
-            "kdna-remote-server:kdna-remote-server:package.json:v:@aikdna/kdna-remote-server"
-            "kdna-web-server:kdna-web-server:package.json:v:@aikdna/kdna-web-server"
-            "kdna-web-client:kdna-web-client:package.json:v:@aikdna/kdna-web-client"
-            "kdna-react:kdna-react:package.json:v:@aikdna/kdna-react"
-            "create-kdna-web-app:create-kdna-web-app:package.json:v:create-kdna-web-app"
-            "kdna-core:kdna:packages/kdna-core/package.json:natural:@aikdna/kdna-core"
-            "kdna-eval:kdna:packages/kdna-eval/package.json:eval/:@aikdna/kdna-eval"
-          )
-          DRIFT=0
-          echo "| package | main | tag | npm | release | drift |"
-          echo "| --- | --- | --- | --- | --- | --- |"
-          for entry in "${PACKAGES[@]}"; do
-            IFS=':' read -r pkg repo package_path tag_prefix npm_spec <<< "$entry"
-            # Use curl + raw.githubusercontent.com (no auth needed for public repos)
-            main_v=$(curl -sS "https://raw.githubusercontent.com/aikdna/${repo}/main/${package_path}" 2>/dev/null \
-              | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d["version"])' 2>/dev/null || echo "")
-            if [ "$tag_prefix" = "natural" ]; then
-              tag_v=$(git ls-remote --tags "https://github.com/aikdna/$repo.git" 2>/dev/null \
-                | awk '{print $2}' \
-                | sed 's#^refs/tags/##' \
-                | awk '$0 ~ /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/ {print $0}' \
-                | sort -V | tail -1 || echo "")
-              tag_stripped="$tag_v"
-              tag_display="$tag_v"
-            else
-              tag_v=$(git ls-remote --tags "https://github.com/aikdna/$repo.git" 2>/dev/null \
-                | awk '{print $2}' \
-                | sed 's#^refs/tags/##' \
-                | awk -v prefix="${tag_prefix}" 'index($0, prefix) == 1 && $0 !~ /\^\{\}$/ {print $0}' \
-                | sort -V | tail -1 || echo "")
-              tag_stripped="${tag_v#${tag_prefix}}"
-              tag_display="${tag_prefix}${tag_stripped}"
-            fi
-            npm_v=$(npm view "$npm_spec" version 2>/dev/null || echo "")
-            if [ "$tag_prefix" = "natural" ]; then
-              release_tag="$npm_v"
-            else
-              release_tag="${tag_prefix}${npm_v}"
-            fi
-            rel_http=$(curl -sS -o /dev/null -w "%{http_code}" "https://api.github.com/repos/aikdna/${repo}/releases/tags/${release_tag}" 2>/dev/null)
-            rel_exists=$([ "$rel_http" = "200" ] && echo "yes" || echo "no")
-            drift="ok"
-            if [ -z "$main_v" ] || [ -z "$npm_v" ] || [ "$main_v" != "$tag_stripped" ] || [ "$tag_stripped" != "$npm_v" ] || [ "$rel_exists" = "no" ]; then
-              drift="DRIFT"
-              DRIFT=$((DRIFT+1))
-            fi
-            echo "| $pkg | ${main_v:-?} | ${tag_display:-?} | ${npm_v:-?} | $rel_exists | $drift |"
-          done
-          echo "## publish-health drift report" >> $GITHUB_STEP_SUMMARY
-          echo "Drift count: $DRIFT" >> $GITHUB_STEP_SUMMARY
-          if [ "$DRIFT" -gt 0 ]; then exit 1; fi
+          node scripts/publish-health.mjs | tee -a "$GITHUB_STEP_SUMMARY"
         continue-on-error: true
 
       - name: Summarize results

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "audit:post-cutover": "node scripts/check-post-cutover-naming.mjs",
     "test:post-cutover": "node --test scripts/test-post-cutover-naming.mjs",
     "test:release-scopes": "node --test scripts/test-scoped-release-readiness.mjs",
+    "test:release-health": "node --test scripts/test-publish-health.mjs",
     "validate:app-schemas": "node scripts/validate-app-schemas.js",
     "validate:protocol-fixtures": "node scripts/validate-protocol-fixtures.js",
     "validate:rfc0013-schemas": "node scripts/validate-rfc0013-schemas.js",

--- a/release-health-policy.json
+++ b/release-health-policy.json
@@ -1,0 +1,92 @@
+{
+  "schema_version": "1",
+  "packages": [
+    {
+      "label": "KDNA CLI",
+      "repository": "aikdna/kdna-cli",
+      "package_json": "package.json",
+      "npm_package": "@aikdna/kdna-cli",
+      "canonical_tag": { "type": "natural" }
+    },
+    {
+      "label": "KDNA MCP Server",
+      "repository": "aikdna/kdna-skills",
+      "package_json": "mcp-server/package.json",
+      "npm_package": "@aikdna/kdna-mcp-server",
+      "canonical_tag": { "type": "prefix", "value": "v" }
+    },
+    {
+      "label": "KDNA Studio CLI",
+      "repository": "aikdna/kdna-studio-cli",
+      "package_json": "package.json",
+      "npm_package": "@aikdna/kdna-studio-cli",
+      "canonical_tag": { "type": "natural" }
+    },
+    {
+      "label": "KDNA Studio Core",
+      "repository": "aikdna/kdna-studio-core",
+      "package_json": "package.json",
+      "npm_package": "@aikdna/kdna-studio-core",
+      "canonical_tag": { "type": "natural" }
+    },
+    {
+      "label": "KDNA Activation Server",
+      "repository": "aikdna/kdna-activation-server",
+      "package_json": "package.json",
+      "npm_package": "@aikdna/kdna-activation-server",
+      "canonical_tag": { "type": "natural" }
+    },
+    {
+      "label": "KDNA Remote Server",
+      "repository": "aikdna/kdna-remote-server",
+      "package_json": "package.json",
+      "npm_package": "@aikdna/kdna-remote-server",
+      "canonical_tag": { "type": "natural" }
+    },
+    {
+      "label": "KDNA Web Server",
+      "repository": "aikdna/kdna-web-server",
+      "package_json": "package.json",
+      "npm_package": "@aikdna/kdna-web-server",
+      "canonical_tag": { "type": "natural" }
+    },
+    {
+      "label": "KDNA Web Client",
+      "repository": "aikdna/kdna-web-client",
+      "package_json": "package.json",
+      "npm_package": "@aikdna/kdna-web-client",
+      "canonical_tag": { "type": "natural" }
+    },
+    {
+      "label": "KDNA React",
+      "repository": "aikdna/kdna-react",
+      "package_json": "package.json",
+      "npm_package": "@aikdna/kdna-react",
+      "canonical_tag": { "type": "natural" }
+    },
+    {
+      "label": "Create KDNA Web App",
+      "repository": "aikdna/create-kdna-web-app",
+      "package_json": "package.json",
+      "npm_package": "create-kdna-web-app",
+      "canonical_tag": { "type": "natural" }
+    },
+    {
+      "label": "KDNA Core",
+      "repository": "aikdna/kdna",
+      "package_json": "packages/kdna-core/package.json",
+      "npm_package": "@aikdna/kdna-core",
+      "canonical_tag": { "type": "natural" }
+    },
+    {
+      "label": "KDNA Eval",
+      "repository": "aikdna/kdna",
+      "package_json": "packages/kdna-eval/package.json",
+      "npm_package": "@aikdna/kdna-eval",
+      "canonical_tag": { "type": "prefix", "value": "eval/" },
+      "legacy_release_tag_sha256": {
+        "0.3.1": "711abd8fd04f2b1466e8c0f331a1139cbe67361fec6c8c3c2957adc7b786c4b4"
+      }
+    }
+  ]
+}

--- a/scripts/publish-health.mjs
+++ b/scripts/publish-health.mjs
@@ -1,0 +1,236 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const policyPath = path.join(repoRoot, 'release-health-policy.json');
+const stableSemver = /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/u;
+const slsaPredicate = 'https://slsa.dev/provenance/v1';
+
+export function canonicalTag(policy, version) {
+  if (!stableSemver.test(version)) {
+    throw new Error(`invalid stable version: ${version}`);
+  }
+  if (policy.type === 'natural') return version;
+  if (policy.type === 'prefix' && typeof policy.value === 'string' && policy.value) {
+    return `${policy.value}${version}`;
+  }
+  throw new Error('canonical_tag must be natural or a non-empty prefix');
+}
+
+export function validatePolicy(policy) {
+  if (policy?.schema_version !== '1' || !Array.isArray(policy.packages)) {
+    throw new Error('release-health policy must use schema_version 1 and a packages array');
+  }
+
+  const packageNames = new Set();
+  const sourcePaths = new Set();
+  for (const entry of policy.packages) {
+    for (const field of ['label', 'repository', 'package_json', 'npm_package', 'canonical_tag']) {
+      if (!entry[field]) throw new Error(`release-health entry is missing ${field}`);
+    }
+    if (!/^aikdna\/[a-z0-9._-]+$/u.test(entry.repository)) {
+      throw new Error(`invalid public repository coordinate: ${entry.repository}`);
+    }
+    if (entry.package_json.startsWith('/') || entry.package_json.split('/').includes('..')) {
+      throw new Error(`package_json must stay inside its repository: ${entry.package_json}`);
+    }
+    if (packageNames.has(entry.npm_package)) {
+      throw new Error(`duplicate npm package: ${entry.npm_package}`);
+    }
+    const sourceKey = `${entry.repository}:${entry.package_json}`;
+    if (sourcePaths.has(sourceKey)) throw new Error(`duplicate package source: ${sourceKey}`);
+    packageNames.add(entry.npm_package);
+    sourcePaths.add(sourceKey);
+    canonicalTag(entry.canonical_tag, '1.2.3');
+
+    for (const [version, digest] of Object.entries(entry.legacy_release_tag_sha256 || {})) {
+      if (!stableSemver.test(version) || !/^[a-f0-9]{64}$/u.test(digest)) {
+        throw new Error(`invalid exact legacy release coordinate for ${entry.npm_package}`);
+      }
+    }
+  }
+  return policy;
+}
+
+export function candidateTags(entry, version) {
+  return [canonicalTag(entry.canonical_tag, version)];
+}
+
+export function legacyTagDigest(entry, version) {
+  return entry.legacy_release_tag_sha256?.[version] || null;
+}
+
+export function fetchHeaders(url) {
+  const headers = {
+    'User-Agent': 'aikdna-publish-health',
+  };
+  if (new URL(url).hostname === 'api.github.com') {
+    headers.Accept = 'application/vnd.github+json';
+    if (process.env.GITHUB_TOKEN) headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+  return headers;
+}
+
+async function fetchJson(url) {
+  const response = await fetch(url, {
+    headers: fetchHeaders(url),
+    signal: AbortSignal.timeout(20_000),
+  });
+  if (!response.ok) throw new Error(`request failed with HTTP ${response.status}`);
+  return response.json();
+}
+
+function resolveTagCommit(repository, tag) {
+  const output = execFileSync(
+    'git',
+    [
+      'ls-remote',
+      '--tags',
+      `https://github.com/${repository}.git`,
+      `refs/tags/${tag}`,
+      `refs/tags/${tag}^{}`,
+    ],
+    { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 20_000 },
+  );
+  const refs = new Map(
+    output
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => line.split(/\s+/u).reverse()),
+  );
+  return refs.get(`refs/tags/${tag}^{}`) || refs.get(`refs/tags/${tag}`) || null;
+}
+
+async function releaseExists(repository, tag) {
+  const url = `https://api.github.com/repos/${repository}/releases/tags/${encodeURIComponent(tag)}`;
+  const response = await fetch(url, {
+    headers: fetchHeaders(url),
+    signal: AbortSignal.timeout(20_000),
+  });
+  if (response.status === 404) return false;
+  if (!response.ok) throw new Error(`release lookup failed with HTTP ${response.status}`);
+  const release = await response.json();
+  return release.draft === false && release.prerelease === false;
+}
+
+async function findLegacyRelease(entry, version) {
+  const expectedDigest = legacyTagDigest(entry, version);
+  if (!expectedDigest) return null;
+  const releases = await fetchJson(
+    `https://api.github.com/repos/${entry.repository}/releases?per_page=100`,
+  );
+  const release = releases.find(
+    (candidate) =>
+      candidate.draft === false &&
+      candidate.prerelease === false &&
+      typeof candidate.tag_name === 'string' &&
+      candidate.tag_name.endsWith(version) &&
+      createHash('sha256').update(candidate.tag_name).digest('hex') === expectedDigest,
+  );
+  if (!release) return null;
+  const commit = resolveTagCommit(entry.repository, release.tag_name);
+  return commit ? { tag: release.tag_name, commit, legacy: true } : null;
+}
+
+async function selectRelease(entry, version) {
+  for (const tag of candidateTags(entry, version)) {
+    const commit = resolveTagCommit(entry.repository, tag);
+    if (commit && (await releaseExists(entry.repository, tag))) {
+      return {
+        tag,
+        commit,
+        legacy: tag !== canonicalTag(entry.canonical_tag, version),
+      };
+    }
+  }
+  return findLegacyRelease(entry, version);
+}
+
+async function auditPackage(entry) {
+  const registry = await fetchJson(
+    `https://registry.npmjs.org/${encodeURIComponent(entry.npm_package)}/latest`,
+  );
+  const npmVersion = registry.version;
+  if (!stableSemver.test(npmVersion || '')) throw new Error('npm latest is not stable SemVer');
+
+  const source = await fetchJson(
+    `https://raw.githubusercontent.com/${entry.repository}/main/${entry.package_json}`,
+  );
+  const release = await selectRelease(entry, npmVersion);
+  const taggedSource = release
+    ? await fetchJson(
+        `https://raw.githubusercontent.com/${entry.repository}/${release.commit}/${entry.package_json}`,
+      )
+    : null;
+  const provenance =
+    Boolean(registry.dist?.attestations?.url) &&
+    registry.dist?.attestations?.provenance?.predicateType === slsaPredicate;
+  const sourceBound =
+    !registry.gitHead || !release ? Boolean(release) : registry.gitHead === release.commit;
+
+  const failures = [];
+  if (source.version !== npmVersion) failures.push('main/npm version mismatch');
+  if (!release) failures.push('release tag or published Release missing');
+  if (taggedSource && taggedSource.version !== npmVersion) failures.push('tag/npm mismatch');
+  if (!sourceBound) failures.push('npm gitHead/tag commit mismatch');
+  if (!provenance) failures.push('SLSA provenance missing');
+
+  return {
+    entry,
+    mainVersion: source.version || null,
+    npmVersion,
+    release,
+    provenance,
+    failures,
+  };
+}
+
+export async function run(policy = validatePolicy(JSON.parse(fs.readFileSync(policyPath, 'utf8')))) {
+  const results = [];
+  for (const entry of policy.packages) {
+    try {
+      results.push(await auditPackage(entry));
+    } catch (error) {
+      results.push({
+        entry,
+        mainVersion: null,
+        npmVersion: null,
+        release: null,
+        provenance: false,
+        failures: [error.message],
+      });
+    }
+  }
+
+  console.log('## npm publish-health report\n');
+  console.log('| package | main | npm | release | provenance | status |');
+  console.log('| --- | --- | --- | --- | --- | --- |');
+  for (const result of results) {
+    const release = result.release
+      ? result.release.legacy
+        ? `historical release for ${result.npmVersion}`
+        : result.release.tag
+      : '?';
+    const status = result.failures.length ? result.failures.join('; ') : 'ok';
+    console.log(
+      `| ${result.entry.npm_package} | ${result.mainVersion || '?'} | ${result.npmVersion || '?'} | ${release} | ${result.provenance ? 'SLSA v1' : 'missing'} | ${status} |`,
+    );
+  }
+
+  const failures = results.reduce((total, result) => total + result.failures.length, 0);
+  const legacy = results.filter((result) => result.release?.legacy).length;
+  console.log(`\nFailures: ${failures}. Exact grandfathered legacy coordinates: ${legacy}.`);
+  return { results, failures, legacy };
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const outcome = await run();
+  process.exitCode = outcome.failures === 0 ? 0 : 1;
+}

--- a/scripts/publish-health.mjs
+++ b/scripts/publish-health.mjs
@@ -192,7 +192,9 @@ async function auditPackage(entry) {
   };
 }
 
-export async function run(policy = validatePolicy(JSON.parse(fs.readFileSync(policyPath, 'utf8')))) {
+export async function run(
+  policy = validatePolicy(JSON.parse(fs.readFileSync(policyPath, 'utf8'))),
+) {
   const results = [];
   for (const entry of policy.packages) {
     try {

--- a/scripts/test-publish-health.mjs
+++ b/scripts/test-publish-health.mjs
@@ -69,7 +69,10 @@ test('GitHub credentials are never sent to registry or source hosts', () => {
   process.env.GITHUB_TOKEN = 'test-only-placeholder';
   try {
     assert.equal(fetchHeaders('https://registry.npmjs.org/a/latest').Authorization, undefined);
-    assert.equal(fetchHeaders('https://raw.githubusercontent.com/a/b/main/package.json').Authorization, undefined);
+    assert.equal(
+      fetchHeaders('https://raw.githubusercontent.com/a/b/main/package.json').Authorization,
+      undefined,
+    );
     assert.equal(
       fetchHeaders('https://api.github.com/repos/a/b/releases/tags/1.0.0').Authorization,
       'Bearer test-only-placeholder',

--- a/scripts/test-publish-health.mjs
+++ b/scripts/test-publish-health.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+import {
+  candidateTags,
+  canonicalTag,
+  fetchHeaders,
+  legacyTagDigest,
+  validatePolicy,
+} from './publish-health.mjs';
+
+const policy = JSON.parse(
+  fs.readFileSync(new URL('../release-health-policy.json', import.meta.url), 'utf8'),
+);
+
+test('release-health policy is complete, unique, and structurally valid', () => {
+  assert.equal(validatePolicy(policy), policy);
+  assert.equal(policy.packages.length, 12);
+  assert.deepEqual(
+    new Set(policy.packages.map((entry) => entry.npm_package)),
+    new Set([
+      '@aikdna/kdna-cli',
+      '@aikdna/kdna-mcp-server',
+      '@aikdna/kdna-studio-cli',
+      '@aikdna/kdna-studio-core',
+      '@aikdna/kdna-activation-server',
+      '@aikdna/kdna-remote-server',
+      '@aikdna/kdna-web-server',
+      '@aikdna/kdna-web-client',
+      '@aikdna/kdna-react',
+      'create-kdna-web-app',
+      '@aikdna/kdna-core',
+      '@aikdna/kdna-eval',
+    ]),
+  );
+});
+
+test('natural and prefixed canonical tags are exact', () => {
+  assert.equal(canonicalTag({ type: 'natural' }, '1.2.3'), '1.2.3');
+  assert.equal(canonicalTag({ type: 'prefix', value: 'eval/' }, '1.2.3'), 'eval/1.2.3');
+  assert.throws(() => canonicalTag({ type: 'natural' }, 'v1.2.3'));
+  assert.throws(() => canonicalTag({ type: 'prefix', value: '' }, '1.2.3'));
+});
+
+test('Eval accepts one exact historical coordinate without perpetuating it', () => {
+  const evalPolicy = policy.packages.find((entry) => entry.npm_package === '@aikdna/kdna-eval');
+  assert.deepEqual(candidateTags(evalPolicy, '0.3.1'), ['eval/0.3.1']);
+  assert.deepEqual(candidateTags(evalPolicy, '0.3.2'), ['eval/0.3.2']);
+  assert.equal(
+    legacyTagDigest(evalPolicy, '0.3.1'),
+    '711abd8fd04f2b1466e8c0f331a1139cbe67361fec6c8c3c2957adc7b786c4b4',
+  );
+  assert.equal(legacyTagDigest(evalPolicy, '0.3.2'), null);
+});
+
+test('all other packages use only their canonical coordinate', () => {
+  for (const entry of policy.packages.filter(
+    (candidate) => candidate.npm_package !== '@aikdna/kdna-eval',
+  )) {
+    assert.deepEqual(candidateTags(entry, '9.8.7'), [canonicalTag(entry.canonical_tag, '9.8.7')]);
+  }
+});
+
+test('GitHub credentials are never sent to registry or source hosts', () => {
+  const previous = process.env.GITHUB_TOKEN;
+  process.env.GITHUB_TOKEN = 'test-only-placeholder';
+  try {
+    assert.equal(fetchHeaders('https://registry.npmjs.org/a/latest').Authorization, undefined);
+    assert.equal(fetchHeaders('https://raw.githubusercontent.com/a/b/main/package.json').Authorization, undefined);
+    assert.equal(
+      fetchHeaders('https://api.github.com/repos/a/b/releases/tags/1.0.0').Authorization,
+      'Bearer test-only-placeholder',
+    );
+  } finally {
+    if (previous === undefined) delete process.env.GITHUB_TOKEN;
+    else process.env.GITHUB_TOKEN = previous;
+  }
+});


### PR DESCRIPTION
## Summary
- replace the stale inline tag-prefix audit with a versioned, testable release-health policy
- verify main, npm latest, exact tag source, published Release, npm gitHead when exposed, and SLSA v1 provenance
- preserve the existing Eval 0.3.1 historical Release by hash only while requiring the canonical eval/ coordinate for future versions
- restrict GitHub authentication headers to api.github.com and add a hostile boundary test

## Local evidence
- npm run test:release-health
- npm run test:release-scopes
- npm run test:post-cutover
- npm run audit:post-cutover
- node scripts/publish-health.mjs (12/12 current coordinates, 0 failures)
- npm run audit:public-confidence
- npm run format:check

Signed-off-by: aikdna <283974009+aikdna@users.noreply.github.com>