### PR TITLE
chore: preserve frozen Core candidate bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,6 @@
 - Reconcile the ecosystem manifest and its two exact-checkout workflows to the
   accepted CLI, MCP, Studio, Swift, shared-app, and VS Code main coordinates;
   MCP 0.5.0 is a candidate over the published 0.4.2 incumbent.
-- Refresh the exact CLI and Skills/MCP source pins after normal CLI loads became
-  state-free and opt-in local audit receipts became path-neutral; keep the
-  manifest and both exact-checkout workflows synchronized.
 - Re-anchor the ecosystem manifest and both exact-checkout workflows to the
   final Skills, Studio Core, Studio CLI, and VS Code release-integrity
   correction commits; record the published 0.1.0 Marketplace extension as the


### PR DESCRIPTION
## Summary
- remove the redundant changelog-only successor note
- keep the final coordinate/checkouts correction while restoring the accepted Core package surface byte-for-byte

## Evidence
- `packages/kdna-core` tree remains exactly the accepted `76bbc587…` package tree
- the retained `b1de7d…` artifact and a fresh npm 11.17 pack extract to byte-identical package contents
- the compressed-byte difference under local Node 24 is the already documented Node/zlib packaging variance, not a source-content difference

This successor prevents an unrelated documentation-only artifact change from propagating into the frozen release candidate.