### PR TITLE
fix(release): bind compatibility publish to exact DCO

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,11 @@ PRs that fail any verification command will be reviewed with requested changes.
 
 All commits must include a `Signed-off-by:` line. Use `git commit -s` to add it automatically.
 
+If a pull request is squash-merged, the final squash commit must also carry a
+`Signed-off-by:` trailer that exactly matches the author name and email GitHub
+assigns to that commit. The trailers on the pull request's source commits do
+not replace this final-commit requirement.
+
 This certifies that you wrote the code or have the right to submit it under the project's license (Apache-2.0). No CLA is required.
 
 ## ANTI-PATTERNS

--- a/packages/kdna/scripts/check-release-readiness.js
+++ b/packages/kdna/scripts/check-release-readiness.js
@@ -5,6 +5,7 @@ const { execFileSync, spawnSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
 const { canonicalTag, validateReleaseContext } = require('./release-policy');
+const { commitDocument } = require('../../../scripts/core-release-authority');
 
 const PACKAGE_ROOT = path.resolve(__dirname, '..');
 const REPO_ROOT = path.resolve(PACKAGE_ROOT, '..', '..');
@@ -46,6 +47,7 @@ function main() {
       tagCommit: git(['rev-parse', `${tag}^{commit}`]),
       mainCommit,
       mainContainsHead: gitIsAncestor(head, mainCommit),
+      authorSignoffMatch: commitDocument(head, REPO_ROOT).authorSignoffMatch,
     },
   });
   console.log(

--- a/packages/kdna/scripts/current-release-binding.js
+++ b/packages/kdna/scripts/current-release-binding.js
@@ -5,6 +5,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { validateReleaseEvidence } = require('./release-evidence');
 const { canonicalTag, validateReleaseContext } = require('./release-policy');
+const { commitDocument } = require('../../../scripts/core-release-authority');
 
 function assert(condition, message) {
   if (!condition) throw new Error(message);
@@ -56,6 +57,7 @@ function readCurrentReleaseBinding({ root, evidence, env = process.env }) {
       tagCommit: git(['rev-parse', `${tag}^{commit}`]),
       mainCommit,
       mainContainsHead: gitIsAncestor(head, mainCommit),
+      authorSignoffMatch: commitDocument(head, root).authorSignoffMatch,
     },
   });
 }

