### PR TITLE
docs(ecosystem): promote compatibility bridge

### DIFF
--- a/.github/workflows/core-smoke.yml
+++ b/.github/workflows/core-smoke.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-assets
-          ref: a189b5005d33bd19a5039b4a86834e920f6b0072
+          ref: 8656656f845adf8f5711114c5fa2fa9ecff05806
           path: .ecosystem-repos/kdna-assets
           fetch-depth: 0
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -247,7 +247,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-assets
-          ref: a189b5005d33bd19a5039b4a86834e920f6b0072
+          ref: 8656656f845adf8f5711114c5fa2fa9ecff05806
           path: .ecosystem-repos/kdna-assets
           fetch-depth: 0
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Publish `@aikdna/kdna@0.13.2` as the maintained Legacy compatibility bridge
+  for CLI 0.35.1, Eval 0.3.2, and Core 0.20.0, with exact Release, registry,
+  signature, provenance, and clean-install acceptance evidence.
 - Replace the repository-level ecosystem inventory with a strict schema-2
   manifest. It records co-located Core, Eval, compatibility, and deprecated npm
   packages; distinguishes repository source commits from conformance anchors;

--- a/docs/status.zh.md
+++ b/docs/status.zh.md
@@ -50,8 +50,8 @@ npm install -g @aikdna/kdna-studio-cli  # 创作 CLI（0.10.2）
 - `@aikdna/kdna-eval@0.3.2` 已发布：实验性评测工具；输出是评价者范围内的证据，
   不是 Core 权威。CLI 的 Asset 观测矩阵不生成来源声明，Cluster 的 trust/economics
   晋级必须在可信证据生产者内调用 Eval API
-- `@aikdna/kdna@0.13.2` 候选：面向 CLI 0.35.1 的 Legacy 兼容桥更新；npm 当前已发布
-  版本在注册表验收前仍为 0.13.1。新集成直接使用 CLI 与 Core
+- `@aikdna/kdna@0.13.2` 已发布：面向 CLI 0.35.1 的维护中 Legacy 兼容桥；
+  新集成仍直接使用 CLI 与 Core
 - `@aikdna/agent`、`@aikdna/kdna-artifact-engine` 与
   `@aikdna/kdna-fidelity-core` 为已弃用的历史 npm 坐标，不属于当前工具链
 

--- a/docs/tool-status-matrix.md
+++ b/docs/tool-status-matrix.md
@@ -65,7 +65,7 @@
 |---|---|
 | `@aikdna/kdna-core@0.20.0` | Beta runtime SDK |
 | `@aikdna/kdna-eval@0.3.2` | Released Experimental evaluation toolkit; issuer-scoped evidence is not KDNA Core authority |
-| `@aikdna/kdna@0.13.2` candidate | Prepared Legacy compatibility update for CLI 0.35.1; 0.13.1 remains published until registry acceptance |
+| `@aikdna/kdna@0.13.2` | Released, maintained Legacy compatibility bridge for CLI 0.35.1; new integrations use CLI and Core directly |
 
 ## Native Apps
 

--- a/ecosystem-manifest.json
+++ b/ecosystem-manifest.json
@@ -50,9 +50,8 @@
           "package_name": "@aikdna/kdna",
           "npm_package": "@aikdna/kdna",
           "version": "0.13.2",
-          "published_version": "0.13.1",
           "lifecycle": "Legacy",
