### PR TITLE
docs: refresh final CLI and Skills coordinates

### DIFF
--- a/.github/workflows/core-smoke.yml
+++ b/.github/workflows/core-smoke.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-cli
-          ref: 478114cda7d1f9e807b0c26b1ebd1b32721150eb
+          ref: 5307fbc0d729f3fb3cb5ad6c24afeeb4053da0a6
           path: .ecosystem-repos/kdna-cli
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-skills
-          ref: a011f03364428f35ef17cda470c0835dff3067fe
+          ref: b58f01bede0a194fb04a7855fd4fcb381f8e965c
           path: .ecosystem-repos/kdna-skills
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -174,12 +174,12 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-cli
-          ref: 478114cda7d1f9e807b0c26b1ebd1b32721150eb
+          ref: 5307fbc0d729f3fb3cb5ad6c24afeeb4053da0a6
           path: .ecosystem-repos/kdna-cli
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-skills
-          ref: a011f03364428f35ef17cda470c0835dff3067fe
+          ref: b58f01bede0a194fb04a7855fd4fcb381f8e965c
           path: .ecosystem-repos/kdna-skills
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:

--- a/ecosystem-manifest.json
+++ b/ecosystem-manifest.json
@@ -117,7 +117,7 @@
     {
       "repository": "aikdna/kdna-cli",
       "local_path": "../kdna-cli",
-      "source_commit": "478114cda7d1f9e807b0c26b1ebd1b32721150eb",
+      "source_commit": "5307fbc0d729f3fb3cb5ad6c24afeeb4053da0a6",
       "conformance_commit": null,
       "component_version": null,
       "artifacts": [],
@@ -197,7 +197,7 @@
     {
       "repository": "aikdna/kdna-skills",
       "local_path": "../kdna-skills",
-      "source_commit": "a011f03364428f35ef17cda470c0835dff3067fe",
+      "source_commit": "b58f01bede0a194fb04a7855fd4fcb381f8e965c",
       "conformance_commit": null,
       "component_version": null,
       "artifacts": [],


### PR DESCRIPTION
## Summary
- bind the ecosystem manifest to the merged CLI state-free load fix
- bind the Skills/MCP source coordinate to its merged runtime candidate repin

## Verification
- `npm run validate:ecosystem-manifest`
- `npm run validate:public-truth`
- `node scripts/docs-ci.js`
- `node scripts/check-publish-drift.js`
- `npm exec -- prettier --check ecosystem-manifest.json`

`npm run test:ecosystem-lock` continues to fail closed on the five intentional unpublished candidate dependency coordinates; this PR does not change published-version authority.