### PR TITLE
docs: restore complete KDNA ecosystem roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-> **Development snapshot — release reset in progress**
+> **Pre-release ecosystem — contract and narrative correction in progress**
 >
-> This repository is not currently a stable, beta, or production-ready
-> release. Published packages and documentation may describe an earlier
-> development snapshot. A new Development Preview has not been released.
+> KDNA is a judgment-asset container and ecosystem. This repository owns the
+> protocol and Core runtime; companion repositories provide creation,
+> consumption, authorization, Apple, Web, Agent, editor, and developer
+> integrations. Existing packages are pre-release snapshots, not Beta, stable,
+> GA, or a reason to retire an integration's mission.
 
 # KDNA
 
@@ -38,13 +40,14 @@ asset internals is not a compatible Agent consumption path.
 >
 > This repo defines **KDNA Core** — the file format, schemas, and runtime loading contract. The official KDNA toolchain is published from this repo and its companion packages.
 
-[![npm](https://img.shields.io/npm/v/@aikdna/kdna-cli)](https://www.npmjs.com/package/@aikdna/kdna-cli) [![CI](https://github.com/aikdna/kdna/actions/workflows/validate.yml/badge.svg)](https://github.com/aikdna/kdna/actions/workflows/validate.yml) [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE) [![Maturity: Beta — format stable, toolchain tested, pre-1.0 features evolving](https://img.shields.io/badge/maturity-Beta-blueviolet)](#maturity)
+[![npm](https://img.shields.io/npm/v/@aikdna/kdna-cli)](https://www.npmjs.com/package/@aikdna/kdna-cli) [![CI](https://github.com/aikdna/kdna/actions/workflows/validate.yml/badge.svg)](https://github.com/aikdna/kdna/actions/workflows/validate.yml) [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE) [![Maturity: Pre-release](https://img.shields.io/badge/maturity-Pre--release-orange)](#maturity)
 
-> **Maturity: Beta** — the current KDNA Asset Container and the local public-asset
-> path are the stable public baseline. Licensed and remote access have public
-> protocol contracts and evolving reference implementations; check release
-> notes before production use. Hosted marketplace, billing, and AIKDNA-hosted
-> loading are not part of the public baseline. See
+> **Maturity: Pre-release** — the container, toolchain, and integrations are
+> being reconciled against their exact public contracts. Component maturity
+> varies and must be stated per repository and version; no integration is
+> declared valueless merely because it is outside one release wave. Check the
+> exact version's schema, specification, fixtures, conformance, and release
+> notes before use. See
 > [`docs/maturity.md`](./docs/maturity.md).
 
 ## See KDNA in action — then create your own

--- a/docs/30-minute-authoring-guide.md
+++ b/docs/30-minute-authoring-guide.md
@@ -10,9 +10,9 @@ validated, packable asset.
 
 | Layer | Status | What it means |
 |---|---|---|
-| KDNA Asset Container | stable | `.kdna` container, `mimetype`, `kdna.json`, `payload.kdnab`, and `checksums.json` are the current local asset baseline. |
-| Runtime CLI | beta-ready | `kdna inspect`, `kdna validate`, `kdna plan-load`, `kdna load`, `kdna pack`, and `kdna unpack` work for local assets. |
-| Studio authoring CLI | beta | `kdna-studio` is the official authoring path, but commands and UX may still change between beta releases. |
+| KDNA Asset Container | pre-release | `.kdna` container, `mimetype`, `kdna.json`, `payload.kdnab`, and `checksums.json` are the current local asset path; exact-version contracts remain authoritative. |
+| Runtime CLI | pre-release | `kdna inspect`, `kdna validate`, `kdna plan-load`, `kdna load`, `kdna pack`, and `kdna unpack` work for local assets. |
+| Studio authoring CLI | pre-release | `kdna-studio` is the official authoring path, but commands and UX may still change between releases. |
 | Agent / MCP loading | preview | Loader and MCP paths use the same LoadPlan-first contract, but agent-specific integration quality varies by runtime. |
 | Evidence and provenance layers | optional / independently versioned | Human Lock, signatures, release evidence, authorization, and evaluation reports do not decide KDNA format validity. |
 
@@ -96,9 +96,9 @@ kdna-studio migrate my_expertise --out ./my_expertise.kdna \
 
 ## Current limitations
 
-- **Authoring path is beta.** The `kdna-studio` CLI is part of the official
+- **Authoring path is pre-release.** The `kdna-studio` CLI is part of the official
   KDNA toolchain but the authoring surface is still evolving.
-- **Official authoring path.** Public beta examples should be exported through
+- **Official authoring path.** Pre-release examples should be exported through
   the official KDNA Studio toolchain. Third-party authoring tools should
   integrate through the official Studio SDK or CLI so the output remains a
   standard packaged `.kdna` file.

--- a/docs/SUNSET_POLICY.md
+++ b/docs/SUNSET_POLICY.md
@@ -27,7 +27,7 @@ KDNA's deprecation policy ensures that users are never caught between a document
 
 | Item | Previous Status | Current Status | Reason |
 |------|----------------|----------------|--------|
-| `kdna dev pack` | Marked "Deprecated" in error | Beta | Actively maintained. Serves a real need for dev-to-asset conversion. |
+| `kdna dev pack` | Marked "Deprecated" in error | Pre-release | Actively maintained. Serves a real need for dev-to-asset conversion. |
 
 ## Enforcement
 

--- a/docs/agents-lack-judgment.md
+++ b/docs/agents-lack-judgment.md
@@ -128,7 +128,7 @@ The full score is harder because KDNA-loaded agents are more conservative — th
 **In judgment, being conservative is better than being wrong.**
 
 The benchmark summary is historical public narrative evidence. The detailed
-benchmark artifact is not part of the current public beta repository.
+benchmark artifact is not part of the current pre-release repository.
 
 ## The Six Layers, Properly Defined
 

--- a/docs/case-study-meeting-decisions.md
+++ b/docs/case-study-meeting-decisions.md
@@ -184,4 +184,4 @@ KDNA does the opposite. It adds a **judgment gate** between discussion and execu
 
 ---
 
-*This case study is based on a composite of real incidents. Identifying details have been changed. The KDNA analysis was produced using the `decision_state` domain asset and historical benchmark methodology. The detailed benchmark artifact is not part of the current public beta repository.*
+*This case study is based on a composite of real incidents. Identifying details have been changed. The KDNA analysis was produced using the `decision_state` domain asset and historical benchmark methodology. The detailed benchmark artifact is not part of the current pre-release repository.*

--- a/docs/core-narrative-and-boundaries.md
+++ b/docs/core-narrative-and-boundaries.md
@@ -172,14 +172,14 @@ MUST NOT redefine:
 
 ### 2.10 Protocol Versioning
 
-The public protocol and toolchain are **Beta**. Package releases follow SemVer,
+The public protocol and toolchain are **pre-release**. Package releases follow SemVer,
 while each wire contract carries its own compatibility coordinate. The current
 container uses `format_version: "0.1.0"` and
 `application/vnd.kdna.asset`.
 
 | Layer | Current Version | Meaning |
 |---|---|---|
-| Protocol maturity | Beta | What KDNA assets are and how they load |
+| Protocol maturity | Pre-release | What KDNA assets are and how they load |
 | Container | `format_version: "0.1.0"` | KDNA Asset Container encoding |
 | Capsule | `kdna.runtime-capsule` + `contract_version: "0.1.0"` | What Agents receive |
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -102,7 +102,7 @@ kdna load ./minimal.kdna --profile=compact --as=prompt
 
 ## Advanced workflows
 
-The basic public beta path is intentionally small: create or generate a
+The basic pre-release path is intentionally small: create or generate a
 packaged `.kdna` file, validate it, plan loading, and load it. Advanced creator,
 adapter, and legacy compatibility commands are tracked in
 [status.md](./status.md).

--- a/docs/getting-started.zh.md
+++ b/docs/getting-started.zh.md
@@ -98,7 +98,7 @@ kdna load ./minimal.kdna --profile=compact --as=prompt
 
 ## 高级工作流
 
-当前 public beta 的基础路径刻意保持很小：创建或生成 packaged `.kdna`
+当前预发布基础路径刻意保持很小：创建或生成 packaged `.kdna`
 文件，校验，规划加载，然后加载。高级创作者命令、Agent 适配器命令和
 legacy 兼容命令统一记录在 [status.md](./status.md)。
 

--- a/docs/kdna-compare-report.md
+++ b/docs/kdna-compare-report.md
@@ -1,7 +1,7 @@
 # KDNA Compare Report — Design Specification
 
 > **Status:** Implemented. `kdna compare` available in `@aikdna/kdna-cli`.
-> Historical benchmark artifacts are not part of the current public beta
+> Historical benchmark artifacts are not part of the current pre-release
 > repository.
 
 ## Overview

--- a/docs/kdna-encryption-authorization.md
+++ b/docs/kdna-encryption-authorization.md
@@ -1,6 +1,6 @@
 # KDNA Encryption & Authorization — Design Specification
 
-> Draft security/product-layer design. Current KDNA Core public beta focuses on
+> Draft security/product-layer design. The current KDNA Core pre-release path focuses on
 > local packaged `.kdna` validation, LoadPlan, and loading. Production
 > encryption, paid authorization, hosted distribution, and signature trust are
 > not current launch requirements.

--- a/docs/maturity.md
+++ b/docs/maturity.md
@@ -1,28 +1,26 @@
 # KDNA Maturity Disclosure
 
-> **Current product maturity: Beta.** This page separates protocol validity,
-> implementation maturity, and optional asset evidence.
+> **Current product maturity: Pre-release.** This page separates exact-version
+> protocol validity, component maturity, and optional asset evidence.
 
-## What Beta Means
+## What Pre-release Means
 
-The KDNA Asset Container and local public-asset path are stable enough for
-integration and conformance testing. Other layers mature independently. A
-stable container does not make every runtime, adapter, server, or asset
-production-ready.
+KDNA has published 0.x protocol, toolchain, and integration snapshots, but the
+ecosystem is correcting contract and narrative inconsistencies before its next
+Development Preview. A released package proves that exact artifact exists; it
+does not make the whole ecosystem stable or make components outside one release
+wave valueless.
 
 | Surface | Maturity |
 |---|---|
-| Asset container, manifest, CBOR payload, checksums | Stable baseline |
-| Local public `validate → plan-load → load` | Stable baseline |
-| Runtime Capsule contract | Stable baseline in the JS reference path |
-| Studio authoring/export | Beta |
-| Single-asset task-aware runtime | Beta |
-| Cluster runtime and Cluster Assay | Beta |
-| Signing and revocation | Beta |
-| Licensed access and encrypted lifecycle | Candidate; confirm release-specific conformance |
-| Remote access protocol | Candidate |
-| Remote and activation reference servers | Experimental and self-hosted |
-| Swift, React, and Web parity | Beta / experimental by repository |
+| Asset container, manifest, CBOR payload, checksums | Pre-release; exact-version contract under reconciliation |
+| Local `validate → plan-load → load` | Pre-release; verify against the exact CLI/Core pair |
+| Runtime Capsule contract | Pre-release in the JS reference path |
+| Studio authoring/export | Pre-release; authoring fidelity under review |
+| Single-asset and multi-asset consumption | Pre-release / experimental by exact command |
+| Signing, revocation, licensed and encrypted lifecycle | Pre-release; security contracts under review |
+| Remote and activation reference servers | Pre-release integrations; self-hosted |
+| Swift, Agent, editor, React, and Web integrations | Pre-release by repository and exact version |
 
 ## Four Things That Must Not Be Collapsed
 
@@ -52,14 +50,18 @@ not separate KDNA product formats. Active user documentation describes one
 current KDNA Asset Container; schema and protocol documents carry the technical
 compatibility identifiers needed by implementations.
 
-## Not in the Public Baseline
+## Not Required by the Core Container
 
-- an AIKDNA-hosted registry or universal discovery service;
+- a hosted registry or universal discovery service;
 - a marketplace, billing service, or mandatory commercial platform;
-- an AIKDNA-hosted remote loading endpoint;
+- a hosted remote loading endpoint;
 - universal content ranking, certification, or recommendation;
 - a guarantee that an asset improves every model or task;
 - a complete memory, learning, evaluation, or deployment platform.
+
+Optional services and integrations may exist without becoming mandatory parts
+of the container protocol. Their value and maturity are assessed through their
+own contracts, users, and release evidence.
 
 For a specific package, use its release notes and CI evidence. For product
 boundaries, see [Core Narrative and Boundaries](./core-narrative-and-boundaries.md).

--- a/docs/open-source-maintenance-baseline.md
+++ b/docs/open-source-maintenance-baseline.md
@@ -7,16 +7,16 @@
 
 | Surface | Lifecycle | Maintenance claim |
 |---|---|---|
-| Protocol, schemas, conformance fixtures | Stable | Format and loader contract changes require tests and public evidence. |
-| `@aikdna/kdna-core` and `@aikdna/kdna-cli` | Beta | Local public `.kdna` assets are the supported first-run path. |
+| Protocol, schemas, conformance fixtures | Pre-release | Format and loader contract changes require tests and public evidence. |
+| `@aikdna/kdna-core` and `@aikdna/kdna-cli` | Pre-release | Local public `.kdna` assets are the supported first-run path. |
 | `@aikdna/kdna-eval` | Experimental | Issuer-scoped evaluation, replay, budget, and consumption evidence; not KDNA Core content authority. |
 | `@aikdna/kdna` | Legacy compatibility | Maintained migration bridge; new integrations use `@aikdna/kdna-cli` and `@aikdna/kdna-core` directly. |
-| Studio Core and Studio CLI | Beta | Public local asset authoring/export is supported; AI-assisted authoring remains experimental. |
+| Studio Core and Studio CLI | Pre-release | Public local asset authoring/export is supported; AI-assisted authoring remains experimental. |
 | Public `.kdna` reference assets | Experimental | Current technical references require metadata, SHA sidecars, public URLs, and public-surface checks; they are not content endorsements or the default onboarding path. |
-| Agent loader skill and MCP server | Beta / Experimental | Loader behavior must preserve plan-load-before-load and content-neutral boundaries. |
-| Web packages and scaffolder | Experimental | Published integration surfaces for upload, inspect, plan-load, load, and activation proxying. |
-| Swift runtime, Studio Swift, and app-shared package | Beta | Swift Core has a current 0.20.0 conformance release; Studio Swift 0.4.0 and App Shared 0.5.0 remain published but require current-runtime recertification before stronger claims. |
-| `kdna-vscode` | Legacy | Historical reference only; current workflows use CLI, Studio CLI, and loader integrations. |
+| Agent loader skill and MCP server | Pre-release / Experimental | Loader behavior must preserve plan-load-before-load and content-neutral boundaries. |
+| Web packages and scaffolder | Pre-release / Experimental | Published integration surfaces for upload, inspect, plan-load, load, and activation proxying. |
+| Swift runtime, Studio Swift, and app-shared package | Pre-release | Swift Core has a current 0.20.0 conformance release; Studio Swift 0.4.0 and App Shared 0.5.0 remain published but require current-runtime recertification before stronger claims. |
+| `kdna-vscode` | Pre-release integration | Editor workflows have an independent maturity lifecycle and remain part of the ecosystem. |
 | `@aikdna/agent` | Legacy / Deprecated | Frozen source only; current Agent integration uses `kdna-loader` or the experimental MCP bridge. |
 | `@aikdna/kdna-artifact-engine` and `@aikdna/kdna-fidelity-core` | Legacy / Deprecated | Historical draft implementations; not part of the current Runtime Capsule toolchain. |
 

--- a/docs/public-roadmap.md
+++ b/docs/public-roadmap.md
@@ -1,52 +1,89 @@
-# Public Roadmap
+# KDNA Public Roadmap
 
-## Current status: development reset
+## One definition
 
-KDNA does not currently have a stable, beta, GA, or production-ready release.
-Published packages and documentation describe development snapshots and may not
-match the source candidate under repair. A new Development Preview has not been
-released.
+KDNA is a judgment-asset container and protocol. It makes implicit, scattered,
+or latent judgment explicit so that it can have independent identity, version,
+integrity, provenance, encryption, authorization, loading, and governance.
+Compatible tools and hosts can create, carry, inspect, authorize, and consume
+that judgment without silently rewriting it.
 
-Current work is intentionally limited to:
+KDNA does not claim to add model intelligence or guarantee better output. Its
+core value is making selected judgment portable, verifiable, manageable, and
+usable across tools and ecosystems.
 
-- correcting public repository and package status;
-- fixing format, integrity, authorization, loading, and projection defects;
-- reducing the supported authoring and Runtime surface;
-- aligning the final source coordinates and conformance evidence.
+## One ecosystem, different responsibilities
 
-This work does not authorize new repositories, commands, protocols, services,
-adapters, or ecosystem products.
+The public repositories form an end-to-end ecosystem whose components have
+different responsibilities, maturity, and release schedules:
 
-## Next possible public milestone
+| Responsibility | Repositories | Mission |
+|---|---|---|
+| Protocol and Core | `kdna` | Container, schema, identity, integrity, encryption, authorization, and loading contracts |
+| Runtime tooling | `kdna-cli` | Inspect, validate, plan, manage, load, and consume KDNA assets |
+| Authoring | `kdna-studio-core`, `kdna-studio-cli` | Make implicit judgment explicit, review it, and export versioned assets |
+| Reference assets | `kdna-assets` | Interoperability fixtures and reference judgment assets |
+| Apple ecosystem | `kdna-core-swift`, `kdna-app-shared`, `kdna-studio-swift` | Swift runtime, shared application contracts, and native authoring integration |
+| Agent and editor integration | `kdna-skills`, `kdna-vscode` | Agent, Skill, MCP, and editor workflows for KDNA creation and consumption |
+| Web ecosystem | `kdna-web-client`, `kdna-web-server`, `kdna-react`, `create-kdna-web-app`, `kdna-demo-web-viewer` | Browser, server, React, scaffolding, and demonstrable end-to-end integration |
+| Authorization and remote use | `kdna-activation-server`, `kdna-remote-server` | Optional entitlement, revocation, and remote consumption deployments |
 
-The next possible milestone is a small **Development Preview / Protocol
-Preview**. It remains blocked until the retained contract is safe, internally
-consistent, built from unique new version coordinates, and verified from one
-final source set. Release coordinates require owner approval.
+The website is the public entry point for explaining this ecosystem. A
+component can be experimental, pre-release, inactive, or awaiting evidence
+without losing its mission or being removed from the ecosystem by default.
 
-A Preview will not claim GA compatibility, external adoption, improved model
-intelligence, or better results. It will still preserve minimum version
-integrity: one version maps to one source and artifact set, breaking changes use
-new coordinates, and unsupported assets are rejected consistently with an
-accurate diagnosis.
+## What is being corrected
+
+Current work separates four questions that were previously mixed together:
+
+1. Is the protocol contract internally correct?
+2. Does a particular tool or integration implement its declared contract?
+3. What maturity and compatibility does an exact version promise?
+4. Does a real user need a particular workflow?
+
+Repository existence, test volume, package publication, and one coordinated
+release wave do not answer all four questions. Maturity must be stated per
+component, and integration value must not be inferred from whether it is in the
+next release set.
 
 ## Evidence boundary
 
-Historical asset-level utility experiments are not a project existence,
-release, or product-admission gate. Their results do not establish general
-model improvement and do not justify new evaluation infrastructure. Content
-utility remains optional, asset-specific, and evaluator-scoped.
+Experiments about whether KDNA increases intelligence, improves output by a
+percentage, or beats equivalent Prompt or Skill content are not project-level
+release gates. Such results are evaluator-specific and asset-specific. They may
+be kept as optional research, but they do not decide whether the container,
+toolchain, authorization model, or ecosystem integrations should exist.
 
-## Explicitly not on the roadmap
+Protocol and product evidence instead focuses on:
 
-- Store, Cluster, Registry, Host, Trace, marketplace, hosted loading, billing,
-  badge, certification, Web/React product suites, or editor products;
-- general migration for maintainer-owned development artifacts;
-- compatibility promises inferred from repository, package, test, or CI
-  existence;
-- new behavior experiments required to prove that KDNA beats equivalent
-  Prompt or Skill content.
+- container identity, version, and byte integrity;
+- faithful preservation of declared judgment and boundaries;
+- encryption, authorization, revocation, and rollback;
+- deterministic validation and accurate load planning;
+- interoperable creation and consumption across supported hosts;
+- explicit, versioned failure when a contract is unsupported.
 
-Future public documentation will describe the exact supported path only after
-the final Development Preview candidate exists. This page does not present
-unreleased local behavior as currently available public functionality.
+## Current priorities
+
+1. Reconcile public claims with exact released versions without erasing the
+   ecosystem's missions.
+2. Fix confirmed protocol, security, schema, projection, and version-integrity
+   defects.
+3. Verify the minimal create-to-consume path and preserve judgment fidelity.
+4. Give every integration an explicit maturity statement and reproducible
+   compatibility evidence.
+5. Publish future Development Preview coordinates component by component when
+   their own gates are satisfied.
+
+No new version may overwrite an existing coordinate. No repository is promoted
+to stable merely because tests pass, and no repository is retired merely
+because it is outside one Preview wave.
+
+## Contribution boundary
+
+New work should explain how it contributes to creating, carrying, verifying,
+authorizing, governing, or consuming judgment assets. Project-level intelligence
+improvement experiments and generalized superiority claims are out of scope.
+Changes to a repository's mission or lifecycle require an explicit owner
+decision; they cannot be inferred from cleanup, release scoping, or an Agent
+audit.

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -115,9 +115,10 @@ KDNA Core is the **official KDNA judgment-asset format and runtime loading contr
 
 ## Current State
 
-The current KDNA Asset Container and local public-asset path are in public beta
-for packaged `.kdna` creation, validation, LoadPlan diagnostics, and loading.
-See [Status](./status.md) for the stable / beta / experimental boundary.
+The current KDNA Asset Container and local public-asset path are pre-release
+snapshots for packaged `.kdna` creation, validation, LoadPlan diagnostics, and
+loading. See [Status](./status.md) and the exact package release notes for the
+released / pre-release / experimental boundary.
 
 A single KDNA asset is the foundation and default consumption path. A KDNA
 Cluster is an explicit advanced path for coordinating multiple assets around a

--- a/docs/status.md
+++ b/docs/status.md
@@ -25,19 +25,19 @@ silently alter single-asset consumption.
 
 | Layer | Status | Public meaning |
 |---|---|---|
-| KDNA Asset Container | Stable baseline | Current mimetype, manifest, CBOR payload, checksums, and container rules |
-| Local public-asset runtime | Stable baseline | `inspect`, `validate`, `plan-load`, `load`, `pack`, `unpack`, Runtime Capsule |
-| Authoring toolchain | Beta | Studio project, card, compile, and `.kdna` export paths |
+| KDNA Asset Container | Pre-release | Current mimetype, manifest, CBOR payload, checksums, and container rules; exact-version contract under reconciliation |
+| Local public-asset runtime | Pre-release | `inspect`, `validate`, `plan-load`, `load`, `pack`, `unpack`, Runtime Capsule |
+| Authoring toolchain | Pre-release | Studio project, card, compile, and `.kdna` export paths |
 | Licensed access | Candidate | Public authorization and encryption contracts; verify the release-specific lifecycle before production use |
 | Remote access | Candidate | Remote access mode and projection contracts are public |
 | Remote/activation reference servers | Experimental | Self-hostable implementations; no AIKDNA-hosted service is part of the baseline |
-| Signing and revocation | Beta | Integrity and provenance mechanisms, not content endorsement |
-| Single-asset consumption runtime | Beta | Task-aware planning, projection, trace, and evaluation surfaces |
-| Cluster runtime | Beta | Explicit multi-asset roles, routing, conflict checks, plans, and traces |
+| Signing and revocation | Pre-release | Integrity and provenance mechanisms, not content endorsement |
+| Single-asset consumption runtime | Pre-release | Task-aware planning, projection, trace, and optional evaluation surfaces |
+| Cluster runtime | Pre-release | Explicit multi-asset roles, routing, conflict checks, plans, and traces |
 | JS Core | Reference implementation | Primary public conformance implementation |
 | Eval package | Experimental | Issuer-scoped replay, budget, and consumption evaluation; not Core authority |
 | `@aikdna/kdna` compatibility package | Legacy compatibility | Maintained migration bridge; not the recommended new integration path |
-| Swift, React, and Web adapters | Beta / experimental | Check each repository's release notes and shared conformance evidence |
+| Swift, Agent, editor, React, and Web integrations | Pre-release / experimental | Check each repository's release notes and shared conformance evidence |
 
 ## Current First-Run Path
 

--- a/docs/tool-status-matrix.md
+++ b/docs/tool-status-matrix.md
@@ -2,7 +2,7 @@
 
 > Last updated: 2026-07-19. Matches `@aikdna/kdna-cli@0.35.1`.
 > `Released` means the command is present in the published package; it is not a
-> claim that the overall Beta protocol/toolchain has reached GA.
+> claim that the overall pre-release protocol/toolchain has reached GA.
 
 ## Runtime CLI (`@aikdna/kdna-cli@0.35.1`)
 
@@ -25,15 +25,15 @@
 | `kdna revoke <asset>` | Issue signed revocation | Released |
 | `kdna revocation status <asset>` | Check revocation status | Released |
 | `kdna load --remote-server <url>` | Load `access:remote` assets via server | Released |
-| `kdna route <asset-path>` | Select a primary framework and emit a trace | Beta |
-| `kdna compose <asset-path>` | Compose a primary with bounded advisors | Beta |
-| `kdna project <asset-path>` | Render a packaged asset as a task-safe projection | Beta |
-| `kdna eval-consumption <asset-path>` | Evaluate a consumption policy with replay and gates | Beta |
+| `kdna route <asset-path>` | Select a primary framework and emit a trace | Pre-release |
+| `kdna compose <asset-path>` | Compose a primary with bounded advisors | Pre-release |
+| `kdna project <asset-path>` | Render a packaged asset as a task-safe projection | Pre-release |
+| `kdna eval-consumption <asset-path>` | Evaluate a consumption policy with replay and gates | Optional experiment; not a project gate |
 | `kdna eval asset <asset-path>` | Emit an Asset Assay observation matrix; CLI inputs do not create provenance claims | Experimental |
 | `kdna eval cluster <plan>` | Emit fail-closed Cluster diagnostics; trust/economics promotion remains inside a trusted Eval API producer | Experimental |
-| `kdna compose-review-workbook` | Generate a review workbook from diagnostics | Beta |
-| `kdna validate-compose-decisions` | Validate a decision ledger against fixture evidence | Beta |
-| `kdna apply-reviewed-compose-decisions` | Create disabled candidate sidecar entries | Beta |
+| `kdna compose-review-workbook` | Generate a review workbook from diagnostics | Pre-release |
+| `kdna validate-compose-decisions` | Validate a decision ledger against fixture evidence | Pre-release |
+| `kdna apply-reviewed-compose-decisions` | Create disabled candidate sidecar entries | Pre-release |
 | `kdna workpack <init\|validate\|plan\|run\|report>` | WorkPack pipeline | Experimental |
 | `kdna doctor [--agents]` | Installation health check | Released |
 | `kdna setup` | First-time setup wizard | Released |
@@ -56,14 +56,14 @@
 
 | Component | Status |
 |---|---|
-| `kdna-loader` skill | **Beta** — supports OpenCode, Codex, Claude Code, Cursor, Gemini. Auto-install via `kdna setup`. |
+| `kdna-loader` skill | **Pre-release** — supports OpenCode, Codex, Claude Code, Cursor, Gemini. Auto-install via `kdna setup`. |
 | MCP server adapter | Experimental |
 
 ## Package Boundaries
 
 | Package | Status |
 |---|---|
-| `@aikdna/kdna-core@0.20.0` | Beta runtime SDK |
+| `@aikdna/kdna-core@0.20.0` | Released pre-release runtime SDK |
 | `@aikdna/kdna-eval@0.3.2` | Released Experimental evaluation toolkit; issuer-scoped evidence is not KDNA Core authority |
 | `@aikdna/kdna@0.13.2` | Released, maintained Legacy compatibility bridge for CLI 0.35.1; new integrations use CLI and Core directly |
 
@@ -76,15 +76,15 @@ private development status is not part of the open protocol's tool matrix.
 
 | Package | Public release | Status |
 |---|---|---|
-| `kdna-core-swift` | `0.20.0` | Beta runtime; conformance is pinned to the current Core fixture commit. |
-| `kdna-studio-swift` | `0.4.0` | Beta authoring kernel; the published release predates current Swift Core integration and awaits recertification. |
-| `kdna-app-shared` | `0.5.0` | Beta presentation infrastructure; the published release predates Swift Core 0.20.0 and awaits recertification. |
+| `kdna-core-swift` | `0.20.0` | Pre-release runtime; conformance is pinned to the current Core fixture commit. |
+| `kdna-studio-swift` | `0.4.0` | Pre-release authoring kernel; the published release predates current Swift Core integration and awaits recertification. |
+| `kdna-app-shared` | `0.5.0` | Pre-release application integration; the published release predates Swift Core 0.20.0 and awaits recertification. |
 
-## Archived / Removed
+## Editor and Legacy Coordinates
 
 | Component | Notes |
 |---|---|
-| `kdna-vscode` | Archived 2026-06-25. Use `kdna-cli` for validate/plan-load/pack/unpack. |
+| `kdna-vscode` | Pre-release editor integration; maturity and compatibility are tracked independently from the CLI. |
 | `@aikdna/agent` | Deprecated legacy npm coordinate. Use the `kdna-loader` integration. |
 | `@aikdna/kdna-artifact-engine` | Deprecated historical implementation of a withdrawn draft contract. |
 | `@aikdna/kdna-fidelity-core` | Deprecated historical implementation of a withdrawn draft contract. |


### PR DESCRIPTION
## What changed

- restores KDNA's public definition as a judgment-asset container and protocol
- restores the complete creation, consumption, authorization, Apple, Web, Agent, editor, and developer integration ecosystem
- separates per-component maturity and release scheduling from repository mission
- removes project-level intelligence-improvement and Prompt/Skill superiority experiments from release gates
- corrects unsupported Beta and stable-baseline claims to exact-version pre-release language

## Why

The earlier lifecycle reset incorrectly inferred that repositories outside one release wave had no continuing mission. That inference was not owner-approved and contradicted the intended end-to-end KDNA ecosystem.

This PR restores the ecosystem mission without publishing a new package, changing protocol semantics, or claiming production readiness.

## Validation

- `npm run audit:public-narrative`
- `npm run audit:public-confidence`
- `npm run test:public-narrative`
- `git diff --check`
