### PR TITLE
fix: reconcile final ecosystem candidate lock

### DIFF
--- a/.github/workflows/core-smoke.yml
+++ b/.github/workflows/core-smoke.yml
@@ -25,13 +25,13 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-assets
-          ref: 853292686ce003d75b2f078ac32634969bb0de98
+          ref: 72362a9749d099799e3093699f43437fe2fa4d8e
           path: .ecosystem-repos/kdna-assets
           fetch-depth: 0
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-cli
-          ref: 5307fbc0d729f3fb3cb5ad6c24afeeb4053da0a6
+          ref: 1d9900ee13176ba20f32ab72bd9a22a7de51503d
           path: .ecosystem-repos/kdna-cli
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -41,12 +41,12 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-demo-web-viewer
-          ref: 6bae1c23ba61aa9860aa2ea74a4f972e6afafd12
+          ref: f2bb5459229c44fe0c8ef0294602797e6c9fd7e2
           path: .ecosystem-repos/kdna-demo-web-viewer
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-react
-          ref: 21bf622300491fdb67fe6db27e8806c9de0d24c1
+          ref: 49e06898a1b9b304119881931421bb1cb0c31c10
           path: .ecosystem-repos/kdna-react
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-skills
-          ref: b58f01bede0a194fb04a7855fd4fcb381f8e965c
+          ref: b64baa90a6d78c91ec34fa2d3674fe5c8f24e505
           path: .ecosystem-repos/kdna-skills
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -79,12 +79,12 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-vscode
-          ref: ec896fda5c1eba1b14631dc5bed7c35564a0c062
+          ref: f5629f664efc098916f9576c4d3652a62c994bd4
           path: .ecosystem-repos/kdna-vscode
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-studio-cli
-          ref: e9741982bb784e7f4410d495c917dc42db6c170f
+          ref: 7056162365897b3008fe0e56c2cdcf95260b6e5d
           path: .ecosystem-repos/kdna-studio-cli
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -94,12 +94,12 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-web-client
-          ref: 36588c414e9ea5c78b2461184389b4b2b5cd6985
+          ref: 7cb0da126d3c36259e48e4447ee58348f54f78e7
           path: .ecosystem-repos/kdna-web-client
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-web-server
-          ref: fa7ab37250dc0cd62dd37938b5c7a766d98bc849
+          ref: d8fcece8642dc1cf47e93a59213eab5b046654eb
           path: .ecosystem-repos/kdna-web-server
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -174,12 +174,12 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-cli
-          ref: 5307fbc0d729f3fb3cb5ad6c24afeeb4053da0a6
+          ref: 1d9900ee13176ba20f32ab72bd9a22a7de51503d
           path: .ecosystem-repos/kdna-cli
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-skills
-          ref: b58f01bede0a194fb04a7855fd4fcb381f8e965c
+          ref: b64baa90a6d78c91ec34fa2d3674fe5c8f24e505
           path: .ecosystem-repos/kdna-skills
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -189,7 +189,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-studio-cli
-          ref: e9741982bb784e7f4410d495c917dc42db6c170f
+          ref: 7056162365897b3008fe0e56c2cdcf95260b6e5d
           path: .ecosystem-repos/kdna-studio-cli
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -212,7 +212,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-vscode
-          ref: ec896fda5c1eba1b14631dc5bed7c35564a0c062
+          ref: f5629f664efc098916f9576c4d3652a62c994bd4
           path: .ecosystem-repos/kdna-vscode
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -227,17 +227,17 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-web-server
-          ref: fa7ab37250dc0cd62dd37938b5c7a766d98bc849
+          ref: d8fcece8642dc1cf47e93a59213eab5b046654eb
           path: .ecosystem-repos/kdna-web-server
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-web-client
-          ref: 36588c414e9ea5c78b2461184389b4b2b5cd6985
+          ref: 7cb0da126d3c36259e48e4447ee58348f54f78e7
           path: .ecosystem-repos/kdna-web-client
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-react
-          ref: 21bf622300491fdb67fe6db27e8806c9de0d24c1
+          ref: 49e06898a1b9b304119881931421bb1cb0c31c10
           path: .ecosystem-repos/kdna-react
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -247,13 +247,13 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-assets
-          ref: 853292686ce003d75b2f078ac32634969bb0de98
+          ref: 72362a9749d099799e3093699f43437fe2fa4d8e
           path: .ecosystem-repos/kdna-assets
           fetch-depth: 0
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-demo-web-viewer
-          ref: 6bae1c23ba61aa9860aa2ea74a4f972e6afafd12
+          ref: f2bb5459229c44fe0c8ef0294602797e6c9fd7e2
           path: .ecosystem-repos/kdna-demo-web-viewer
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
         with:

