### PR TITLE
fix: settle ecosystem gate at 30 minutes and advance CLI pin past Keychain hardening

### DIFF
--- a/.github/workflows/core-smoke.yml
+++ b/.github/workflows/core-smoke.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-cli
-          ref: a3eadd63afbf2f5a363c82cee2de2fbe02243b90
+          ref: e48d9179b101613704350c91a7b0498679253c3e
           path: .ecosystem-repos/kdna-cli
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -174,7 +174,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-cli
-          ref: a3eadd63afbf2f5a363c82cee2de2fbe02243b90
+          ref: e48d9179b101613704350c91a7b0498679253c3e
           path: .ecosystem-repos/kdna-cli
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:

--- a/ecosystem-manifest.json
+++ b/ecosystem-manifest.json
@@ -117,7 +117,7 @@
     {
       "repository": "aikdna/kdna-cli",
       "local_path": "../kdna-cli",
-      "source_commit": "a3eadd63afbf2f5a363c82cee2de2fbe02243b90",
+      "source_commit": "e48d9179b101613704350c91a7b0498679253c3e",
       "conformance_commit": null,
       "component_version": null,
       "artifacts": [],

--- a/scripts/core-release-authority.js
+++ b/scripts/core-release-authority.js
@@ -1483,7 +1483,7 @@ function runTrustedNpmCommand(args, options = {}) {
       timeout:
         options.timeout ||
         (Array.isArray(args) && args[0] === 'run' && args[1] === 'ecosystem-gate'
-          ? 40 * 60_000
+          ? 30 * 60_000
           : 15 * 60_000),
     });
     assert(!result.error, 'trusted npm workflow command failed');


### PR DESCRIPTION
With the headless keychain hangs closed (aikdna/kdna-cli#127), the ecosystem gate no longer needs the emergency 40-minute window; it settles at 30 minutes with the stage-progress diagnostics retained. Advances the CLI pin to merged main e48d9179 (argv fallback removed, deterministic refusal). Verified: manifest validator, 18/18 manifest tests, Prettier.