### PR TITLE
release: repair compatibility gate rehearsal

### DIFF
--- a/.github/workflows/core-smoke.yml
+++ b/.github/workflows/core-smoke.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-core-swift
-          ref: b1f7f1a7cba5459413f00ecc0302f71e0d21ef78
+          ref: 4a9b732b590a711c544da5280a4b78f071369617
           path: .ecosystem-repos/kdna-core-swift
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:

--- a/.github/workflows/core-smoke.yml
+++ b/.github/workflows/core-smoke.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   smoke:
     name: core-smoke
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
@@ -53,8 +53,18 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-skills
-          ref: 7e2b2725a700176209f5e21444e28a049e808d4f
+          ref: c9ac7de534b7ba810217d1d15b14a23a6e5b845f
           path: .ecosystem-repos/kdna-skills
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          repository: aikdna/kdna-core-swift
+          ref: b1f7f1a7cba5459413f00ecc0302f71e0d21ef78
+          path: .ecosystem-repos/kdna-core-swift
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          repository: aikdna/kdna-vscode
+          ref: c0d885ba8222b6dccad87ec67f7d82fcc1283107
+          path: .ecosystem-repos/kdna-vscode
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-studio-cli
@@ -81,23 +91,45 @@ jobs:
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: '3.12'
+      - name: Select the outside-repository trusted npm release
+        run: |
+          echo "KDNA_TRUSTED_NPM_TARBALL=$RUNNER_TEMP/npm-11.17.0.tgz" >> "$GITHUB_ENV"
+      - name: Fetch and authenticate the audited npm release bytes
+        run: >-
+          node scripts/core-release-authority.js provision-npm
+          --artifact "$RUNNER_TEMP/npm-11.17.0.tgz"
+      - name: Verify the isolated npm CLI and extraction boundary
+        run: node scripts/core-release-authority.js verify-npm
       - name: Install workspace deps
-        run: npm ci
+        run: node scripts/core-release-authority.js trusted-npm ci --ignore-scripts
       - name: Install fixed Python test dependency
         run: python -m pip install --disable-pip-version-check --no-input pytest==9.1.0
       - name: Run core-smoke
-        run: npm run test:core-smoke
+        run: node scripts/core-release-authority.js trusted-npm run test:core-smoke
       - name: Run full kdna-core test suite
-        run: npm --workspace @aikdna/kdna-core test
+        run: >-
+          node scripts/core-release-authority.js trusted-npm
+          --workspace @aikdna/kdna-core test
       - name: Run kdna-eval test suite
-        run: npm --workspace @aikdna/kdna-eval test
+        run: >-
+          node scripts/core-release-authority.js trusted-npm
+          --workspace @aikdna/kdna-eval test
       - name: Cross-repo ecosystem-version-lock (PR-8)
         env:
           KDNA_REPOS_ROOT: ${{ github.workspace }}/.ecosystem-repos
           KDNA_CONTROL_ROOT: ${{ github.workspace }}
-        run: npm run test:ecosystem-lock
+        run: >-
+          node scripts/core-release-authority.js trusted-npm
+          run test:ecosystem-lock
       - name: Verify Python adapter against the exact current CLI
         env:
           KDNA_CLI: ${{ github.workspace }}/node_modules/.bin/kdna
           PYTHONPATH: ${{ github.workspace }}/python-sdk
         run: python -m pytest python-sdk/tests -q
+      - name: Rehearse the complete compatibility ecosystem gate
+        env:
+          KDNA_PYTHON: ${{ env.pythonLocation }}/bin/python
+        run: node scripts/core-release-authority.js trusted-npm run ecosystem-gate
+      - name: Remove the trusted npm release bytes
+        if: always()
+        run: rm -f "$KDNA_TRUSTED_NPM_TARBALL"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -175,7 +175,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-skills
-          ref: 7e2b2725a700176209f5e21444e28a049e808d4f
+          ref: c9ac7de534b7ba810217d1d15b14a23a6e5b845f
           path: .ecosystem-repos/kdna-skills
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -190,7 +190,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-core-swift
-          ref: b1f7f1a7cba5459413f00ecc0302f71e0d21ef78
+          ref: 4a9b732b590a711c544da5280a4b78f071369617
           path: .ecosystem-repos/kdna-core-swift
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:

--- a/ecosystem-manifest.json
+++ b/ecosystem-manifest.json
@@ -76,7 +76,7 @@
       "supported_kdna_version": "1.0",
       "supported_access_modes": ["public"],
       "supported_entitlement_profiles": [],