--- a/ecosystem-manifest.json
+++ b/ecosystem-manifest.json
@@ -117,7 +117,7 @@
     {
       "repository": "aikdna/kdna-cli",
       "local_path": "../kdna-cli",
-      "source_commit": "5307fbc0d729f3fb3cb5ad6c24afeeb4053da0a6",
+      "source_commit": "1d9900ee13176ba20f32ab72bd9a22a7de51503d",
       "conformance_commit": null,
       "component_version": null,
       "artifacts": [],
@@ -149,7 +149,7 @@
     {
       "repository": "aikdna/kdna-assets",
       "local_path": "../kdna-assets",
-      "source_commit": "853292686ce003d75b2f078ac32634969bb0de98",
+      "source_commit": "72362a9749d099799e3093699f43437fe2fa4d8e",
       "conformance_commit": "76bbc587ce05f7e575c2373832cc5c9eee9df98a",
       "component_version": null,
       "packages": [],
@@ -197,7 +197,7 @@
     {
       "repository": "aikdna/kdna-skills",
       "local_path": "../kdna-skills",
-      "source_commit": "b58f01bede0a194fb04a7855fd4fcb381f8e965c",
+      "source_commit": "b64baa90a6d78c91ec34fa2d3674fe5c8f24e505",
       "conformance_commit": null,
       "component_version": null,
       "artifacts": [],
@@ -263,7 +263,7 @@
     {
       "repository": "aikdna/kdna-studio-cli",
       "local_path": "../kdna-studio-cli",
-      "source_commit": "e9741982bb784e7f4410d495c917dc42db6c170f",
+      "source_commit": "7056162365897b3008fe0e56c2cdcf95260b6e5d",
       "conformance_commit": null,
       "component_version": null,
       "artifacts": [],
@@ -359,7 +359,7 @@
     {
       "repository": "aikdna/kdna-web-server",
       "local_path": "../kdna-web-server",
-      "source_commit": "fa7ab37250dc0cd62dd37938b5c7a766d98bc849",
+      "source_commit": "d8fcece8642dc1cf47e93a59213eab5b046654eb",
       "conformance_commit": null,
       "component_version": null,
       "artifacts": [],
@@ -391,7 +391,7 @@
     {
       "repository": "aikdna/kdna-web-client",
       "local_path": "../kdna-web-client",
-      "source_commit": "36588c414e9ea5c78b2461184389b4b2b5cd6985",
+      "source_commit": "7cb0da126d3c36259e48e4447ee58348f54f78e7",
       "conformance_commit": null,
       "component_version": null,
       "artifacts": [],
@@ -423,7 +423,7 @@
     {
       "repository": "aikdna/kdna-react",
       "local_path": "../kdna-react",
-      "source_commit": "21bf622300491fdb67fe6db27e8806c9de0d24c1",
+      "source_commit": "49e06898a1b9b304119881931421bb1cb0c31c10",
       "conformance_commit": null,
       "component_version": null,
       "artifacts": [],
@@ -488,7 +488,7 @@
     {
       "repository": "aikdna/kdna-demo-web-viewer",
       "local_path": "../kdna-demo-web-viewer",
-      "source_commit": "6bae1c23ba61aa9860aa2ea74a4f972e6afafd12",
+      "source_commit": "f2bb5459229c44fe0c8ef0294602797e6c9fd7e2",
       "conformance_commit": null,
       "component_version": null,
       "artifacts": [],
@@ -582,7 +582,7 @@
     {
       "repository": "aikdna/kdna-vscode",
       "local_path": "../kdna-vscode",
-      "source_commit": "ec896fda5c1eba1b14631dc5bed7c35564a0c062",
+      "source_commit": "f5629f664efc098916f9576c4d3652a62c994bd4",
       "conformance_commit": null,
       "component_version": null,
       "artifacts": [],

--- a/scripts/ecosystem-version-lock.js
+++ b/scripts/ecosystem-version-lock.js
@@ -61,7 +61,6 @@ const EXPECTED_BINDINGS = Object.freeze(
     ['kdna-assets', 'package.json', 'devDependencies', '@aikdna/kdna-core'],
     ['kdna-assets', 'package.json', 'devDependencies', '@aikdna/kdna-cli'],
     ['kdna-cli', 'package.json', 'dependencies', '@aikdna/kdna-core'],
-    ['kdna-cli', 'package.json', 'dependencies', '@aikdna/kdna-eval'],
     ['kdna-demo-web-viewer', 'app/package.json', 'dependencies', '@aikdna/kdna-core'],
     ['kdna-demo-web-viewer', 'app/package.json', 'dependencies', '@aikdna/kdna-react'],
     ['kdna-demo-web-viewer', 'app/package.json', 'dependencies', '@aikdna/kdna-web-client'],

--- a/scripts/ecosystem-version-lock.test.js
+++ b/scripts/ecosystem-version-lock.test.js
@@ -197,9 +197,16 @@ test('consumer discovery keeps peer and development declarations distinct', (t) 
   );
 });
 
-test('explicit policy contains 34 unique current managed dependency declarations', () => {
-  assert.equal(EXPECTED_BINDINGS.length, 34);
+test('explicit policy contains 33 unique current managed dependency declarations', () => {
+  assert.equal(EXPECTED_BINDINGS.length, 33);
   assert.equal(new Set(EXPECTED_BINDINGS.map(bindingKey)).size, EXPECTED_BINDINGS.length);
+  assert.equal(
+    EXPECTED_BINDINGS.some(
+      ({ repository, packageName }) =>
+        repository === 'kdna-cli' && packageName === '@aikdna/kdna-eval',
+    ),
+    false,
+  );
 });
 
 test('reconciliation fails closed when an expected repository, manifest, or dependency vanishes', () => {


### PR DESCRIPTION
## Summary
- remove the retired CLI-to-Eval dependency from the authoritative ecosystem lock
- lock the current 33 managed dependency declarations
- add a regression assertion that the retired binding cannot return
- advance the schema-2 source coordinates and both cross-repository workflows to the accepted 16-repository main baseline

## Verification
- full `npm test` (initial run exposed stale publish-workflow pins; corrected in the second commit)
- `npm run validate:ecosystem-manifest`
- `node --test tests/container-cli/ecosystem-manifest-validation.test.js`
- candidate-aware `npm run test:ecosystem-lock`
- `git diff --check`

Signed-off-by: aikdna <283974009+aikdna@users.noreply.github.com>