--- a/packages/kdna/scripts/release-policy.js
+++ b/packages/kdna/scripts/release-policy.js
@@ -46,6 +46,10 @@ function validateReleaseContext({ pkg, changelog, env, git }) {
   assert(git.tagCommit === git.head, `${tag} must resolve to HEAD`);
   assert(env.GITHUB_SHA === git.head, 'GITHUB_SHA must equal HEAD and the release tag commit');
   assert(git.mainContainsHead === true, 'release tag commit must be an ancestor of origin/main');
+  assert(
+    git.authorSignoffMatch === true,
+    'release commit author must have an exact normalized DCO Signed-off-by trailer',
+  );
 
   const heading = new RegExp(
     `^## ${escapeRegExp(pkg.version)}(?: \\(\\d{4}-\\d{2}-\\d{2}\\))?$`,

--- a/packages/kdna/test/publish-hardening.test.js
+++ b/packages/kdna/test/publish-hardening.test.js
@@ -86,6 +86,7 @@ function releaseInput(overrides = {}) {
       tagCommit: HASH,
       mainCommit: HASH,
       mainContainsHead: true,
+      authorSignoffMatch: true,
       ...overrides.git,
     },
   };
@@ -366,6 +367,7 @@ test('release context rejects every ambiguous or mutable release input', async (
     ['tag differs from head', releaseInput({ git: { tagCommit: OTHER_HASH } })],
     ['missing protected main', releaseInput({ git: { mainCommit: '' } })],
     ['tag commit outside protected main', releaseInput({ git: { mainContainsHead: false } })],
+    ['release commit DCO mismatch', releaseInput({ git: { authorSignoffMatch: false } })],
     ['workflow sha differs from head', releaseInput({ env: { GITHUB_SHA: OTHER_HASH } })],
     ['substring changelog', releaseInput({ changelog: '# Changelog\n\nnotes for 1.2.3 only\n' })],
     ['prefix heading', releaseInput({ changelog: '# Changelog\n\n## 1.2.30\n' })],
@@ -435,7 +437,7 @@ test('current release binding rejects stale evidence before lookup or publicatio
   assert.equal(publishCalls, 0);
 });
 
-test('current release reader accepts protected main ancestry and rejects a branch-only tag', (t) => {
+test('current release reader requires exact DCO and protected main ancestry', (t) => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kdna-compat-main-ancestry-'));
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));
   fs.mkdirSync(path.join(root, 'packages', 'kdna'), { recursive: true });
@@ -451,7 +453,7 @@ test('current release reader accepts protected main ancestry and rejects a branc
   runGit(root, ['config', 'user.name', 'KDNA Test']);
   runGit(root, ['config', 'user.email', 'test@example.invalid']);
   runGit(root, ['add', '.']);
-  runGit(root, ['commit', '--quiet', '-m', 'test: accepted main']);
+  runGit(root, ['commit', '--quiet', '-s', '-m', 'test: accepted main']);
   const accepted = runGit(root, ['rev-parse', 'HEAD']);
   runGit(root, ['update-ref', 'refs/remotes/origin/main', accepted]);
   runGit(root, ['tag', 'compat/1.2.3']);
@@ -464,9 +466,25 @@ test('current release reader accepts protected main ancestry and rejects a branc
     }),
   );
 
+  fs.writeFileSync(path.join(root, 'unsigned.txt'), 'not signed off\n');
+  runGit(root, ['add', 'unsigned.txt']);
+  runGit(root, ['commit', '--quiet', '-m', 'test: unsigned candidate']);
+  const unsigned = runGit(root, ['rev-parse', 'HEAD']);
+  runGit(root, ['update-ref', 'refs/remotes/origin/main', unsigned]);
+  runGit(root, ['tag', '--force', 'compat/1.2.3']);
+  assert.throws(
+    () =>
+      readCurrentReleaseBinding({
+        root,
+        evidence: evidence({ source: { commit: unsigned } }),
+        env: releaseInput({ env: { GITHUB_SHA: unsigned } }).env,
+      }),
+    /valid DCO Signed-off-by trailer/u,
+  );
+
   fs.writeFileSync(path.join(root, 'branch-only.txt'), 'not accepted\n');
   runGit(root, ['add', 'branch-only.txt']);
-  runGit(root, ['commit', '--quiet', '-m', 'test: branch-only candidate']);
+  runGit(root, ['commit', '--quiet', '-s', '-m', 'test: branch-only candidate']);
   const branchOnly = runGit(root, ['rev-parse', 'HEAD']);
   runGit(root, ['tag', '--force', 'compat/1.2.3']);
   assert.throws(

--- a/packages/kdna/test/publish-hardening.test.js
+++ b/packages/kdna/test/publish-hardening.test.js
@@ -466,6 +466,29 @@ test('current release reader requires exact DCO and protected main ancestry', (t
     }),
   );
 
+  fs.writeFileSync(path.join(root, 'mismatched-signoff.txt'), 'wrong signer\n');
+  runGit(root, ['add', 'mismatched-signoff.txt']);
+  runGit(root, [
+    'commit',
+    '--quiet',
+    '-m',
+    'test: mismatched signoff',
+    '-m',
+    'Signed-off-by: Other Author <other@example.invalid>',
+  ]);
+  const mismatched = runGit(root, ['rev-parse', 'HEAD']);
+  runGit(root, ['update-ref', 'refs/remotes/origin/main', mismatched]);
+  runGit(root, ['tag', '--force', 'compat/1.2.3']);
+  assert.throws(
+    () =>
+      readCurrentReleaseBinding({
+        root,
+        evidence: evidence({ source: { commit: mismatched } }),
+        env: releaseInput({ env: { GITHUB_SHA: mismatched } }).env,
+      }),
+    /author must have an exact normalized DCO Signed-off-by trailer/u,
+  );
+
   fs.writeFileSync(path.join(root, 'unsigned.txt'), 'not signed off\n');
   runGit(root, ['add', 'unsigned.txt']);
   runGit(root, ['commit', '--quiet', '-m', 'test: unsigned candidate']);


### PR DESCRIPTION
## Summary

- require the compatibility release target to have an author-matching DCO trailer
- revalidate that exact DCO binding in the registry guard and final publisher
- cover signed, unsigned, and protected-main ancestry cases with real temporary Git commits
- document the final squash-commit identity requirement for maintainers

## Context

The merge of #208 was correctly blocked by the exact-commit Core release gate because GitHub assigned the squash commit an author email different from the supplied trailer. Compatibility publication previously relied on main CI for this invariant; this change makes the publication path itself fail closed even if a red main check were ignored.

## Verification

- `npm test --workspace=@aikdna/kdna` (111/111)
- `npm run test:release-scopes` (8/8)
- `npm run format:check`
- `npm run audit:public-confidence`
- `npm run audit:public-narrative`
- `npm run validate:public-truth`
- exact-commit Core release-authority test against the signed recovery commit (92 passed, 0 failed, 3 environment-specific skips)

Signed-off-by: aikdna <283974009+aikdna@users.noreply.github.com>