### PR TITLE
docs: record final state-free source pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 - Reconcile the ecosystem manifest and its two exact-checkout workflows to the
   accepted CLI, MCP, Studio, Swift, shared-app, and VS Code main coordinates;
   MCP 0.5.0 is a candidate over the published 0.4.2 incumbent.
+- Refresh the exact CLI and Skills/MCP source pins after normal CLI loads became
+  state-free and opt-in local audit receipts became path-neutral; keep the
+  manifest and both exact-checkout workflows synchronized.
 - Re-anchor the ecosystem manifest and both exact-checkout workflows to the
   final Skills, Studio Core, Studio CLI, and VS Code release-integrity
   correction commits; record the published 0.1.0 Marketplace extension as the


### PR DESCRIPTION
## Summary
- record why the exact CLI and Skills/MCP pins advanced
- provide an author-matching DCO successor after GitHub authored the prior squash with the account email

## Verification
- `npm exec -- prettier --check CHANGELOG.md`
- `npm run audit:public-narrative`
- `npm run audit:public-confidence`

The preceding coordinate merge is technically green, but its GitHub-generated squash author did not match its trailer; release authority correctly rejects it as a terminal release commit. This signed successor restores a valid final-main DCO boundary.