-          "release_status": "candidate",
+          "release_status": "compatibility",
           "dependency_policy": "current",
           "known_limitations": [
             "maintained migration bridge; new integrations should install the CLI and Core packages directly"
@@ -148,7 +147,7 @@
     {
       "repository": "aikdna/kdna-assets",
       "local_path": "../kdna-assets",
-      "source_commit": "a189b5005d33bd19a5039b4a86834e920f6b0072",
+      "source_commit": "8656656f845adf8f5711114c5fa2fa9ecff05806",
       "conformance_commit": "1e77e3e0d486c330fe9f9262b514ef24c859d469",
       "component_version": null,
       "packages": [],

--- a/packages/kdna/test/publish-hardening.test.js
+++ b/packages/kdna/test/publish-hardening.test.js
@@ -41,27 +41,11 @@ const CHECKOUT_ACTION_SHA = '9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0';
 const SETUP_NODE_ACTION_SHA = '249970729cb0ef3589644e2896645e5dc5ba9c38';
 const SETUP_PYTHON_ACTION_SHA = 'ece7cb06caefa5fff74198d8649806c4678c61a1';
 const UPLOAD_ACTION_SHA = 'ea165f8d65b6e75b540449e92b4886f43607fa02';
-const EXPECTED_CONSUMER_CHECKOUTS = [
-  ['aikdna/create-kdna-web-app', '4241dc20814bae4fcf72d44df7c0670ef70bda00'],
-  ['aikdna/kdna-cli', '0a23a2528bd55ee99a4d3a9ed488793973096fd4'],
-  ['aikdna/kdna-skills', 'c9ac7de534b7ba810217d1d15b14a23a6e5b845f'],
-  ['aikdna/kdna-studio-core', 'e1d49b3cb3e6c236499a3ecbd6884497e41fd834'],
-  ['aikdna/kdna-studio-cli', 'abd1624741a5dfa0b1a604e44d57209ce3caf18b'],
-  ['aikdna/kdna-activation-server', '6e203a78c038f15c0e65f19b9aa22a6f642478cb'],
-  ['aikdna/kdna-remote-server', 'eb677ea0fece9b0886724df8383563253ec45600'],
-  ['aikdna/kdna-web-server', '9fc1377bfb378d5977ab77dcdc30ee4f0b2a181d'],
-  ['aikdna/kdna-web-client', 'd128ac815fc82d0249b7f49793a1a0103949c4ee'],
-  ['aikdna/kdna-react', '3edcdce0f75b6dfb1eb4147cedaf24f8af6574a3'],
-  ['aikdna/kdna-assets', 'a189b5005d33bd19a5039b4a86834e920f6b0072'],
-  ['aikdna/kdna-demo-web-viewer', 'a7d4df05973d472ec24ba060f3d9c02c0d22c6f3'],
-];
-const EXPECTED_COMPAT_CHECKOUTS = [
-  ...EXPECTED_CONSUMER_CHECKOUTS,
-  ['aikdna/kdna-core-swift', '4a9b732b590a711c544da5280a4b78f071369617'],
-  ['aikdna/kdna-app-shared', '3f999a6e8d7015ef024beea044584eb2eac50d90'],
-  ['aikdna/kdna-studio-swift', '638bd845ff265f0488b7bfccb745f608b23ead88'],
-  ['aikdna/kdna-vscode', 'c0d885ba8222b6dccad87ec67f7d82fcc1283107'],
-];
+const EXPECTED_COMPAT_CHECKOUTS = JSON.parse(
+  fs.readFileSync(path.join(REPO_ROOT, 'ecosystem-manifest.json'), 'utf8'),
+).components
+  .filter((component) => component.local_path && component.local_path !== '.')
+  .map((component) => [component.repository, component.source_commit]);
 
 function releaseInput(overrides = {}) {
   const version = overrides.pkg?.version || '1.2.3';

--- a/release-health-policy.json
+++ b/release-health-policy.json
@@ -105,8 +105,7 @@
       "repository": "aikdna/kdna",
       "package_json": "packages/kdna/package.json",
       "npm_package": "@aikdna/kdna",
-      "version": "0.13.1",
-      "candidate_version": "0.13.2",
+      "version": "0.13.2",
       "canonical_tag": { "type": "prefix", "value": "compat/" }
     }
   ]

--- a/scripts/ecosystem-version-lock.test.js
+++ b/scripts/ecosystem-version-lock.test.js
@@ -64,7 +64,7 @@ test('schema-2 package records derive Eval and compatibility coordinates without
           {
             package_json: 'packages/kdna/package.json',
             npm_package: '@aikdna/kdna',
-            version: '0.13.1',
+            version: '0.13.2',
             release_status: 'compatibility',
             dependency_policy: 'current',
           },
@@ -82,7 +82,7 @@ test('schema-2 package records derive Eval and compatibility coordinates without
 
   const policy = readBaselines(root);
   assert.deepEqual(Object.fromEntries([...policy.baselines].sort()), {
-    '@aikdna/kdna': '0.13.1',
+    '@aikdna/kdna': '0.13.2',
     '@aikdna/kdna-core': '0.20.0',
     '@aikdna/kdna-eval': '0.3.2',
   });

--- a/scripts/generate-release-evidence.test.js
+++ b/scripts/generate-release-evidence.test.js
@@ -9,19 +9,19 @@ const { validateKnownPackages } = require('./generate-release-evidence');
 
 const repoRoot = path.resolve(__dirname, '..');
 
-test('release evidence inventories candidate source without treating it as current-published', () => {
+test('release evidence inventories the maintained compatibility source', () => {
   const manifest = JSON.parse(
     fs.readFileSync(path.join(repoRoot, 'ecosystem-manifest.json'), 'utf8'),
   );
   assert.doesNotThrow(() => validateKnownPackages(manifest));
 
-  const withoutCandidateSource = structuredClone(manifest);
-  const compatibility = withoutCandidateSource.components
+  const withoutCompatibilitySource = structuredClone(manifest);
+  const compatibility = withoutCompatibilitySource.components
     .find((component) => component.repository === 'aikdna/kdna')
     .packages.find((packageRecord) => packageRecord.npm_package === '@aikdna/kdna');
   compatibility.release_status = 'deprecated';
   assert.throws(
-    () => validateKnownPackages(withoutCandidateSource),
+    () => validateKnownPackages(withoutCompatibilitySource),
     /release evidence package inventory differs/u,
   );
 });

--- a/scripts/test-publish-health.mjs
+++ b/scripts/test-publish-health.mjs
@@ -84,21 +84,29 @@ test('release-health policy is an exact projection of current public package rec
   }
 });
 
-test('candidate health monitors the incumbent registry release and candidate main source', () => {
+test('maintained compatibility health monitors the exact published source', () => {
   const compat = policy.packages.find((entry) => entry.npm_package === '@aikdna/kdna');
-  assert.equal(compat.version, '0.13.1');
+  assert.equal(compat.version, '0.13.2');
   assert.equal(expectedMainVersion(compat), '0.13.2');
+  assert.equal(compat.candidate_version, undefined);
+});
+
+test('candidate health requires a stable version newer than its incumbent', () => {
+  const compat = policy.packages.find((entry) => entry.npm_package === '@aikdna/kdna');
+  const candidate = { ...compat, version: '0.13.1', candidate_version: '0.13.2' };
+  assert.equal(validatePolicy({ ...policy, packages: [candidate] }).packages[0], candidate);
+  assert.equal(expectedMainVersion(candidate), '0.13.2');
   assert.throws(
-    () => validatePolicy({ ...policy, packages: [{ ...compat, candidate_version: '0.13.1' }] }),
+    () => validatePolicy({ ...policy, packages: [{ ...candidate, candidate_version: '0.13.1' }] }),
     /invalid candidate version/u,
   );
   assert.throws(
-    () => validatePolicy({ ...policy, packages: [{ ...compat, candidate_version: '0.13.0' }] }),
+    () => validatePolicy({ ...policy, packages: [{ ...candidate, candidate_version: '0.13.0' }] }),
     /invalid candidate version/u,
   );
   assert.throws(
     () =>
-      validatePolicy({ ...policy, packages: [{ ...compat, candidate_version: '0.13.2-rc.1' }] }),
+      validatePolicy({ ...policy, packages: [{ ...candidate, candidate_version: '0.13.2-rc.1' }] }),
     /invalid candidate version/u,
   );
 });

--- a/tests/container-cli/ecosystem-manifest-validation.test.js
+++ b/tests/container-cli/ecosystem-manifest-validation.test.js
@@ -254,6 +254,43 @@ test('canonical schema-2 manifest inventories every public repository, co-locate
   );
 });
 
+test('ecosystem workflow checkouts stay pinned to schema-2 source commits', () => {
+  const canonical = JSON.parse(
+    fs.readFileSync(path.join(repoRoot, 'ecosystem-manifest.json'), 'utf8'),
+  );
+  const components = canonical.components.filter(
+    (entry) => entry.local_path && entry.local_path !== '.' && entry.source_commit,
+  );
+
+  for (const workflowName of ['core-smoke.yml', 'publish.yml']) {
+    const workflow = fs.readFileSync(
+      path.join(repoRoot, '.github', 'workflows', workflowName),
+      'utf8',
+    );
+    for (const entry of components) {
+      const repositoryMarker = `repository: ${entry.repository}`;
+      let offset = 0;
+      let occurrences = 0;
+      while ((offset = workflow.indexOf(repositoryMarker, offset)) >= 0) {
+        const nextStep = workflow.indexOf('\n      - ', offset);
+        const checkoutBlock = workflow.slice(offset, nextStep >= 0 ? nextStep : workflow.length);
+        assert.match(
+          checkoutBlock,
+          new RegExp(`^\\s*ref: ${entry.source_commit}\\s*$`, 'mu'),
+          `${workflowName} must check out ${entry.repository} at its schema-2 source commit`,
+        );
+        occurrences += 1;
+        offset += repositoryMarker.length;
+      }
+      assert.equal(
+        occurrences,
+        1,
+        `${workflowName} must check out ${entry.repository} exactly once`,
+      );
+    }
+  }
+});
+
 test('canonical Core conformance anchor is bound to the exact Core release tag', (t) => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kdna-manifest-core-anchor-'));
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));


### PR DESCRIPTION
## Summary

- promote `@aikdna/kdna@0.13.2` from release candidate to the maintained Legacy compatibility bridge
- align the schema-2 ecosystem manifest, release-health policy, public status docs, and evidence tests
- advance the audited `kdna-assets` source anchor to accepted main commit `8656656f845adf8f5711114c5fa2fa9ecff05806`
- bind both ecosystem workflows to that exact asset source and test every external workflow checkout against the schema-2 manifest

## Acceptance evidence

- npm `@aikdna/kdna@0.13.2` is published and is `latest`
- stable GitHub Release `compat/0.13.2` targets exact protected-main commit `22a14a0917e21a97714de24a891c67ec8a9bf807`
- registry signature and SLSA v1 provenance are present and bind the publish workflow to that tag and commit
- clean cold install resolved one physical CLI/Core/Eval toolchain and passed `kdna eval asset --help`
- live publish health reports all 13 current packages aligned, `Failures: 0`

## Validation

- ecosystem manifest validation and hostile manifest fixtures
- release-health and ecosystem-lock suites
- release-scope validation
- public truth, confidence, narrative, and documentation audits
- publish drift and live publish health
- Prettier and `git diff --check`

No package code, lockfile, or schema behavior changes are included.