### PR TITLE
feat: extend check-publish-drift into a pre-publish narrative gate

### DIFF
--- a/.github/workflows/core-smoke.yml
+++ b/.github/workflows/core-smoke.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-cli
-          ref: f281cd5f8d60363bea64636916b98b5e6cb6ae1e
+          ref: 6841900df1df876f2b6e300b1416b4a9186c0aba
           path: .ecosystem-repos/kdna-cli
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -174,7 +174,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-cli
-          ref: f281cd5f8d60363bea64636916b98b5e6cb6ae1e
+          ref: 6841900df1df876f2b6e300b1416b4a9186c0aba
           path: .ecosystem-repos/kdna-cli
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:

--- a/ecosystem-manifest.json
+++ b/ecosystem-manifest.json
@@ -126,14 +126,14 @@
           "package_json": "package.json",
           "package_name": "@aikdna/kdna-cli",
           "npm_package": "@aikdna/kdna-cli",
-          "version": "0.36.0",
+          "version": "0.36.1",
           "lifecycle": "Pre-release",
           "release_status": "active",
           "dependency_policy": "current",
           "known_limitations": [],
           "recommended_entrypoint": "npm install -g @aikdna/kdna-cli",
           "legacy_replacement": null,
-          "published_version": "0.36.0"
+          "published_version": "0.36.1"
         }
       ],
       "lifecycle": "Pre-release",

--- a/ecosystem-manifest.json
+++ b/ecosystem-manifest.json
@@ -117,7 +117,7 @@
     {
       "repository": "aikdna/kdna-cli",
       "local_path": "../kdna-cli",
-      "source_commit": "f281cd5f8d60363bea64636916b98b5e6cb6ae1e",
+      "source_commit": "6841900df1df876f2b6e300b1416b4a9186c0aba",
       "conformance_commit": null,
       "component_version": null,
       "artifacts": [],

--- a/release-health-policy.json
+++ b/release-health-policy.json
@@ -6,7 +6,7 @@
       "repository": "aikdna/kdna-cli",
       "package_json": "package.json",
       "npm_package": "@aikdna/kdna-cli",
-      "version": "0.36.0",
+      "version": "0.36.1",
       "canonical_tag": {
         "type": "natural"
       }

--- a/scripts/check-publish-drift.js
+++ b/scripts/check-publish-drift.js
@@ -83,6 +83,27 @@ for (const { repo, pkg, expectedVersion } of PACKAGES) {
         : 'repository package version must equal the manifest version',
     );
   }
+
+  // Pre-publish narrative gate: the in-package README and its Chinese mirror
+  // must not advertise a different "latest" version than the one being
+  // published. A stale "latest is X" claim misleads installers.
+  if (!CANDIDATE_BRANCH_REPOS.has(repo)) {
+    for (const readmeName of ['README.md', 'README.zh.md']) {
+      const readmePath = path.join(repoPath, readmeName);
+      if (!fs.existsSync(readmePath)) continue;
+      const readmeText = fs.readFileSync(readmePath, 'utf8');
+      const latestClaim = readmeText.match(
+        /(?:registry\s+`?latest`?\s*(?:release)?\s*(?:is|为|是)?\s*`?|latest`?\s*(?:is|为|是)\s*`?)(\d+\.\d+\.\d+)/i,
+      );
+      if (latestClaim) {
+        check(
+          `${pkg} ${readmeName} latest-claim=${latestClaim[1]} manifest=${expectedVersion}`,
+          latestClaim[1] === expectedVersion,
+          `${readmeName} latest-version claim must equal the manifest version`,
+        );
+      }
+    }
+  }
 }
 
 console.log(


### PR DESCRIPTION
Extend check-publish-drift.js to also verify that each in-scope package's README and Chinese mirror (README.zh.md) latest-version claim equals the manifest version, so a stale 'latest is X' claim is caught before publish. Also sync the ecosystem-manifest kdna-cli record to the published 0.36.1. The remaining web-server 0.3.0->0.3.1 drift is the consumer-chain upgrade scheduled for the 0.22.0 release wave.