-      "conformance_commit": "7e2b2725a700176209f5e21444e28a049e808d4f",
+      "conformance_commit": "c9ac7de534b7ba810217d1d15b14a23a6e5b845f",
       "known_limitations": [
         "MCP is a structured bridge; the loader skill remains the default Agent integration"
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1767,7 +1767,7 @@
     },
     "packages/kdna": {
       "name": "@aikdna/kdna",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aikdna/kdna-cli": "0.35.0",

--- a/packages/kdna/CHANGELOG.md
+++ b/packages/kdna/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.13.1 (2026-07-18)
+
+- Preserve the 0.13.0 toolchain binding while rehearsing the full cross-repo
+  gate in the same audited, scripts-off npm environment used for publication.
+- Bind the MCP test checkout to its accepted isolation fix so the nested
+  dry-run explicitly verifies prepublish ordering without weakening real
+  retained-artifact publication.
+- Add a bounded ecosystem-stage diagnostic for fail-closed release failures;
+  arbitrary child and provider output remains suppressed.
+- Supersede the withdrawn `compat/0.13.0` GitHub release, which stopped before
+  artifact construction and was never published to npm.
+
 ## 0.13.0 (2026-07-18)
 
 - Pin the compatibility package to the exact KDNA CLI 0.35.0 and KDNA Core

--- a/packages/kdna/README.md
+++ b/packages/kdna/README.md
@@ -25,7 +25,7 @@ npm install -g @aikdna/kdna-cli
 This package remains available so older installation instructions using
 `@aikdna/kdna` resolve to the current KDNA CLI.
 
-Version 0.13.0 is bound to `@aikdna/kdna-cli@0.35.0` and
+Version 0.13.1 is bound to `@aikdna/kdna-cli@0.35.0` and
 `@aikdna/kdna-core@0.20.0`, requires Node.js 20 or later, and installs one
 physical Core package. It is a migration bridge, not the recommended package
 for new applications.

--- a/packages/kdna/package.json
+++ b/packages/kdna/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aikdna/kdna",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "KDNA toolkit compatibility package. The kdna CLI binary has moved to @aikdna/kdna-cli \u2014 use npm install -g @aikdna/kdna-cli.",
   "type": "commonjs",
   "bin": {

--- a/packages/kdna/scripts/smoke-release-artifact.js
+++ b/packages/kdna/scripts/smoke-release-artifact.js
@@ -78,7 +78,7 @@ function main() {
     const cliPath = path.join(modules, '@aikdna', 'kdna-cli');
     const corePath = path.join(modules, '@aikdna', 'kdna-core');
     const expected = [
-      [compatPath, '@aikdna/kdna', '0.13.0'],
+      [compatPath, '@aikdna/kdna', '0.13.1'],
       [cliPath, '@aikdna/kdna-cli', '0.35.0'],
       [corePath, '@aikdna/kdna-core', '0.20.0'],
     ];

--- a/packages/kdna/test/compat.test.js
+++ b/packages/kdna/test/compat.test.js
@@ -73,7 +73,7 @@ function discoverPackableFixtures(fixturesRoot) {
 
 test('compatibility manifest pins one released toolchain without claiming the current CLI binary', () => {
   const pkg = JSON.parse(fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf8'));
-  assert.equal(pkg.version, '0.13.0');
+  assert.equal(pkg.version, '0.13.1');
   assert.deepEqual(pkg.dependencies, {
     '@aikdna/kdna-cli': '0.35.0',
     '@aikdna/kdna-core': '0.20.0',
@@ -97,7 +97,7 @@ test('root lock resolves the compatibility package to one exact Core and CLI pai
     '@aikdna/kdna-cli': '0.35.0',
     '@aikdna/kdna-core': '0.20.0',
   });
-  assert.equal(lock.packages['packages/kdna'].version, '0.13.0');
+  assert.equal(lock.packages['packages/kdna'].version, '0.13.1');
   assertCurrentToolchainLock(lock);
 });
 

--- a/packages/kdna/test/publish-hardening.test.js
+++ b/packages/kdna/test/publish-hardening.test.js
@@ -43,7 +43,7 @@ const UPLOAD_ACTION_SHA = 'ea165f8d65b6e75b540449e92b4886f43607fa02';
 const EXPECTED_CONSUMER_CHECKOUTS = [
   ['aikdna/create-kdna-web-app', '4241dc20814bae4fcf72d44df7c0670ef70bda00'],
   ['aikdna/kdna-cli', '6927df153b0b3b592a500760f6d87eac6fde7860'],
-  ['aikdna/kdna-skills', '7e2b2725a700176209f5e21444e28a049e808d4f'],
+  ['aikdna/kdna-skills', 'c9ac7de534b7ba810217d1d15b14a23a6e5b845f'],
   ['aikdna/kdna-studio-core', 'e1d49b3cb3e6c236499a3ecbd6884497e41fd834'],
   ['aikdna/kdna-studio-cli', 'abd1624741a5dfa0b1a604e44d57209ce3caf18b'],
   ['aikdna/kdna-activation-server', '6e203a78c038f15c0e65f19b9aa22a6f642478cb'],
@@ -53,6 +53,11 @@ const EXPECTED_CONSUMER_CHECKOUTS = [
   ['aikdna/kdna-react', '3edcdce0f75b6dfb1eb4147cedaf24f8af6574a3'],
   ['aikdna/kdna-assets', '2e28e0d16d2b915b942a8b600c0ba62c1de4898e'],
   ['aikdna/kdna-demo-web-viewer', 'a7d4df05973d472ec24ba060f3d9c02c0d22c6f3'],
+];
+const EXPECTED_COMPAT_CHECKOUTS = [
+  ...EXPECTED_CONSUMER_CHECKOUTS,
+  ['aikdna/kdna-core-swift', 'b1f7f1a7cba5459413f00ecc0302f71e0d21ef78'],
+  ['aikdna/kdna-vscode', 'c0d885ba8222b6dccad87ec67f7d82fcc1283107'],
 ];
 
 function releaseInput(overrides = {}) {
@@ -249,11 +254,7 @@ test('compatibility workflow fixes every live checkout and publishes only the re
   const workflow = fs.readFileSync(path.join(REPO_ROOT, '.github', 'workflows', 'publish.yml'), 'utf8');
   const start = workflow.indexOf('  publish-compat:');
   const job = workflow.slice(start);
-  for (const [repository, commit] of [
-    ...EXPECTED_CONSUMER_CHECKOUTS,
-    ['aikdna/kdna-core-swift', 'b1f7f1a7cba5459413f00ecc0302f71e0d21ef78'],
-    ['aikdna/kdna-vscode', 'c0d885ba8222b6dccad87ec67f7d82fcc1283107'],
-  ]) {
+  for (const [repository, commit] of EXPECTED_COMPAT_CHECKOUTS) {
     assert.match(job, new RegExp(`repository: ${repository.replace('/', '\\/')}\\n\\s+ref: ${commit}`, 'u'));
   }
   assert.match(job, /ref: \$\{\{ github\.event\.release\.tag_name \}\}/u);
@@ -292,27 +293,45 @@ test('compatibility workflow fixes every live checkout and publishes only the re
   assert.match(job, /if: always\(\)/u);
 });
 
-test('core smoke checks every expected dependency consumer at an immutable accepted commit', () => {
+test('core smoke rehearses the release ecosystem with every immutable accepted checkout', () => {
   const workflow = fs.readFileSync(
     path.join(REPO_ROOT, '.github', 'workflows', 'core-smoke.yml'),
     'utf8',
   );
-  for (const [repository, commit] of EXPECTED_CONSUMER_CHECKOUTS) {
+  for (const [repository, commit] of EXPECTED_COMPAT_CHECKOUTS) {
     assert.match(
       workflow,
       new RegExp(`repository: ${repository.replace('/', '\\/')}\\n\\s+ref: ${commit}`, 'u'),
     );
   }
-  const versionLock = workflow.indexOf('npm run test:ecosystem-lock');
-  assert.ok(versionLock >= 0);
+  assert.match(workflow, /runs-on: macos-latest/u);
+  const provisionNpm = workflow.indexOf('provision-npm');
+  const verifyNpm = workflow.indexOf('verify-npm');
+  const install = workflow.indexOf('trusted-npm ci --ignore-scripts');
+  const versionLock = workflow.indexOf('run test:ecosystem-lock');
+  const ecosystemGateRun = workflow.indexOf('run ecosystem-gate');
+  assert.ok(provisionNpm >= 0 && provisionNpm < verifyNpm);
+  assert.ok(verifyNpm < install && install < versionLock);
+  assert.ok(versionLock < ecosystemGateRun);
   assert.ok(workflow.includes('KDNA_REPOS_ROOT: ${{ github.workspace }}/.ecosystem-repos'));
   assert.ok(workflow.includes('KDNA_CONTROL_ROOT: ${{ github.workspace }}'));
+  assert.ok(workflow.includes('KDNA_PYTHON: ${{ env.pythonLocation }}/bin/python'));
+  assert.ok(workflow.includes('KDNA_TRUSTED_NPM_TARBALL=$RUNNER_TEMP/npm-11.17.0.tgz'));
+  assert.match(workflow, /if: always\(\)/u);
   assert.match(workflow, /pytest==9\.1\.0/u);
   assert.match(workflow, /python -m pytest python-sdk\/tests -q/u);
   const ecosystemGate = fs.readFileSync(path.join(REPO_ROOT, 'scripts', 'ecosystem-gate.js'), 'utf8');
   assert.match(ecosystemGate, /python adapter pytest against current CLI/u);
+  assert.match(
+    ecosystemGate,
+    /const swiftModuleCache = fs\.mkdtempSync\([\s\S]*kdna-core-swift-ecosystem-gate-module-cache-/u,
+  );
+  assert.match(
+    ecosystemGate,
+    /finally \{\s+fs\.rmSync\(swiftModuleCache, \{ recursive: true, force: true \}\);\s+\}/u,
+  );
   const immutableCheckouts = [...workflow.matchAll(/uses: actions\/checkout@([^\s]+)/gu)];
-  assert.equal(immutableCheckouts.length, EXPECTED_CONSUMER_CHECKOUTS.length + 1);
+  assert.equal(immutableCheckouts.length, EXPECTED_COMPAT_CHECKOUTS.length + 1);
   for (const match of immutableCheckouts) assert.equal(match[1], CHECKOUT_ACTION_SHA);
 });
 
@@ -653,7 +672,7 @@ test('guard and publisher reparse one exact tarball before the network operation
       bound += 1;
     },
     lookup: (spec) => {
-      assert.equal(spec, '@aikdna/kdna@0.13.0');
+      assert.equal(spec, '@aikdna/kdna@0.13.1');
       lookedUp += 1;
       return e404Result(candidate);
     },

--- a/packages/kdna/test/publish-hardening.test.js
+++ b/packages/kdna/test/publish-hardening.test.js
@@ -56,7 +56,7 @@ const EXPECTED_CONSUMER_CHECKOUTS = [
 ];
 const EXPECTED_COMPAT_CHECKOUTS = [
   ...EXPECTED_CONSUMER_CHECKOUTS,
-  ['aikdna/kdna-core-swift', 'b1f7f1a7cba5459413f00ecc0302f71e0d21ef78'],
+  ['aikdna/kdna-core-swift', '4a9b732b590a711c544da5280a4b78f071369617'],
   ['aikdna/kdna-vscode', 'c0d885ba8222b6dccad87ec67f7d82fcc1283107'],
 ];
 

--- a/scripts/core-release-authority.js
+++ b/scripts/core-release-authority.js
@@ -9,6 +9,10 @@ const os = require('node:os');
 const path = require('node:path');
 const { TextDecoder } = require('node:util');
 const zlib = require('node:zlib');
+const {
+  ECOSYSTEM_GATE_STAGE_MAX_BYTES,
+  isSafeEcosystemGateStage,
+} = require('./ecosystem-gate-stages.js');
 
 const REPO_ROOT = path.resolve(__dirname, '..');
 const PACKAGE_RELATIVE = 'packages/kdna-core';
@@ -1421,6 +1425,29 @@ function runNpm(invocation, args, options = {}) {
   }
 }
 
+function extractSafeEcosystemFailureStage(args, result) {
+  if (
+    !Array.isArray(args) ||
+    args.length !== 2 ||
+    args[0] !== 'run' ||
+    args[1] !== 'ecosystem-gate'
+  ) {
+    return null;
+  }
+  const output = `${result && typeof result.stdout === 'string' ? result.stdout : ''}\n${
+    result && typeof result.stderr === 'string' ? result.stderr : ''
+  }`;
+  const matches = [
+    ...output.matchAll(
+      new RegExp(
+        `^KDNA_SAFE_ECOSYSTEM_STAGE=([a-z0-9-]{1,${ECOSYSTEM_GATE_STAGE_MAX_BYTES}})\\r?$`,
+        'gmu',
+      ),
+    ),
+  ].filter((match) => isSafeEcosystemGateStage(match[1]));
+  return matches.length === 1 ? matches[0][1] : null;
+}
+
 function runTrustedNpmCommand(args, options = {}) {
   assert(
     Array.isArray(args) &&
@@ -1455,7 +1482,14 @@ function runTrustedNpmCommand(args, options = {}) {
     });
     assert(!result.error, 'trusted npm workflow command failed');
     assert(Number.isInteger(result.status), 'trusted npm workflow command failed');
-    assert(result.status === 0, 'trusted npm workflow command failed');
+    if (result.status !== 0) {
+      const safeStage = extractSafeEcosystemFailureStage(args, result);
+      fail(
+        safeStage
+          ? `trusted npm workflow command failed at ecosystem stage ${safeStage}`
+          : 'trusted npm workflow command failed',
+      );
+    }
     if (result.stdout) process.stdout.write(result.stdout);
     return true;
   } finally {
@@ -2841,6 +2875,7 @@ module.exports = {
   createTokenUserConfig,
   comparePackageCommits,
   evaluateRegistryResult,
+  extractSafeEcosystemFailureStage,
   expectedRegistryE404,
   downloadTrustedNpmBytes,
   guardCandidate,

--- a/scripts/core-release-authority.test.js
+++ b/scripts/core-release-authority.test.js
@@ -31,6 +31,7 @@ const {
   commitDocument,
   createTokenUserConfig,
   evaluateRegistryResult,
+  extractSafeEcosystemFailureStage,
   expectedRegistryE404,
   guardCandidate,
   inspectTree,
@@ -479,6 +480,40 @@ test(
     assert.doesNotMatch(result.stderr, new RegExp(marker, 'u'));
   },
 );
+
+test('trusted npm exposes only one exact ecosystem stage sentinel', () => {
+  const args = ['run', 'ecosystem-gate'];
+  assert.equal(
+    extractSafeEcosystemFailureStage(args, {
+      stdout: 'ordinary test output\n',
+      stderr: 'provider details\nKDNA_SAFE_ECOSYSTEM_STAGE=swift-test\n',
+    }),
+    'swift-test',
+  );
+  for (const result of [
+    { stdout: 'KDNA_SAFE_ECOSYSTEM_STAGE=swift-test-suffix!', stderr: '' },
+    { stdout: 'prefix KDNA_SAFE_ECOSYSTEM_STAGE=swift-test', stderr: '' },
+    {
+      stdout: 'KDNA_SAFE_ECOSYSTEM_STAGE=swift-test\n',
+      stderr: 'KDNA_SAFE_ECOSYSTEM_STAGE=core-test\n',
+    },
+    { stdout: 'KDNA_SAFE_ECOSYSTEM_STAGE=Swift-Test\n', stderr: '' },
+    { stdout: 'KDNA_SAFE_ECOSYSTEM_STAGE=provider-detail\n', stderr: '' },
+    {
+      stdout: `KDNA_SAFE_ECOSYSTEM_STAGE=${'a'.repeat(33)}\n`,
+      stderr: '',
+    },
+  ]) {
+    assert.equal(extractSafeEcosystemFailureStage(args, result), null);
+  }
+  assert.equal(
+    extractSafeEcosystemFailureStage(['test'], {
+      stdout: 'KDNA_SAFE_ECOSYSTEM_STAGE=swift-test\n',
+      stderr: '',
+    }),
+    null,
+  );
+});
 
 test('publisher process environment uses a minimal provenance and token whitelist', () => {
   const invocation = {

--- a/scripts/ecosystem-gate-stages.js
+++ b/scripts/ecosystem-gate-stages.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const ECOSYSTEM_GATE_STAGE_MAX_BYTES = 32;
+const ECOSYSTEM_GATE_STAGES = Object.freeze([
+  'core-test',
+  'core-examples',
+  'core-manifest',
+  'core-public-truth',
+  'core-audit',
+  'python-adapter',
+  'cli-install',
+  'cli-audit',
+  'mcp-install',
+  'mcp-audit',
+  'studio-core-install',
+  'studio-core-audit',
+  'studio-cli-install',
+  'studio-cli-audit',
+  'cli-test',
+  'mcp-test',
+  'studio-core-test',
+  'studio-cli-test',
+  'swift-test',
+  'proof-asset-validate',
+  'proof-asset-plan',
+  'proof-asset-load',
+  'core-tarball',
+  'cli-tarball',
+  'mcp-tarball',
+]);
+const ECOSYSTEM_GATE_STAGE_SET = new Set(ECOSYSTEM_GATE_STAGES);
+
+function isSafeEcosystemGateStage(stage) {
+  return (
+    typeof stage === 'string' &&
+    Buffer.byteLength(stage, 'utf8') <= ECOSYSTEM_GATE_STAGE_MAX_BYTES &&
+    ECOSYSTEM_GATE_STAGE_SET.has(stage)
+  );
+}
+
+module.exports = {
+  ECOSYSTEM_GATE_STAGE_MAX_BYTES,
+  ECOSYSTEM_GATE_STAGES,
+  isSafeEcosystemGateStage,
+};

--- a/scripts/ecosystem-gate.js
+++ b/scripts/ecosystem-gate.js
@@ -5,27 +5,35 @@ const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
 const { spawnSync } = require('node:child_process');
+const { isSafeEcosystemGateStage } = require('./ecosystem-gate-stages.js');
 
 const repoRoot = path.resolve(__dirname, '..');
 const manifest = JSON.parse(
   fs.readFileSync(path.join(repoRoot, 'ecosystem-manifest.json'), 'utf8'),
 );
 const npmCacheDir = path.join(repoRoot, '.npm-cache', 'ecosystem-gate');
-const swiftModuleCache = path.join(os.tmpdir(), 'kdna-core-swift-ecosystem-gate-module-cache');
+const swiftModuleCache = fs.mkdtempSync(
+  path.join(os.tmpdir(), 'kdna-core-swift-ecosystem-gate-module-cache-'),
+);
 const failures = [];
+let firstFailureStage = null;
 
 function section(title) {
   console.log(`\n=== ${title} ===`);
 }
 
-function fail(label, message) {
+function fail(stage, label, message) {
+  if (!isSafeEcosystemGateStage(stage)) {
+    throw new Error('ecosystem gate stage identifier is invalid');
+  }
+  if (firstFailureStage === null) firstFailureStage = stage;
   failures.push(`${label}: ${message}`);
   console.error(`FAIL ${label}: ${message}`);
 }
 
-function run(label, cwd, command, args, options = {}) {
+function run(stage, label, cwd, command, args, options = {}) {
   if (!fs.existsSync(cwd)) {
-    fail(label, `missing directory ${cwd}`);
+    fail(stage, label, `missing directory ${cwd}`);
     return;
   }
   console.log(`$ ${command} ${args.join(' ')}`);
@@ -36,17 +44,17 @@ function run(label, cwd, command, args, options = {}) {
     env: { ...process.env, npm_config_cache: npmCacheDir, ...(options.env || {}) },
   });
   if (result.error) {
-    fail(label, result.error.message);
+    fail(stage, label, result.error.message);
     return;
   }
   if (result.status !== 0) {
-    fail(label, `exited ${result.status}`);
+    fail(stage, label, `exited ${result.status}`);
   }
 }
 
-function runCaptured(label, cwd, command, args, options = {}) {
+function runCaptured(stage, label, cwd, command, args, options = {}) {
   if (!fs.existsSync(cwd)) {
-    fail(label, `missing directory ${cwd}`);
+    fail(stage, label, `missing directory ${cwd}`);
     return;
   }
   console.log(`$ ${command} ${args.join(' ')}`);
@@ -57,12 +65,12 @@ function runCaptured(label, cwd, command, args, options = {}) {
     env: { ...process.env, npm_config_cache: npmCacheDir, ...(options.env || {}) },
   });
   if (result.error) {
-    fail(label, result.error.message);
+    fail(stage, label, result.error.message);
     return;
   }
   if (result.status !== 0) {
     if (result.stderr) process.stderr.write(result.stderr);
-    fail(label, `exited ${result.status}`);
+    fail(stage, label, `exited ${result.status}`);
     return;
   }
   console.log(
@@ -85,20 +93,21 @@ function packFiles(cwd) {
   return new Set((parsed[0] && parsed[0].files ? parsed[0].files : []).map((file) => file.path));
 }
 
-function assertPack(label, cwd, checks) {
+function assertPack(stage, label, cwd, checks) {
   try {
     const files = packFiles(cwd);
     for (const required of checks.required || []) {
-      if (!files.has(required)) fail(label, `tarball missing ${required}`);
+      if (!files.has(required)) fail(stage, label, `tarball missing ${required}`);
     }
     for (const forbiddenPattern of checks.forbidden || []) {
       for (const file of files) {
-        if (forbiddenPattern.test(file)) fail(label, `tarball includes forbidden file ${file}`);
+        if (forbiddenPattern.test(file))
+          fail(stage, label, `tarball includes forbidden file ${file}`);
       }
     }
     console.log(`PASS ${label}: ${files.size} tarball file(s) checked`);
   } catch (error) {
-    fail(label, error.message);
+    fail(stage, label, error.message);
   }
 }
 
@@ -125,120 +134,171 @@ function referenceAssetComponents() {
   return manifest.components.filter((entry) => entry.artifact_path);
 }
 
-section('Core Repo Gates');
-run('kdna npm test', repoRoot, 'npm', ['test']);
-run('kdna validate:examples', repoRoot, 'npm', ['run', 'validate:examples']);
-run('kdna validate:ecosystem-manifest', repoRoot, 'npm', ['run', 'validate:ecosystem-manifest']);
-run('kdna validate:public-truth', repoRoot, 'npm', ['run', 'validate:public-truth']);
-run('kdna production npm audit', repoRoot, 'npm', ['audit', '--omit=dev']);
-run(
-  'python adapter pytest against current CLI',
-  path.join(repoRoot, 'python-sdk'),
-  process.env.KDNA_PYTHON || 'python3',
-  ['-m', 'pytest', 'tests', '-q'],
-  {
-    env: {
-      KDNA_CLI: path.join(repoRoot, 'node_modules', '.bin', 'kdna'),
-      PYTHONPATH: path.join(repoRoot, 'python-sdk'),
+try {
+  section('Core Repo Gates');
+  run('core-test', 'kdna npm test', repoRoot, 'npm', ['test']);
+  run('core-examples', 'kdna validate:examples', repoRoot, 'npm', ['run', 'validate:examples']);
+  run('core-manifest', 'kdna validate:ecosystem-manifest', repoRoot, 'npm', [
+    'run',
+    'validate:ecosystem-manifest',
+  ]);
+  run('core-public-truth', 'kdna validate:public-truth', repoRoot, 'npm', [
+    'run',
+    'validate:public-truth',
+  ]);
+  run('core-audit', 'kdna production npm audit', repoRoot, 'npm', ['audit', '--omit=dev']);
+  run(
+    'python-adapter',
+    'python adapter pytest against current CLI',
+    path.join(repoRoot, 'python-sdk'),
+    process.env.KDNA_PYTHON || 'python3',
+    ['-m', 'pytest', 'tests', '-q'],
+    {
+      env: {
+        KDNA_CLI: path.join(repoRoot, 'node_modules', '.bin', 'kdna'),
+        PYTHONPATH: path.join(repoRoot, 'python-sdk'),
+      },
     },
-  },
-);
+  );
 
-section('Cross Repo Package Tests');
-run('kdna-cli fresh npm ci', componentPath('aikdna/kdna-cli'), 'npm', ['ci']);
-run('kdna-cli production npm audit', componentPath('aikdna/kdna-cli'), 'npm', [
-  'audit',
-  '--omit=dev',
-]);
-run(
-  'kdna-skills mcp fresh npm ci',
-  path.join(componentPath('aikdna/kdna-skills'), 'mcp-server'),
-  'npm',
-  ['ci'],
-);
-run(
-  'kdna-skills mcp production npm audit',
-  path.join(componentPath('aikdna/kdna-skills'), 'mcp-server'),
-  'npm',
-  ['audit', '--omit=dev'],
-);
-run('kdna-studio-core fresh npm ci', componentPath('aikdna/kdna-studio-core'), 'npm', ['ci']);
-run('kdna-studio-core production npm audit', componentPath('aikdna/kdna-studio-core'), 'npm', [
-  'audit',
-  '--omit=dev',
-]);
-run('kdna-studio-cli fresh npm ci', componentPath('aikdna/kdna-studio-cli'), 'npm', ['ci']);
-run('kdna-studio-cli production npm audit', componentPath('aikdna/kdna-studio-cli'), 'npm', [
-  'audit',
-  '--omit=dev',
-]);
-run('kdna-cli npm test', componentPath('aikdna/kdna-cli'), 'npm', ['test']);
-run(
-  'kdna-skills mcp npm test',
-  path.join(componentPath('aikdna/kdna-skills'), 'mcp-server'),
-  'npm',
-  ['test'],
-);
-run('kdna-studio-core npm test', componentPath('aikdna/kdna-studio-core'), 'npm', ['test']);
-run('kdna-studio-cli npm test', componentPath('aikdna/kdna-studio-cli'), 'npm', ['test']);
-run(
-  'kdna-core-swift fixed conformance swift test',
-  componentPath('aikdna/kdna-core-swift'),
-  'swift',
-  ['test', '--disable-sandbox', '-Xcc', `-fmodules-cache-path=${swiftModuleCache}`],
-  {
-    env: {
-      KDNA_CONFORMANCE_ROOT: repoRoot,
-      CLANG_MODULE_CACHE_PATH: swiftModuleCache,
+  section('Cross Repo Package Tests');
+  run('cli-install', 'kdna-cli fresh npm ci', componentPath('aikdna/kdna-cli'), 'npm', ['ci']);
+  run('cli-audit', 'kdna-cli production npm audit', componentPath('aikdna/kdna-cli'), 'npm', [
+    'audit',
+    '--omit=dev',
+  ]);
+  run(
+    'mcp-install',
+    'kdna-skills mcp fresh npm ci',
+    path.join(componentPath('aikdna/kdna-skills'), 'mcp-server'),
+    'npm',
+    ['ci'],
+  );
+  run(
+    'mcp-audit',
+    'kdna-skills mcp production npm audit',
+    path.join(componentPath('aikdna/kdna-skills'), 'mcp-server'),
+    'npm',
+    ['audit', '--omit=dev'],
+  );
+  run(
+    'studio-core-install',
+    'kdna-studio-core fresh npm ci',
+    componentPath('aikdna/kdna-studio-core'),
+    'npm',
+    ['ci'],
+  );
+  run(
+    'studio-core-audit',
+    'kdna-studio-core production npm audit',
+    componentPath('aikdna/kdna-studio-core'),
+    'npm',
+    ['audit', '--omit=dev'],
+  );
+  run(
+    'studio-cli-install',
+    'kdna-studio-cli fresh npm ci',
+    componentPath('aikdna/kdna-studio-cli'),
+    'npm',
+    ['ci'],
+  );
+  run(
+    'studio-cli-audit',
+    'kdna-studio-cli production npm audit',
+    componentPath('aikdna/kdna-studio-cli'),
+    'npm',
+    ['audit', '--omit=dev'],
+  );
+  run('cli-test', 'kdna-cli npm test', componentPath('aikdna/kdna-cli'), 'npm', ['test']);
+  run(
+    'mcp-test',
+    'kdna-skills mcp npm test',
+    path.join(componentPath('aikdna/kdna-skills'), 'mcp-server'),
+    'npm',
+    ['test'],
+  );
+  run(
+    'studio-core-test',
+    'kdna-studio-core npm test',
+    componentPath('aikdna/kdna-studio-core'),
+    'npm',
+    ['test'],
+  );
+  run(
+    'studio-cli-test',
+    'kdna-studio-cli npm test',
+    componentPath('aikdna/kdna-studio-cli'),
+    'npm',
+    ['test'],
+  );
+  run(
+    'swift-test',
+    'kdna-core-swift fixed conformance swift test',
+    componentPath('aikdna/kdna-core-swift'),
+    'swift',
+    ['test', '--disable-sandbox', '-Xcc', `-fmodules-cache-path=${swiftModuleCache}`],
+    {
+      env: {
+        KDNA_CONFORMANCE_ROOT: repoRoot,
+        CLANG_MODULE_CACHE_PATH: swiftModuleCache,
+      },
     },
-  },
-);
+  );
 
-section('Legacy Proof Asset Release Artifacts');
-const kdnaBin = path.join(repoRoot, 'packages', 'kdna', 'bin', 'kdna.js');
-for (const component of referenceAssetComponents()) {
-  const assetRoot = componentPath(component.repository);
-  run(`${component.repository} validate release artifact`, assetRoot, 'node', [
-    kdnaBin,
-    'validate',
-    component.artifact_path,
-  ]);
-  run(`${component.repository} plan release artifact load`, assetRoot, 'node', [
-    kdnaBin,
-    'plan-load',
-    component.artifact_path,
-  ]);
-  runCaptured(`${component.repository} load release artifact`, assetRoot, 'node', [
-    kdnaBin,
-    'load',
-    component.artifact_path,
-    '--profile=compact',
-    '--as=prompt',
-  ]);
-}
+  section('Legacy Proof Asset Release Artifacts');
+  const kdnaBin = path.join(repoRoot, 'packages', 'kdna', 'bin', 'kdna.js');
+  for (const component of referenceAssetComponents()) {
+    const assetRoot = componentPath(component.repository);
+    run(
+      'proof-asset-validate',
+      `${component.repository} validate release artifact`,
+      assetRoot,
+      'node',
+      [kdnaBin, 'validate', component.artifact_path],
+    );
+    run(
+      'proof-asset-plan',
+      `${component.repository} plan release artifact load`,
+      assetRoot,
+      'node',
+      [kdnaBin, 'plan-load', component.artifact_path],
+    );
+    runCaptured(
+      'proof-asset-load',
+      `${component.repository} load release artifact`,
+      assetRoot,
+      'node',
+      [kdnaBin, 'load', component.artifact_path, '--profile=compact', '--as=prompt'],
+    );
+  }
 
-section('Tarball Allowlist Checks');
-assertPack('@aikdna/kdna-core', path.join(repoRoot, 'packages', 'kdna-core'), {
-  required: ['LICENSE', 'NOTICE', 'src/container/index.js', 'src/container/index.mjs'],
-  forbidden: [/\.bak$/, /\.tgz$/],
-});
-assertPack('@aikdna/kdna-cli', componentPath('aikdna/kdna-cli'), {
-  required: ['LICENSE', 'NOTICE', 'src/cli.js'],
-  forbidden: [/\.bak$/, /\.tgz$/],
-});
-assertPack(
-  '@aikdna/kdna-mcp-server',
-  path.join(componentPath('aikdna/kdna-skills'), 'mcp-server'),
-  {
-    required: ['LICENSE', 'NOTICE', 'bin/kdna-mcp.mjs'],
+  section('Tarball Allowlist Checks');
+  assertPack('core-tarball', '@aikdna/kdna-core', path.join(repoRoot, 'packages', 'kdna-core'), {
+    required: ['LICENSE', 'NOTICE', 'src/container/index.js', 'src/container/index.mjs'],
     forbidden: [/\.bak$/, /\.tgz$/],
-  },
-);
+  });
+  assertPack('cli-tarball', '@aikdna/kdna-cli', componentPath('aikdna/kdna-cli'), {
+    required: ['LICENSE', 'NOTICE', 'src/cli.js'],
+    forbidden: [/\.bak$/, /\.tgz$/],
+  });
+  assertPack(
+    'mcp-tarball',
+    '@aikdna/kdna-mcp-server',
+    path.join(componentPath('aikdna/kdna-skills'), 'mcp-server'),
+    {
+      required: ['LICENSE', 'NOTICE', 'bin/kdna-mcp.mjs'],
+      forbidden: [/\.bak$/, /\.tgz$/],
+    },
+  );
 
-if (failures.length > 0) {
-  console.error('\nEcosystem gate failed:');
-  for (const failure of failures) console.error(`- ${failure}`);
-  process.exit(1);
+  if (failures.length > 0) {
+    console.error(`KDNA_SAFE_ECOSYSTEM_STAGE=${firstFailureStage}`);
+    console.error('\nEcosystem gate failed:');
+    for (const failure of failures) console.error(`- ${failure}`);
+    process.exitCode = 1;
+  } else {
+    console.log('\nEcosystem gate passed.');
+  }
+} finally {
+  fs.rmSync(swiftModuleCache, { recursive: true, force: true });
 }
-
-console.log('\nEcosystem gate passed.');


### PR DESCRIPTION
## What changed

- advance the compatibility package to 0.13.1 without changing its exact CLI 0.35.0 and Core 0.20.0 binding;
- pin the accepted KDNA Skills MCP isolation repair and Swift Core 0.20.0 conformance baseline in the ecosystem release workflows;
- rehearse the complete compatibility ecosystem gate on macOS with the same audited, scripts-off npm authority used by publication;
- isolate and always clean the Swift module cache;
- expose only one bounded, allowlisted ecosystem-stage identifier when the trusted wrapper suppresses a failed child command.

## Why

The withdrawn compat/0.13.0 GitHub release stopped before artifact construction because its trusted scripts-off environment exposed an MCP nested dry-run assumption. After that repair, local release rehearsal exposed shared Swift module-cache contamination. The first PR rehearsal then caught that the previously pinned Swift checkout predated the accepted Core 0.20.0 conformance baseline. The release gate now reproduces the publication environment before a tag is created and reports a safe stage identifier without forwarding arbitrary child or provider output.

## Impact

This does not change the KDNA runtime contract. It hardens the compatibility release path and prepares @aikdna/kdna 0.13.1 as the replacement for the withdrawn, never-published 0.13.0 candidate.

## Validation

- GitHub macOS `core-smoke` passed the complete release-environment rehearsal in 4m51s;
- full trusted local cross-repository ecosystem gate passed, including Core, CLI, MCP, Studio, Python, Swift, proof assets, and tarball allowlists;
- compatibility package tests: 103/103;
- Core release-authority tests: 92 passed, 3 environment-dependent tests skipped as designed;
- cross-repository version lock: 34/34 exact bindings;
- public-surface, public-narrative, post-cutover naming, formatting, and diff checks passed;
- independent P0-P3 review completed with no remaining findings.
