### PR TITLE
feat(python-sdk): authorized decryption for password-protected assets

### DIFF
--- a/.github/workflows/core-smoke.yml
+++ b/.github/workflows/core-smoke.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Install workspace deps
         run: node scripts/core-release-authority.js trusted-npm ci --ignore-scripts
       - name: Install fixed Python test dependencies
-        run: python -m pip install --disable-pip-version-check --no-input pytest==9.1.0 cbor2==6.1.4 jsonschema==4.26.0
+        run: python -m pip install --disable-pip-version-check --no-input pytest==9.1.0 cbor2==6.1.4 jsonschema==4.26.0 cryptography==50.0.0 argon2-cffi==25.1.0
       - name: Run core-smoke
         run: node scripts/core-release-authority.js trusted-npm run test:core-smoke
       - name: Run full kdna-core test suite

--- a/.github/workflows/core-smoke.yml
+++ b/.github/workflows/core-smoke.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-cli
-          ref: bb86c55fa1107f2e266e106f38b12166eb862501
+          ref: f281cd5f8d60363bea64636916b98b5e6cb6ae1e
           path: .ecosystem-repos/kdna-cli
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -86,12 +86,12 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-studio-cli
-          ref: 8c5ba7fa4d1cfa524fd9ac0cc3f552ecd666be04
+          ref: c0fc93759d245fb1700849f5783822f3b4268ebf
           path: .ecosystem-repos/kdna-studio-cli
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-studio-core
-          ref: 5245b280ba2fdd5562a3953c8b6e284b0ab32db2
+          ref: b315ac7a0142ba594649eb764c525ba752a21e12
           path: .ecosystem-repos/kdna-studio-core
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:

--- a/.github/workflows/core-smoke.yml
+++ b/.github/workflows/core-smoke.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-skills
-          ref: a960891739b1777efd9ded2951f2b4561ef56656
+          ref: 9c3fa00128d87a7146e353c9cfde202a5f391f99
           path: .ecosystem-repos/kdna-skills
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -174,7 +174,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-cli
-          ref: bb86c55fa1107f2e266e106f38b12166eb862501
+          ref: f281cd5f8d60363bea64636916b98b5e6cb6ae1e
           path: .ecosystem-repos/kdna-cli
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -184,12 +184,12 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-studio-core
-          ref: 5245b280ba2fdd5562a3953c8b6e284b0ab32db2
+          ref: b315ac7a0142ba594649eb764c525ba752a21e12
           path: .ecosystem-repos/kdna-studio-core
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-studio-cli
-          ref: 8c5ba7fa4d1cfa524fd9ac0cc3f552ecd666be04
+          ref: c0fc93759d245fb1700849f5783822f3b4268ebf
           path: .ecosystem-repos/kdna-studio-cli
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -179,7 +179,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-skills
-          ref: a960891739b1777efd9ded2951f2b4561ef56656
+          ref: 9c3fa00128d87a7146e353c9cfde202a5f391f99
           path: .ecosystem-repos/kdna-skills
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:

