### PR TITLE
chore: advance CLI and Studio Core pins past the U0 prerequisite wave

### DIFF
--- a/.github/workflows/core-smoke.yml
+++ b/.github/workflows/core-smoke.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-cli
-          ref: e48d9179b101613704350c91a7b0498679253c3e
+          ref: db58804bcd4e760e990906067a633b196db1eb8d
           path: .ecosystem-repos/kdna-cli
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-studio-core
-          ref: 9774e12c61bfbc1439c66dc35af14da7bb686e71
+          ref: 4513f7393fcbc95e13a7a09871ea78d336b93520
           path: .ecosystem-repos/kdna-studio-core
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -174,7 +174,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-cli
-          ref: e48d9179b101613704350c91a7b0498679253c3e
+          ref: db58804bcd4e760e990906067a633b196db1eb8d
           path: .ecosystem-repos/kdna-cli
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -184,7 +184,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-studio-core
-          ref: 9774e12c61bfbc1439c66dc35af14da7bb686e71
+          ref: 4513f7393fcbc95e13a7a09871ea78d336b93520
           path: .ecosystem-repos/kdna-studio-core
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:

--- a/ecosystem-manifest.json
+++ b/ecosystem-manifest.json
@@ -117,7 +117,7 @@
     {
       "repository": "aikdna/kdna-cli",
       "local_path": "../kdna-cli",
-      "source_commit": "e48d9179b101613704350c91a7b0498679253c3e",
+      "source_commit": "db58804bcd4e760e990906067a633b196db1eb8d",
       "conformance_commit": null,
       "component_version": null,
       "artifacts": [],
@@ -228,7 +228,7 @@
     {
       "repository": "aikdna/kdna-studio-core",
       "local_path": "../kdna-studio-core",
-      "source_commit": "9774e12c61bfbc1439c66dc35af14da7bb686e71",
+      "source_commit": "4513f7393fcbc95e13a7a09871ea78d336b93520",
       "conformance_commit": null,
       "component_version": null,
       "artifacts": [],


### PR DESCRIPTION
Advances manifest pins and workflow checkout refs to merged mains: kdna-cli db58804 (discovery/install hardening), kdna-studio-core 4513f73 (atomic identity rotation). The downstream Core conformance pin intentionally stays at the content-identical pre-dispatcher coordinate; advancing it is a release-wave item now that the dispatcher change moved the Core package tree. Verified: manifest validator, 18/18 manifest tests.