### PR TITLE
fix: only degrade silently when the container dispatcher itself is absent

### DIFF
--- a/packages/kdna-core/CHANGELOG.md
+++ b/packages/kdna-core/CHANGELOG.md
@@ -3,8 +3,12 @@
 ## Unreleased
 
 - Warn with `KDNA_DISPATCHER_DEGRADED` when the container dispatcher fails to
-  load for any reason other than the module being absent, instead of silently
-  degrading to the legacy reader.
+  load for any reason other than the dispatcher file itself being absent,
+  instead of silently degrading to the legacy reader. The absence check now
+  resolves the dispatcher path up front, so a present dispatcher with a
+  missing internal dependency, a syntax or initialization error, or a
+  permission error is reported instead of being mistaken for a missing
+  module.
 - Fail closed on hostile Argon2id parameters in untrusted password envelopes:
   `memory_kib`, `iterations`, and `parallelism` must be integers within
   defensive bounds (256 MiB / 16 / 8), removing a remote denial-of-service

--- a/packages/kdna-core/src/container/index.js
+++ b/packages/kdna-core/src/container/index.js
@@ -52,17 +52,40 @@ const {
   isVerifiedExternalEntitlement,
 } = require('../external-key-grant');
 
+function warnDispatcherDegraded(e) {
+  process.emitWarning(
+    `container-dispatcher failed to load; falling back to the legacy reader: ${e.message}`,
+    { code: 'KDNA_DISPATCHER_DEGRADED' },
+  );
+  return { readAsset: null };
+}
+
 const { readAsset } = (() => {
+  const dispatcherRequest = '../container-dispatcher.js';
+  // Absence check via require.resolve: resolution only inspects the module
+  // path and never executes the target, so it can only fail with
+  // MODULE_NOT_FOUND when the dispatcher file itself cannot be located.
+  // Message matching is intentionally not used: Node prints the require
+  // stack inside MODULE_NOT_FOUND messages, so a dispatcher whose own
+  // internal dependency is missing would mention "container-dispatcher"
+  // and be misclassified as absent.
   try {
-    return require('../container-dispatcher.js');
+    require.resolve(dispatcherRequest);
   } catch (e) {
-    if (!(e && e.code === 'MODULE_NOT_FOUND' && /container-dispatcher/.test(e.message || ''))) {
-      process.emitWarning(
-        `container-dispatcher failed to load; falling back to the legacy reader: ${e.message}`,
-        { code: 'KDNA_DISPATCHER_DEGRADED' },
-      );
+    if (e && e.code === 'MODULE_NOT_FOUND') {
+      // The dispatcher file is genuinely absent: expected in minimal
+      // installs. Fall back silently.
+      return { readAsset: null };
     }
-    return { readAsset: null };
+    return warnDispatcherDegraded(e);
+  }
+  // The file resolved; any failure from here on (missing internal
+  // dependency, syntax error, initialization throw, permission error) is a
+  // real load failure and must be surfaced.
+  try {
+    return require(dispatcherRequest);
+  } catch (e) {
+    return warnDispatcherDegraded(e);
   }
 })();
 

--- a/packages/kdna-core/test/container-dispatcher.test.js
+++ b/packages/kdna-core/test/container-dispatcher.test.js
@@ -40,15 +40,78 @@ test('container schema validation does not depend on the host project cwd', () =
   execFileSync(process.execPath, ['-e', script], { cwd: tmp });
 });
 
