### PR TITLE
fix: re-anchor ecosystem manifest and smoke pins to web-server 0.3.1

### DIFF
--- a/.github/workflows/core-smoke.yml
+++ b/.github/workflows/core-smoke.yml
@@ -101,7 +101,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-web-server
-          ref: 5148ef337d0a3206b9b0e75f066cbfaca972c99f
+          ref: a4dce0b636193d604e39b383cdcf8f5a897b3872
           path: .ecosystem-repos/kdna-web-server
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -227,7 +227,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-web-server
-          ref: 5148ef337d0a3206b9b0e75f066cbfaca972c99f
+          ref: a4dce0b636193d604e39b383cdcf8f5a897b3872
           path: .ecosystem-repos/kdna-web-server
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:

--- a/ecosystem-manifest.json
+++ b/ecosystem-manifest.json
@@ -359,7 +359,7 @@
     {
       "repository": "aikdna/kdna-web-server",
       "local_path": "../kdna-web-server",
-      "source_commit": "5148ef337d0a3206b9b0e75f066cbfaca972c99f",
+      "source_commit": "a4dce0b636193d604e39b383cdcf8f5a897b3872",
       "conformance_commit": null,
       "component_version": null,
       "artifacts": [],
@@ -368,7 +368,7 @@
           "package_json": "package.json",
           "package_name": "@aikdna/kdna-web-server",
           "npm_package": "@aikdna/kdna-web-server",
-          "version": "0.3.0",
+          "version": "0.3.1",
           "lifecycle": "Experimental",
           "release_status": "active",
           "dependency_policy": "current",

--- a/release-health-policy.json
+++ b/release-health-policy.json
@@ -67,7 +67,7 @@
       "repository": "aikdna/kdna-web-server",
       "package_json": "package.json",
       "npm_package": "@aikdna/kdna-web-server",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "canonical_tag": {
         "type": "natural"
       }


### PR DESCRIPTION
@aikdna/kdna-web-server 0.3.1 is published (registry latest). Update the ecosystem-manifest web-server record (version 0.3.0 -> 0.3.1, source_commit -> the 0.3.1 release commit a4dce0b) and the core-smoke/publish checkout pins to match. Resolves the docs-ci manifest-vs-registry drift for web-server. validate:ecosystem-manifest + docs-ci pass.