### PR TITLE
docs: add explicit DCO policy reference

### DIFF
--- a/DCO.md
+++ b/DCO.md
@@ -1,0 +1,5 @@
+# KDNA DCO Policy
+
+All commits to this repository must carry a DCO sign-off matching the commit author.
+GitHub squash merges must use an email matching the DCO sign-off identity.
+See CONTRIBUTING.md for details.


### PR DESCRIPTION
Fixes squash-merge DCO mismatch. Author email now matches sign-off identity.