### PR TITLE
fix: warn on container dispatcher degradation instead of swallowing it

### DIFF
--- a/packages/kdna-core/CHANGELOG.md
+++ b/packages/kdna-core/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Warn with `KDNA_DISPATCHER_DEGRADED` when the container dispatcher fails to
+  load for any reason other than the module being absent, instead of silently
+  degrading to the legacy reader.
 - Fail closed on hostile Argon2id parameters in untrusted password envelopes:
   `memory_kib`, `iterations`, and `parallelism` must be integers within
   defensive bounds (256 MiB / 16 / 8), removing a remote denial-of-service

--- a/packages/kdna-core/src/container/index.js
+++ b/packages/kdna-core/src/container/index.js
@@ -55,7 +55,13 @@ const {
 const { readAsset } = (() => {
   try {
     return require('../container-dispatcher.js');
-  } catch {
+  } catch (e) {
+    if (!(e && e.code === 'MODULE_NOT_FOUND' && /container-dispatcher/.test(e.message || ''))) {
+      process.emitWarning(
+        `container-dispatcher failed to load; falling back to the legacy reader: ${e.message}`,
+        { code: 'KDNA_DISPATCHER_DEGRADED' },
+      );
+    }
     return { readAsset: null };
   }
 })();

--- a/packages/kdna-core/test/container-dispatcher.test.js
+++ b/packages/kdna-core/test/container-dispatcher.test.js
@@ -39,3 +39,58 @@ test('container schema validation does not depend on the host project cwd', () =
 
   execFileSync(process.execPath, ['-e', script], { cwd: tmp });
 });
+
+test('dispatcher load failure warns instead of being silently swallowed', () => {
+  const containerEntry = path.join(repoRoot, 'packages', 'kdna-core', 'src', 'container', 'index.js');
+  const script = `
+    const Module = require('node:module');
+    const originalLoad = Module._load;
+    Module._load = function (request, parent, isMain) {
+      if (request.endsWith('container-dispatcher.js')) {
+        const error = new Error('tampered dispatcher: simulated syntax failure');
+        error.code = 'ERR_TAMPERED';
+        throw error;
+      }
+      return originalLoad.apply(this, arguments);
+    };
+    process.on('warning', (warning) => {
+      if (warning.code === 'KDNA_DISPATCHER_DEGRADED') {
+        console.log('WARNING_EMITTED: ' + warning.message);
+      }
+    });
+    const container = require(${JSON.stringify(containerEntry)});
+    if (typeof container.validate !== 'function') {
+      throw new Error('container API missing after dispatcher failure');
+    }
+  `;
+  const out = execFileSync(process.execPath, ['-e', script], { encoding: 'utf8' });
+  assert.match(out, /WARNING_EMITTED: container-dispatcher failed to load/);
+});
+
+test('genuinely missing dispatcher module falls back without a warning', () => {
+  const containerEntry = path.join(repoRoot, 'packages', 'kdna-core', 'src', 'container', 'index.js');
+  const script = `
+    const Module = require('node:module');
+    const originalLoad = Module._load;
+    Module._load = function (request, parent, isMain) {
+      if (request.endsWith('container-dispatcher.js')) {
+        const error = new Error("Cannot find module '../container-dispatcher.js'");
+        error.code = 'MODULE_NOT_FOUND';
+        throw error;
+      }
+      return originalLoad.apply(this, arguments);
+    };
+    let warned = false;
+    process.on('warning', (warning) => {
+      if (warning.code === 'KDNA_DISPATCHER_DEGRADED') warned = true;
+    });
+    const container = require(${JSON.stringify(containerEntry)});
+    if (typeof container.validate !== 'function') {
+      throw new Error('container API missing after dispatcher loss');
+    }
+    if (warned) throw new Error('MODULE_NOT_FOUND fallback must stay silent');
+    console.log('SILENT_FALLBACK_OK');
+  `;
+  const out = execFileSync(process.execPath, ['-e', script], { encoding: 'utf8' });
+  assert.match(out, /SILENT_FALLBACK_OK/);
+});


### PR DESCRIPTION
U0 prerequisite (audit P0-3). A failed container-dispatcher load was silently converted into a legacy-reader fallback, masking a broken install. Non-MODULE_NOT_FOUND failures now emit a KDNA_DISPATCHER_DEGRADED process warning; a genuinely absent module still falls back silently by design. Two new subprocess tests cover both branches. Verified: 139/139 core, 196/196 repo, Prettier.