-test('dispatcher load failure warns instead of being silently swallowed', () => {
+test('genuinely missing dispatcher module falls back without a warning', () => {
+  const containerEntry = path.join(repoRoot, 'packages', 'kdna-core', 'src', 'container', 'index.js');
+  const script = `
+    const Module = require('node:module');
+    const originalResolveFilename = Module._resolveFilename;
+    Module._resolveFilename = function (request, parent, isMain, options) {
+      if (request.endsWith('container-dispatcher.js')) {
+        const error = new Error("Cannot find module '../container-dispatcher.js'");
+        error.code = 'MODULE_NOT_FOUND';
+        throw error;
+      }
+      return originalResolveFilename.apply(this, arguments);
+    };
+    let warned = false;
+    process.on('warning', (warning) => {
+      if (warning.code === 'KDNA_DISPATCHER_DEGRADED') warned = true;
+    });
+    const container = require(${JSON.stringify(containerEntry)});
+    if (typeof container.validate !== 'function') {
+      throw new Error('container API missing after dispatcher loss');
+    }
+    if (warned) throw new Error('MODULE_NOT_FOUND fallback must stay silent');
+    console.log('SILENT_FALLBACK_OK');
+  `;
+  const out = execFileSync(process.execPath, ['-e', script], { encoding: 'utf8' });
+  assert.match(out, /SILENT_FALLBACK_OK/);
+});
+
+test('missing internal dispatcher dependency warns instead of degrading silently', () => {
+  const containerEntry = path.join(repoRoot, 'packages', 'kdna-core', 'src', 'container', 'index.js');
+  const dispatcherEntry = path.join(repoRoot, 'packages', 'kdna-core', 'src', 'container-dispatcher.js');
+  const script = `
+    const Module = require('node:module');
+    const originalLoad = Module._load;
+    Module._load = function (request, parent, isMain) {
+      if (parent && parent.filename && parent.filename.endsWith('container-dispatcher.js')) {
+        // Simulate Node's real MODULE_NOT_FOUND shape for a missing
+        // dependency: the message embeds the require stack, which mentions
+        // container-dispatcher even though the dispatcher itself exists.
+        const error = new Error(
+          "Cannot find module 'kdna-dispatcher-internal-dep'\\n" +
+          'Require stack:\\n- ' + parent.filename
+        );
+        error.code = 'MODULE_NOT_FOUND';
+        error.requireStack = [parent.filename];
+        throw error;
+      }
+      return originalLoad.apply(this, arguments);
+    };
+    process.on('warning', (warning) => {
+      if (warning.code === 'KDNA_DISPATCHER_DEGRADED') {
+        console.log('WARNING_EMITTED: ' + warning.message);
+      }
+    });
+    const container = require(${JSON.stringify(containerEntry)});
+    if (typeof container.validate !== 'function') {
+      throw new Error('container API missing after dispatcher dependency failure');
+    }
+  `;
+  const out = execFileSync(process.execPath, ['-e', script], { encoding: 'utf8' });
+  assert.match(out, /WARNING_EMITTED: container-dispatcher failed to load/);
+  assert.match(out, new RegExp(dispatcherEntry.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+});
+
+test('dispatcher syntax or initialization failure warns before degrading', () => {
   const containerEntry = path.join(repoRoot, 'packages', 'kdna-core', 'src', 'container', 'index.js');
   const script = `
     const Module = require('node:module');
     const originalLoad = Module._load;
     Module._load = function (request, parent, isMain) {
       if (request.endsWith('container-dispatcher.js')) {
-        const error = new Error('tampered dispatcher: simulated syntax failure');
-        error.code = 'ERR_TAMPERED';
+        const error = new SyntaxError('tampered dispatcher: simulated syntax failure');
         throw error;
       }
       return originalLoad.apply(this, arguments);
@@ -67,30 +130,22 @@ test('dispatcher load failure warns instead of being silently swallowed', () => 
   assert.match(out, /WARNING_EMITTED: container-dispatcher failed to load/);
 });
 
-test('genuinely missing dispatcher module falls back without a warning', () => {
+test('intact dispatcher loads normally without any degradation warning', () => {
   const containerEntry = path.join(repoRoot, 'packages', 'kdna-core', 'src', 'container', 'index.js');
+  const example = path.join(repoRoot, 'examples', 'minimal');
   const script = `
-    const Module = require('node:module');
-    const originalLoad = Module._load;
-    Module._load = function (request, parent, isMain) {
-      if (request.endsWith('container-dispatcher.js')) {
-        const error = new Error("Cannot find module '../container-dispatcher.js'");
-        error.code = 'MODULE_NOT_FOUND';
-        throw error;
-      }
-      return originalLoad.apply(this, arguments);
-    };
     let warned = false;
     process.on('warning', (warning) => {
       if (warning.code === 'KDNA_DISPATCHER_DEGRADED') warned = true;
     });
     const container = require(${JSON.stringify(containerEntry)});
-    if (typeof container.validate !== 'function') {
-      throw new Error('container API missing after dispatcher loss');
+    const result = container.validate(${JSON.stringify(example)});
+    if (!result.overall_valid) {
+      throw new Error(JSON.stringify(result.problems || result, null, 2));
     }
-    if (warned) throw new Error('MODULE_NOT_FOUND fallback must stay silent');
-    console.log('SILENT_FALLBACK_OK');
+    if (warned) throw new Error('healthy dispatcher must not warn');
+    console.log('HEALTHY_DISPATCHER_OK');
   `;
   const out = execFileSync(process.execPath, ['-e', script], { encoding: 'utf8' });
-  assert.match(out, /SILENT_FALLBACK_OK/);
+  assert.match(out, /HEALTHY_DISPATCHER_OK/);
 });


### PR DESCRIPTION
## Problem

`packages/kdna-core/src/container/index.js` degraded silently whenever a `MODULE_NOT_FOUND` error message mentioned `container-dispatcher` anywhere. Node embeds the require stack in `MODULE_NOT_FOUND` messages, so a dispatcher file that **exists** but fails because one of its own internal dependencies is missing (the require stack names `container-dispatcher.js`) was misclassified as "module absent" and swallowed with zero warnings.

## Fix

The absence check now resolves the dispatcher path up front via `require.resolve('../container-dispatcher.js')`:

- Resolution never executes the module, so `MODULE_NOT_FOUND` at this step can only mean the dispatcher file itself cannot be located — the one case that is expected in minimal installs and must stay silent.
- Once resolution succeeds, any failure from `require()` — missing internal dependency, syntax error, initialization throw, permission error — emits a `KDNA_DISPATCHER_DEGRADED` warning before falling back to the legacy reader.

Message-regex matching is removed entirely; the rationale is documented in a comment at the site.

No new protocol fields, no new public commands, no API surface change.

## Tests

Four subprocess tests in `packages/kdna-core/test/container-dispatcher.test.js` (existing pattern):

- **(a)** dispatcher file itself absent (`Module._resolveFilename` throws `MODULE_NOT_FOUND`) → silent fallback, no warning;
- **(b)** dispatcher present but its internal `require` fails with a real Node-shaped `MODULE_NOT_FOUND` whose require stack names the dispatcher → `KDNA_DISPATCHER_DEGRADED` emitted, message names the dispatcher path;
- **(c)** dispatcher syntax/initialization failure (`SyntaxError`) → warning emitted;
- **(d)** intact dispatcher → loads normally, `validate` passes, no warning.

No other tests reference the degradation path (repo-wide grep: only this test file and the CHANGELOG).

## Verification

- `npm --workspace @aikdna/kdna-core test` — 141/141 pass
- `npm test` — 196/196 pass
- `npm run format:check` — pass
- `npm run lint` — pass

## Changelog

`packages/kdna-core/CHANGELOG.md` Unreleased entry updated to state the precise behavior: silent only when the dispatcher file itself is absent; missing internal dependency, syntax/initialization, and permission failures are reported.