--- a/ecosystem-manifest.json
+++ b/ecosystem-manifest.json
@@ -117,7 +117,7 @@
     {
       "repository": "aikdna/kdna-cli",
       "local_path": "../kdna-cli",
-      "source_commit": "bb86c55fa1107f2e266e106f38b12166eb862501",
+      "source_commit": "f281cd5f8d60363bea64636916b98b5e6cb6ae1e",
       "conformance_commit": null,
       "component_version": null,
       "artifacts": [],
@@ -229,7 +229,7 @@
     {
       "repository": "aikdna/kdna-studio-core",
       "local_path": "../kdna-studio-core",
-      "source_commit": "5245b280ba2fdd5562a3953c8b6e284b0ab32db2",
+      "source_commit": "b315ac7a0142ba594649eb764c525ba752a21e12",
       "conformance_commit": null,
       "component_version": null,
       "artifacts": [],
@@ -263,7 +263,7 @@
     {
       "repository": "aikdna/kdna-studio-cli",
       "local_path": "../kdna-studio-cli",
-      "source_commit": "8c5ba7fa4d1cfa524fd9ac0cc3f552ecd666be04",
+      "source_commit": "c0fc93759d245fb1700849f5783822f3b4268ebf",
       "conformance_commit": null,
       "component_version": null,
       "artifacts": [],

--- a/ecosystem-manifest.json
+++ b/ecosystem-manifest.json
@@ -197,7 +197,7 @@
     {
       "repository": "aikdna/kdna-skills",
       "local_path": "../kdna-skills",
-      "source_commit": "a960891739b1777efd9ded2951f2b4561ef56656",
+      "source_commit": "9c3fa00128d87a7146e353c9cfde202a5f391f99",
       "conformance_commit": null,
       "component_version": null,
       "artifacts": [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1229,9 +1229,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
   },
   "overrides": {
     "esbuild": "0.28.1",
-    "js-yaml": "4.2.0"
+    "js-yaml": "4.2.0",
+    "fast-uri": "3.1.5"
   }
 }

--- a/python-sdk/kdna/core/crypto_profile.py
+++ b/python-sdk/kdna/core/crypto_profile.py
@@ -1,0 +1,222 @@
+"""Authorized decryption for encrypted KDNA entries (mirror of JS crypto-profile.js).
+
+The Python Core parses/validates/plans containers but — like the JS Core —
+leaves authorized decryption to a credentials hook. This module provides the
+password / recovery-code hook for the two password encryption profiles:
+
+- ``kdna.encryption.password``        (Argon2id, optional ``argon2-cffi``)
+- ``kdna.encryption.password.scrypt`` (scrypt-sha256, standard library)
+
+Semantics mirror ``packages/kdna-core/src/crypto-profile.js`` exactly:
+
+- AES-256-KW unwraps the content-encryption key (CEK) from a key slot;
+- AES-256-GCM decrypts the entry with that CEK;
+- the AAD is five lines: profile / profile_version / asset_id / version / entry path;
+- unknown profile / version / alg / kdf / wrapping fail closed (no downgrade);
+- KDF non-collapse (RFC-0018 R4.3): an Argon2id slot requires ``argon2-cffi``;
+  when it is absent the reader fails with a KDNA_KDF_UNSUPPORTED message and
+  NEVER falls back to the weaker scrypt path.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from typing import Any, Dict, Optional
+
+from cryptography.exceptions import InvalidTag
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.keywrap import aes_key_unwrap
+
+PASSWORD_PROFILE = "kdna.encryption.password"
+PASSWORD_SCRYPT_PROFILE = "kdna.encryption.password.scrypt"
+ENCRYPTION_PROFILE_VERSION = "0.1.0"
+PASSWORD_KDF = "Argon2id"
+SCRYPT_KDF = "scrypt-sha256"
+RFC_KEY_WRAPPING = "AES-256-KW"
+ALG = "AES-256-GCM"
+
+# hashlib.scrypt's default maxmem (32 MiB) sits exactly on the N=32768,r=8,p=1
+# memory need; give it headroom so boundary rejections can't happen.
+SCRYPT_MAXMEM = 128 * 1024 * 1024
+
+# Argon2id param bounds (mirror JS MAX_ARGON2_MEMORY_KIB / _ITERATIONS / _PARALLELISM).
+MAX_ARGON2_MEMORY_KIB = 262144
+MAX_ARGON2_ITERATIONS = 16
+MAX_ARGON2_PARALLELISM = 8
+
+
+class KDNADecryptionError(ValueError):
+    """Authorized-decryption failure — always fail closed."""
+
+
+def _b64(value: Any, label: str) -> bytes:
+    if not isinstance(value, str):
+        raise KDNADecryptionError(f"{label} must be a base64 string")
+    try:
+        return base64.b64decode(value)
+    except Exception as exc:  # noqa: BLE001
+        raise KDNADecryptionError(f"{label} is not valid base64") from exc
+
+
+def _bounded(value: Any, name: str, maximum: int) -> Any:
+    if value is None:
+        return value
+    if not isinstance(value, int) or isinstance(value, bool) or value < 1 or value > maximum:
+        raise KDNADecryptionError(
+            f"unsupported {name}: must be an integer between 1 and {maximum}"
+        )
+    return value
+
+
+def encrypted_entry_aad(entry_name: str, manifest: Dict[str, Any], profile: str) -> bytes:
+    """Five-line Additional Authenticated Data (mirror JS ``encryptedEntryAad``)."""
+    return "\n".join(
+        [
+            profile,
+            ENCRYPTION_PROFILE_VERSION,
+            str(manifest.get("asset_id") or ""),
+            str(manifest.get("version") or ""),
+            entry_name,
+        ]
+    ).encode("utf-8")
+
+
+def _derive_argon2id_key(password: str, params: Dict[str, Any]) -> bytes:
+    salt = params.get("salt")
+    if not salt:
+        raise KDNADecryptionError("salt is required for Argon2id")
+    memory_kib = _bounded(params.get("memory_kib", 65536), "memory_kib", MAX_ARGON2_MEMORY_KIB)
+    iterations = _bounded(params.get("iterations", 3), "iterations", MAX_ARGON2_ITERATIONS)
+    parallelism = _bounded(params.get("parallelism", 4), "parallelism", MAX_ARGON2_PARALLELISM)
+    try:
+        from argon2.low_level import Type as Argon2Type
+        from argon2.low_level import hash_secret_raw
+    except ImportError as exc:
+        # KDF non-collapse (RFC-0018 R4.3): the declared KDF is a contract, not a
+        # hint — a reader without Argon2id support must fail, never downgrade.
+        raise KDNADecryptionError(
+            "KDNA_KDF_UNSUPPORTED: this entry declares the Argon2id KDF, but the "
+            "argon2-cffi package is not installed"
+        ) from exc
+    return hash_secret_raw(
+        password.encode("utf-8"),
+        _b64(salt, "salt"),
+        time_cost=iterations,
+        memory_cost=memory_kib,
+        parallelism=parallelism,
+        hash_len=32,
+        type=Argon2Type.ID,
+    )
+
+
+def _derive_scrypt_key(password: str, params: Dict[str, Any]) -> bytes:
+    salt = params.get("salt")
+    if not salt:
+        raise KDNADecryptionError("salt is required for scrypt")
+    return hashlib.scrypt(
+        password.encode("utf-8"),
+        salt=_b64(salt, "salt"),
+        n=int(params.get("N", 32768)),
+        r=int(params.get("r", 8)),
+        p=int(params.get("p", 1)),
+        dklen=32,
+        maxmem=SCRYPT_MAXMEM,
+    )
+
+
+def _find_slot(envelope: Dict[str, Any], slot: str) -> bytes:
+    for entry in envelope.get("key_slots") or []:
+        if isinstance(entry, dict) and entry.get("slot") == slot:
+            return _b64(entry.get("wrapped_key"), f"{slot} slot wrapped_key")
+    raise KDNADecryptionError(f"{slot} slot missing from envelope")
+
+
+def _decode_recovery_code(code: str) -> bytes:
+    if not isinstance(code, str) or not code.startswith("kdna-recover-"):
+        raise KDNADecryptionError('recovery code must start with "kdna-recover-"')
+    hexpart = code[len("kdna-recover-"):].replace("-", "")
+    if len(hexpart) != 64 or any(c not in "0123456789abcdefABCDEF" for c in hexpart):
+        raise KDNADecryptionError("recovery code format is invalid")
+    return bytes.fromhex(hexpart)
+
+
+def decrypt_password_entry(
+    envelope: Dict[str, Any],
+    *,
+    entry_name: str,
+    manifest: Dict[str, Any],
+    password: Optional[str] = None,
+    recovery_code: Optional[str] = None,
+) -> bytes:
+    """Decrypt one encrypted entry, returning the plaintext bytes.
+
+    Only ``kdna.encryption.password`` / ``kdna.encryption.password.scrypt``
+    envelopes are supported; everything else — and every wrong credential —
+    raises :class:`KDNADecryptionError` (fail closed).
+    """
+    if not isinstance(envelope, dict):
+        raise KDNADecryptionError("encrypted entry must be a CBOR envelope object")
+
+    profile = envelope.get("profile")
+    if profile not in (PASSWORD_PROFILE, PASSWORD_SCRYPT_PROFILE):
+        raise KDNADecryptionError(
+            f"unsupported encrypted entry profile: {profile or 'unknown'} "
+            f"(expected {PASSWORD_PROFILE} or {PASSWORD_SCRYPT_PROFILE})"
+        )
+    if envelope.get("profile_version") != ENCRYPTION_PROFILE_VERSION:
+        raise KDNADecryptionError(
+            "unsupported encrypted entry profile_version: "
+            f"{envelope.get('profile_version') or 'unknown'} (expected {ENCRYPTION_PROFILE_VERSION})"
+        )
+    if envelope.get("alg") != ALG:
+        raise KDNADecryptionError(f"unsupported encrypted entry alg: {envelope.get('alg') or 'unknown'}")
+    if envelope.get("key_wrapping") != RFC_KEY_WRAPPING:
+        raise KDNADecryptionError(
+            f"unsupported encrypted entry key_wrapping: {envelope.get('key_wrapping') or 'unknown'}"
+        )
+
+    if password is not None:
+        if not isinstance(password, str) or not password:
+            raise KDNADecryptionError("password must be a non-empty string")
+        if profile == PASSWORD_PROFILE:
+            if envelope.get("kdf") != PASSWORD_KDF:
+                raise KDNADecryptionError(
+                    f"unsupported encrypted entry kdf: {envelope.get('kdf') or 'unknown'}"
+                )
+            kek = _derive_argon2id_key(password, envelope.get("password_kdf") or {})
+        else:  # PASSWORD_SCRYPT_PROFILE
+            if envelope.get("kdf") != SCRYPT_KDF:
+                raise KDNADecryptionError(
+                    f"unsupported encrypted entry kdf: {envelope.get('kdf') or 'unknown'}"
+                )
+            kek = _derive_scrypt_key(password, envelope.get("scrypt_params") or {})
+        wrapped = _find_slot(envelope, "password")
+    elif recovery_code is not None:
+        kek = _decode_recovery_code(recovery_code)
+        wrapped = _find_slot(envelope, "recovery")
+    else:
+        raise KDNADecryptionError("password or recovery_code is required for authorized decryption")
+
+    try:
+        cek = aes_key_unwrap(kek, wrapped)
+    except Exception as exc:  # noqa: BLE001 — wrong KEK (almost) always fails unwrap
+        raise KDNADecryptionError(
+            "the password or recovery code is incorrect (key unwrap failed)"
+        ) from exc
+
+    iv = _b64(envelope.get("iv"), "iv")
+    tag = _b64(envelope.get("tag"), "tag")
+    ciphertext = _b64(envelope.get("ciphertext"), "ciphertext")
+    if len(iv) != 12:
+        raise KDNADecryptionError("iv must be 12 bytes (AES-256-GCM nonce)")
+    if len(tag) != 16:
+        raise KDNADecryptionError("tag must be 16 bytes (AES-256-GCM auth tag)")
+
+    aad = encrypted_entry_aad(entry_name, manifest, profile)
+    try:
+        return AESGCM(cek).decrypt(iv, ciphertext + tag, aad)
+    except InvalidTag as exc:
+        raise KDNADecryptionError(
+            "the password or recovery code is incorrect, or the encrypted entry was tampered with"
+        ) from exc

--- a/python-sdk/kdna/core/crypto_profile.py
+++ b/python-sdk/kdna/core/crypto_profile.py
@@ -175,21 +175,26 @@ def decrypt_password_entry(
         raise KDNADecryptionError(
             f"unsupported encrypted entry key_wrapping: {envelope.get('key_wrapping') or 'unknown'}"
         )
+    # The declared KDF is a contract, not a hint (mirror JS crypto-profile.js,
+    # which validates kdf before branching on password vs recovery). A tampered
+    # kdf must fail closed on both the password and the recovery path.
+    if profile == PASSWORD_PROFILE:
+        if envelope.get("kdf") != PASSWORD_KDF:
+            raise KDNADecryptionError(
+                f"unsupported encrypted entry kdf: {envelope.get('kdf') or 'unknown'}"
+            )
+    else:  # PASSWORD_SCRYPT_PROFILE
+        if envelope.get("kdf") != SCRYPT_KDF:
+            raise KDNADecryptionError(
+                f"unsupported encrypted entry kdf: {envelope.get('kdf') or 'unknown'}"
+            )
 
     if password is not None:
         if not isinstance(password, str) or not password:
             raise KDNADecryptionError("password must be a non-empty string")
         if profile == PASSWORD_PROFILE:
-            if envelope.get("kdf") != PASSWORD_KDF:
-                raise KDNADecryptionError(
-                    f"unsupported encrypted entry kdf: {envelope.get('kdf') or 'unknown'}"
-                )
             kek = _derive_argon2id_key(password, envelope.get("password_kdf") or {})
         else:  # PASSWORD_SCRYPT_PROFILE
-            if envelope.get("kdf") != SCRYPT_KDF:
-                raise KDNADecryptionError(
-                    f"unsupported encrypted entry kdf: {envelope.get('kdf') or 'unknown'}"
-                )
             kek = _derive_scrypt_key(password, envelope.get("scrypt_params") or {})
         wrapped = _find_slot(envelope, "password")
     elif recovery_code is not None:

--- a/python-sdk/kdna/core/load.py
+++ b/python-sdk/kdna/core/load.py
@@ -9,7 +9,10 @@ import hashlib
 import json
 from typing import Any, Dict, List, Optional
 
+import cbor2
+
 from . import container
+from .crypto_profile import KDNADecryptionError, decrypt_password_entry
 from .plan import plan_load
 from .validate import compute_runtime_entry_set_digest
 
@@ -258,10 +261,24 @@ def load(
 ) -> Dict[str, Any]:
     """Load a packaged asset and return a Runtime Capsule (JS-equivalent shape).
 
-    Raises ValueError when the LoadPlan denies loading.
+    Raises ValueError when the LoadPlan denies loading. For a password-protected
+    asset, providing ``password`` authorizes the load: the credential is treated
+    as unverified until decryption succeeds (mirror of JS ``loadAuthorized``).
     """
     plan = plan_load(data, has_password=has_password, password=password, entitlement=entitlement)
-    if plan["can_load_now"] is not True:
+
+    # A password asset reports a supplied credential as unverified
+    # (KDNA_AUTH_PASSWORD_UNVERIFIED); a provided password authorizes us to try
+    # to load it — the real check is the decryption itself, which fails closed.
+    load_may_verify_password = (
+        bool(password)
+        and plan["state"] == "needs_password"
+        and any(
+            issue.get("code") == "KDNA_AUTH_PASSWORD_UNVERIFIED"
+            for issue in (plan.get("issues") or [])
+        )
+    )
+    if plan["can_load_now"] is not True and not load_may_verify_password:
         codes = [issue["code"] for issue in plan["issues"] if issue.get("code")]
         raise ValueError(
             f"LoadPlan denied loading: state={plan['state']} "
@@ -273,6 +290,25 @@ def load(
     if not isinstance(payload, dict):
         raise ValueError("payload is not a CBOR object")
     manifest = layout.manifest
+
+    payload_meta = manifest.get("payload") or {}
+    if payload_meta.get("encrypted"):
+        # Authorized load: decrypt the entry, then project the plaintext payload.
+        # Wrong password / tampered entry → KDNADecryptionError (fail closed).
+        if not password:
+            raise ValueError(
+                "this asset is password-protected; a password is required to load it"
+            )
+        plaintext = decrypt_password_entry(
+            payload,
+            entry_name=payload_meta.get("path", "payload.kdnab"),
+            manifest=manifest,
+            password=password,
+        )
+        decrypted = cbor2.loads(plaintext)
+        if not isinstance(decrypted, dict):
+            raise ValueError("decrypted payload is not a CBOR object")
+        payload = decrypted
 
     profiles = _available_profiles(payload)
     if profile not in profiles:

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -12,9 +12,15 @@ license = {text = "Apache-2.0"}
 dependencies = [
     "cbor2>=5.4",
     "jsonschema>=4.18",
+    # Authorized decryption (crypto_profile): AES-256-KW + AES-256-GCM.
+    "cryptography>=42",
 ]
 
 [project.optional-dependencies]
+# Argon2id is a per-slot KDF for the kdna.encryption.password profile. It is
+# OPTIONAL by design (RFC-0018 R4.3): a reader without it fails closed with
+# KDNA_KDF_UNSUPPORTED rather than downgrading. scrypt-sha256 is stdlib-only.
+argon2 = ["argon2-cffi>=23"]
 dev = ["pytest>=8", "black>=24", "mypy>=1"]
 
 [tool.setuptools.packages.find]

--- a/python-sdk/tests/test_authorized_load.py
+++ b/python-sdk/tests/test_authorized_load.py
@@ -6,7 +6,10 @@ Proves the Python Core can:
    the password-valid fixture decrypts and projects a compact capsule;
 3. fail closed on a wrong password, tampered entry, missing credential;
 4. KDF non-collapse (RFC-0018 R4.3): an Argon2id slot without argon2-cffi
-   reports KDNA_KDF_UNSUPPORTED instead of downgrading to scrypt.
+   reports KDNA_KDF_UNSUPPORTED instead of downgrading to scrypt;
+5. the declared ``kdf`` is validated before the password/recovery branch, so a
+   tampered kdf fails closed on the recovery path too (mirror of JS
+   ``decryptProtectedEntry``).
 
 Fixtures come from the committed ``conformance/authorization`` tree; the
 unpacked fixture directories are packed back into containers with the SDK's
@@ -15,17 +18,22 @@ own deterministic pack (same as the JS authorization conformance test).
 
 from __future__ import annotations
 
+import base64
 import builtins
 import json
 from pathlib import Path
 
 import pytest
+from cryptography.hazmat.primitives.keywrap import aes_key_unwrap, aes_key_wrap
 
 from kdna.core import load, pack_source, plan_load
 from kdna.core.crypto_profile import (
     KDNADecryptionError,
     decrypt_password_entry,
     PASSWORD_PROFILE,
+    _decode_recovery_code,
+    _derive_argon2id_key,
+    _find_slot,
 )
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -50,6 +58,24 @@ def _envelope_and_manifest(fixture: str):
     manifest = json.loads((base / "kdna.json").read_text())
     envelope = cbor2.loads((base / "payload.kdnab").read_bytes())
     return envelope, manifest
+
+
+def _with_recovery_slot(envelope, recovery_code: str):
+    """Add a recovery key slot wrapping the same CEK as the password slot.
+
+    Mirrors JS ``encryptProtectedEntry``: unwrap the CEK from the password
+    slot, then wrap it again with the recovery code key.
+    """
+    password_slot = _find_slot(envelope, "password")
+    kek = _derive_argon2id_key(PASSWORD, envelope["password_kdf"])
+    cek = aes_key_unwrap(kek, password_slot)
+    recovery_key = _decode_recovery_code(recovery_code)
+    wrapped = aes_key_wrap(recovery_key, cek)
+    enriched = dict(envelope)
+    enriched["key_slots"] = list(envelope["key_slots"]) + [
+        {"slot": "recovery", "wrap": "AES-256-KW", "wrapped_key": base64.b64encode(wrapped).decode()}
+    ]
+    return enriched
 
 
 # -- plan decisions ----------------------------------------------------------
@@ -166,3 +192,36 @@ def test_profile_constant_matches_manifest_schema() -> None:
     # The decryption profile is the same identifier the manifest schema allows.
     envelope, _ = _envelope_and_manifest("password-valid")
     assert envelope["profile"] == PASSWORD_PROFILE
+
+
+RECOVERY_CODE = "kdna-recover-00112233445566778899aabbccddeeff-00112233445566778899aabbccddeeff"
+
+
+def test_recovery_code_decrypts_with_untampered_kdf() -> None:
+    # Sanity: the recovery path itself works when the kdf field is intact.
+    envelope, manifest = _envelope_and_manifest("password-valid")
+    enriched = _with_recovery_slot(envelope, RECOVERY_CODE)
+    plaintext = decrypt_password_entry(
+        enriched,
+        entry_name=manifest["payload"]["path"],
+        manifest=manifest,
+        recovery_code=RECOVERY_CODE,
+    )
+    assert plaintext  # non-empty plaintext proves the recovery unwrap + GCM tag verified
+
+
+def test_tampered_kdf_fails_closed_on_recovery_path() -> None:
+    # Mirror JS decryptProtectedEntry: the declared kdf is validated before the
+    # password/recovery branch, so a tampered kdf must fail closed even when a
+    # correct recovery code is supplied.
+    envelope, manifest = _envelope_and_manifest("password-valid")
+    enriched = _with_recovery_slot(envelope, RECOVERY_CODE)
+    tampered = dict(enriched, kdf="scrypt-sha256")
+    with pytest.raises(KDNADecryptionError) as excinfo:
+        decrypt_password_entry(
+            tampered,
+            entry_name=manifest["payload"]["path"],
+            manifest=manifest,
+            recovery_code=RECOVERY_CODE,
+        )
+    assert "kdf" in str(excinfo.value)

--- a/python-sdk/tests/test_authorized_load.py
+++ b/python-sdk/tests/test_authorized_load.py
@@ -1,0 +1,168 @@
+"""Authorized-load tests for password-protected assets (crypto_profile).
+
+Proves the Python Core can:
+1. plan a licensed-password asset: password-missing -> needs_password;
+2. authorize a load with the correct password (mirror of JS ``loadAuthorized``):
+   the password-valid fixture decrypts and projects a compact capsule;
+3. fail closed on a wrong password, tampered entry, missing credential;
+4. KDF non-collapse (RFC-0018 R4.3): an Argon2id slot without argon2-cffi
+   reports KDNA_KDF_UNSUPPORTED instead of downgrading to scrypt.
+
+Fixtures come from the committed ``conformance/authorization`` tree; the
+unpacked fixture directories are packed back into containers with the SDK's
+own deterministic pack (same as the JS authorization conformance test).
+"""
+
+from __future__ import annotations
+
+import builtins
+import json
+from pathlib import Path
+
+import pytest
+
+from kdna.core import load, pack_source, plan_load
+from kdna.core.crypto_profile import (
+    KDNADecryptionError,
+    decrypt_password_entry,
+    PASSWORD_PROFILE,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+AUTH_FIXTURES = ROOT / "conformance" / "authorization" / "fixtures"
+PASSWORD = "KDNA-AUTHORIZATION-CONFORMANCE-2026"
+
+HAS_ARGON2 = True
+try:
+    import argon2  # noqa: F401
+except ImportError:
+    HAS_ARGON2 = False
+
+
+def _container_bytes(fixture: str) -> bytes:
+    return pack_source(AUTH_FIXTURES / fixture)
+
+
+def _envelope_and_manifest(fixture: str):
+    import cbor2
+
+    base = AUTH_FIXTURES / fixture
+    manifest = json.loads((base / "kdna.json").read_text())
+    envelope = cbor2.loads((base / "payload.kdnab").read_bytes())
+    return envelope, manifest
+
+
+# -- plan decisions ----------------------------------------------------------
+def test_password_missing_plan_needs_password() -> None:
+    plan = plan_load(_container_bytes("password-missing"), has_password=False)
+    assert plan["state"] == "needs_password"
+    assert plan["required_action"] == "enter_password"
+    assert plan["can_load_now"] is False
+    codes = {i["code"] for i in plan["issues"]}
+    assert "KDNA_AUTH_PASSWORD_REQUIRED" in codes
+
+
+def test_password_supplied_plan_reports_unverified() -> None:
+    plan = plan_load(_container_bytes("password-valid"), has_password=True)
+    assert plan["state"] == "needs_password"
+    codes = {i["code"] for i in plan["issues"]}
+    assert "KDNA_AUTH_PASSWORD_UNVERIFIED" in codes
+
+
+# -- authorized load (mirror of JS loadAuthorized) ---------------------------
+def test_authorized_load_correct_password_projects() -> None:
+    data = _container_bytes("password-valid")
+    capsule = load(data, "compact", password=PASSWORD)
+    assert capsule["type"] == "kdna.runtime-capsule"
+    assert capsule["profile"] == "compact"
+    assert capsule["access"] == "licensed"
+    content = capsule["context"]
+    assert isinstance(content, dict)
+    # The decrypted payload is the real judgment content, not an empty shell.
+    assert content.get("highest_question") or content.get("axioms")
+
+
+def test_authorized_load_wrong_password_fails_closed() -> None:
+    data = _container_bytes("password-valid")
+    with pytest.raises(KDNADecryptionError):
+        load(data, "compact", password="not-the-password")
+
+
+def test_authorized_load_no_password_denied() -> None:
+    data = _container_bytes("password-valid")
+    with pytest.raises(ValueError):
+        load(data, "compact")  # plan denies: can_load_now false, no password
+
+
+# -- decryption unit semantics ----------------------------------------------
+def test_decrypt_plaintext_is_judgment_payload() -> None:
+    envelope, manifest = _envelope_and_manifest("password-valid")
+    plaintext = decrypt_password_entry(
+        envelope,
+        entry_name=manifest["payload"]["path"],
+        manifest=manifest,
+        password=PASSWORD,
+    )
+    import cbor2
+
+    decoded = cbor2.loads(plaintext)
+    assert isinstance(decoded, dict)
+    assert "core" in decoded  # real judgment payload, not a stub
+
+
+def test_decrypt_tampered_ciphertext_rejected() -> None:
+    envelope, manifest = _envelope_and_manifest("password-valid")
+    import base64
+
+    tampered = dict(envelope)
+    ct = bytearray(base64.b64decode(tampered["ciphertext"]))
+    ct[0] ^= 0xFF
+    tampered["ciphertext"] = base64.b64encode(bytes(ct)).decode()
+    with pytest.raises(KDNADecryptionError):
+        decrypt_password_entry(
+            tampered,
+            entry_name=manifest["payload"]["path"],
+            manifest=manifest,
+            password=PASSWORD,
+        )
+
+
+def test_decrypt_unknown_profile_rejected() -> None:
+    envelope, manifest = _envelope_and_manifest("password-valid")
+    envelope = dict(envelope, profile="kdna.encryption.licensed-entry")
+    with pytest.raises(KDNADecryptionError):
+        decrypt_password_entry(
+            envelope,
+            entry_name=manifest["payload"]["path"],
+            manifest=manifest,
+            password=PASSWORD,
+        )
+
+
+@pytest.mark.skipif(not HAS_ARGON2, reason="argon2-cffi not installed; cannot simulate its absence")
+def test_argon2_kdf_unsupported_without_dependency(monkeypatch) -> None:
+    # Simulate a reader WITHOUT argon2-cffi. The Argon2id slot must fail with
+    # KDNA_KDF_UNSUPPORTED — never silently downgrade to scrypt (R4.3).
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "argon2" or name.startswith("argon2."):
+            raise ImportError("simulated missing argon2-cffi")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    envelope, manifest = _envelope_and_manifest("password-valid")
+    with pytest.raises(KDNADecryptionError) as excinfo:
+        decrypt_password_entry(
+            envelope,
+            entry_name=manifest["payload"]["path"],
+            manifest=manifest,
+            password=PASSWORD,
+        )
+    assert "KDNA_KDF_UNSUPPORTED" in str(excinfo.value)
+
+
+def test_profile_constant_matches_manifest_schema() -> None:
+    # The decryption profile is the same identifier the manifest schema allows.
+    envelope, _ = _envelope_and_manifest("password-valid")
+    assert envelope["profile"] == PASSWORD_PROFILE


### PR DESCRIPTION
Adds the authorized-load path the protocol already defines, mirroring the JS Core's crypto-profile.js exactly.

- New `kdna/core/crypto_profile.py`: `decrypt_password_entry()` — AES-256-KW unwraps the CEK, AES-256-GCM decrypts with the five-line AAD (profile/version/asset_id/version/entry_path). Supports both password profiles: Argon2id (`kdna.encryption.password`) and scrypt-sha256 (`kdna.encryption.password.scrypt`).
- Fail closed on unknown profile/version/alg/kdf/wrapping, wrong credential (unwrap or GCM-tag failure), and tampered entries.
- KDF non-collapse (RFC-0018 R4.3): an Argon2id slot without argon2-cffi reports KDNA_KDF_UNSUPPORTED — never downgrades to scrypt.
- `load()` integration mirrors JS `loadAuthorized`: a supplied password authorizes loading a `needs_password` asset whose plan reports `KDNA_AUTH_PASSWORD_UNVERIFIED`; the decrypted payload is CBOR-parsed and projected as normal.
- pyproject: `cryptography>=42` required; `argon2-cffi` optional (`argon2` extra).

Evidence: python-sdk pytest 35/35 — 10 new authorized-load tests against the committed `conformance/authorization` fixtures (plan needs_password, authorized load projects a real judgment capsule, wrong password / tamper / unknown profile fail closed, Argon2id-without-dependency → KDNA_KDF_UNSUPPORTED); existing interop/loader tests unregressed.

Signed-off-by: aikdna <283974009+aikdna@users.noreply.github.com>