### PR TITLE
docs: bind accepted license wave commits

### DIFF
--- a/ecosystem-manifest.json
+++ b/ecosystem-manifest.json
@@ -57,7 +57,7 @@
       "supported_kdna_version": "1.0",
       "supported_access_modes": ["public"],
       "supported_entitlement_profiles": [],
-      "conformance_commit": "2dd1e2844fd8b8deff8ea0e2620fd946e5c9544f",
+      "conformance_commit": "c8a6c294d2c57e891b4baef6c601cfa0a8798086",
       "known_limitations": [
         "reference assets provide content-specific evidence and do not establish a general protocol capability claim",
         "the repository package is private validation tooling; the public coordinate is the exact GitHub Release artifact, not an npm package"
@@ -124,7 +124,7 @@
       "supported_kdna_version": "1.0",
       "supported_access_modes": ["licensed"],
       "supported_entitlement_profiles": ["license_key"],
-      "conformance_commit": "bb75f114fbd0969a176671e12df3b003186228da",
+      "conformance_commit": "6e203a78c038f15c0e65f19b9aa22a6f642478cb",
       "known_limitations": [
         "self-hosted support surface only; not an AIKDNA-hosted activation service",
         "paid distribution and commercial delivery flows are not part of the public Core baseline"
@@ -142,7 +142,7 @@
       "supported_kdna_version": "1.0",
       "supported_access_modes": ["remote"],
       "supported_entitlement_profiles": [],
-      "conformance_commit": "9df3155ee0b45814cc31c5476373494eee595761",
+      "conformance_commit": "eb677ea0fece9b0886724df8383563253ec45600",
       "known_limitations": [
         "self-hosted projection server only; there is no AIKDNA-hosted remote loading service",
         "remote-mode server operation remains an experimental self-hosted reference surface"
@@ -160,7 +160,7 @@
       "supported_kdna_version": "1.0",
       "supported_access_modes": ["public"],
       "supported_entitlement_profiles": [],
-      "conformance_commit": "6a7cfc493d454affda249a5fc8c12ec0ed473fb1",
+      "conformance_commit": "9fc1377bfb378d5977ab77dcdc30ee4f0b2a181d",
       "known_limitations": [
         "published to npm as an experimental integration surface, not a stable hosted-platform claim",
         "the verified surface is Node.js-hosted Next.js and Express; server-side Studio export, remote forwarding, and CORS helpers are not implemented"
@@ -178,7 +178,7 @@
       "supported_kdna_version": "1.0",
       "supported_access_modes": ["public"],
       "supported_entitlement_profiles": [],
-      "conformance_commit": "7b7f140cfe3abde5d5efb1794bed726d47eaec84",
+      "conformance_commit": "d128ac815fc82d0249b7f49793a1a0103949c4ee",
       "known_limitations": [
         "published to npm as an experimental integration surface, not a stable browser runtime",
         "browser utilities must never perform KDNA decryption; server-side loading remains required"
@@ -196,7 +196,7 @@
       "supported_kdna_version": "1.0",
       "supported_access_modes": ["public"],
       "supported_entitlement_profiles": [],
-      "conformance_commit": "986f2956e07f357b2bd92a499b4e9153871c5e6b",
+      "conformance_commit": "3edcdce0f75b6dfb1eb4147cedaf24f8af6574a3",
       "known_limitations": [
         "published to npm as an experimental integration surface, not a hosted-platform claim",
         "the verified boundary is Web Client 0.2.2, Web Server 0.3.0, Activation 0.2.0, React 18 or 19, and Node.js 20 or later"


### PR DESCRIPTION
## Summary
- update the central ecosystem manifest to the six accepted Apache-2.0 mainline commits
- preserve all package versions, lifecycle states, artifact coordinates, and public limitations
- bind Assets to the commit that separates root Apache-2.0 code/docs from entry-scoped CC-BY-4.0 assets

## Accepted downstream evidence
- all six protected PRs and main CI runs are green
- GitHub identifies Activation, React, Remote, Web Client, Web Server, and Assets as Apache-2.0
- local manifest validation passed against an exact clean CLI conformance checkout
- public-truth, public-surface, post-cutover naming, and diff checks passed

Signed-off-by: aikdna <283974009+aikdna@users.noreply.github.com>