### PR TITLE
chore: reanchor final release coordinates

### DIFF
--- a/.github/workflows/core-smoke.yml
+++ b/.github/workflows/core-smoke.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-skills
-          ref: a186b3d5080837576a0934c62c995c29759e462c
+          ref: a011f03364428f35ef17cda470c0835dff3067fe
           path: .ecosystem-repos/kdna-skills
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -79,17 +79,17 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-vscode
-          ref: e199205d6e27d31e928d4d0423fa9509bd545b24
+          ref: ec896fda5c1eba1b14631dc5bed7c35564a0c062
           path: .ecosystem-repos/kdna-vscode
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-studio-cli
-          ref: f937966f04c8713497032208a1d5a85a85cdf221
+          ref: e9741982bb784e7f4410d495c917dc42db6c170f
           path: .ecosystem-repos/kdna-studio-cli
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-studio-core
-          ref: d215be1b1535e04dc865a996609c0144415575c1
+          ref: 8ca7df19cadd32a08b4067a39992bb28039bf294
           path: .ecosystem-repos/kdna-studio-core
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -179,17 +179,17 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-skills
-          ref: a186b3d5080837576a0934c62c995c29759e462c
+          ref: a011f03364428f35ef17cda470c0835dff3067fe
           path: .ecosystem-repos/kdna-skills
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-studio-core
-          ref: d215be1b1535e04dc865a996609c0144415575c1
+          ref: 8ca7df19cadd32a08b4067a39992bb28039bf294
           path: .ecosystem-repos/kdna-studio-core
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-studio-cli
-          ref: f937966f04c8713497032208a1d5a85a85cdf221
+          ref: e9741982bb784e7f4410d495c917dc42db6c170f
           path: .ecosystem-repos/kdna-studio-cli
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -212,7 +212,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-vscode
-          ref: e199205d6e27d31e928d4d0423fa9509bd545b24
+          ref: ec896fda5c1eba1b14631dc5bed7c35564a0c062
           path: .ecosystem-repos/kdna-vscode
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 - Reconcile the ecosystem manifest and its two exact-checkout workflows to the
   accepted CLI, MCP, Studio, Swift, shared-app, and VS Code main coordinates;
   MCP 0.5.0 is a candidate over the published 0.4.2 incumbent.
+- Re-anchor the ecosystem manifest and both exact-checkout workflows to the
+  final Skills, Studio Core, Studio CLI, and VS Code release-integrity
+  correction commits; record the published 0.1.0 Marketplace extension as the
+  incumbent while keeping 0.2.0 explicitly unpublished and unassessed.
 - Reconcile current public maturity language to pre-release, keep exact
   published-version contracts separate from corrective source candidates, and
   remove output-improvement language from the active Agent guide. Apply the

--- a/ecosystem-manifest.json
+++ b/ecosystem-manifest.json
@@ -197,7 +197,7 @@
     {
       "repository": "aikdna/kdna-skills",
       "local_path": "../kdna-skills",
-      "source_commit": "a186b3d5080837576a0934c62c995c29759e462c",
+      "source_commit": "a011f03364428f35ef17cda470c0835dff3067fe",
       "conformance_commit": null,
       "component_version": null,
       "artifacts": [],
@@ -229,7 +229,7 @@
     {
       "repository": "aikdna/kdna-studio-core",
       "local_path": "../kdna-studio-core",
-      "source_commit": "d215be1b1535e04dc865a996609c0144415575c1",
+      "source_commit": "8ca7df19cadd32a08b4067a39992bb28039bf294",
       "conformance_commit": null,
       "component_version": null,
       "artifacts": [],
@@ -263,7 +263,7 @@
     {
       "repository": "aikdna/kdna-studio-cli",
       "local_path": "../kdna-studio-cli",
-      "source_commit": "f937966f04c8713497032208a1d5a85a85cdf221",
+      "source_commit": "e9741982bb784e7f4410d495c917dc42db6c170f",
       "conformance_commit": null,
       "component_version": null,
       "artifacts": [],
@@ -582,7 +582,7 @@
     {
       "repository": "aikdna/kdna-vscode",
       "local_path": "../kdna-vscode",
-      "source_commit": "e199205d6e27d31e928d4d0423fa9509bd545b24",
+      "source_commit": "ec896fda5c1eba1b14631dc5bed7c35564a0c062",
       "conformance_commit": null,
       "component_version": null,
       "artifacts": [],
@@ -596,7 +596,7 @@
           "release_status": "source-only",
           "dependency_policy": "none",
           "known_limitations": [
-            "editor integration mission retained; technical Host/UI acceptance is synthetic and does not substitute for Owner judgment-material acceptance or Marketplace review"
+            "the historical 0.1.0 Marketplace extension remains the published incumbent; 0.2.0 is an unpublished source candidate whose technical Host/UI acceptance does not substitute for Owner judgment-material acceptance or Marketplace review"
           ],
           "recommended_entrypoint": null,
           "legacy_replacement": null
@@ -607,7 +607,7 @@
       "supported_access_modes": [],
       "supported_entitlement_profiles": [],
       "known_limitations": [
-        "accepted source uses the exact CLI/Core candidate line and passed real Extension Development Host controls, but end-user judgment acceptance and Marketplace release remain unassessed"
+        "the historical 0.1.0 Marketplace extension remains published; accepted 0.2.0 source uses the exact CLI/Core candidate line and passed real Extension Development Host controls, but end-user judgment acceptance and the 0.2.0 Marketplace release remain unassessed"
       ],
       "recommended_entrypoint": null,
       "legacy_replacement": null


### PR DESCRIPTION
Summary:
- bind the ecosystem manifest and both exact-checkout workflows to the accepted final Skills, Studio Core, Studio CLI, and VS Code commits
- record the historical VS Code 0.1.0 Marketplace incumbent while keeping 0.2.0 unpublished and unassessed
- add the release-coordinate correction to the Unreleased changelog

Local evidence:
- ecosystem manifest validation: passed (21 components, 18 packages, 2 artifacts)
- manifest/workflow binding tests: 18/18 passed
- Core smoke: passed
- public-surface and public-narrative checks: passed
- stable published-line lock: intentionally reports the five unpublished candidate dependencies; this is the release-order boundary, not a green assertion

No package was published, no tag or Release was created, and no production state was changed.