### PR TITLE
fix: final DCO policy with exact identity match

### DIFF
--- a/.github/dco-policy.md
+++ b/.github/dco-policy.md
@@ -1,1 +1,12 @@
-fix: enforce exact DCO identity match
+# KDNA DCO Policy
+
+Every commit merged to main must carry a `Signed-off-by` trailer whose
+normalized identity (name + email) exactly matches the commit `Author`.
+
+For squash merges the PR body must end with:
+
+```
+Signed-off-by: <Name> <Email>
+```
+
+where `<Email>` is the GitHub noreply address (e.g. `283974009+aikdna@users.noreply.github.com`).


### PR DESCRIPTION
Replaces placeholder DCO policy with real enforceable rules. Commit Author matches Signed-off-by. Must be merged with identity-preserving method.