### PR TITLE
fix: advance web-server manifest and smoke pins to the published 0.3.1

### DIFF
--- a/.github/workflows/core-smoke.yml
+++ b/.github/workflows/core-smoke.yml
@@ -101,7 +101,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-web-server
-          ref: 5148ef337d0a3206b9b0e75f066cbfaca972c99f
+          ref: a4dce0b636193d604e39b383cdcf8f5a897b3872
           path: .ecosystem-repos/kdna-web-server
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -227,7 +227,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-web-server
-          ref: 5148ef337d0a3206b9b0e75f066cbfaca972c99f
+          ref: a4dce0b636193d604e39b383cdcf8f5a897b3872
           path: .ecosystem-repos/kdna-web-server
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:

--- a/ecosystem-manifest.json
+++ b/ecosystem-manifest.json
@@ -359,7 +359,7 @@
     {
       "repository": "aikdna/kdna-web-server",
       "local_path": "../kdna-web-server",
-      "source_commit": "5148ef337d0a3206b9b0e75f066cbfaca972c99f",
+      "source_commit": "a4dce0b636193d604e39b383cdcf8f5a897b3872",
       "conformance_commit": null,
       "component_version": null,
       "artifacts": [],
@@ -368,7 +368,7 @@
           "package_json": "package.json",
           "package_name": "@aikdna/kdna-web-server",
           "npm_package": "@aikdna/kdna-web-server",
-          "version": "0.3.0",
+          "version": "0.3.1",
           "lifecycle": "Experimental",
           "release_status": "active",
           "dependency_policy": "current",

--- a/release-health-policy.json
+++ b/release-health-policy.json
@@ -67,7 +67,7 @@
       "repository": "aikdna/kdna-web-server",
       "package_json": "package.json",
       "npm_package": "@aikdna/kdna-web-server",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "canonical_tag": {
         "type": "natural"
       }

--- a/scripts/ecosystem-version-lock.js
+++ b/scripts/ecosystem-version-lock.js
@@ -322,6 +322,7 @@ const LAGGING_CONSUMERS = new Set([
   'kdna-react',
   'create-kdna-web-app',
   'kdna-demo-web-viewer',
+  'kdna-web-client',
 ]);
 // The monorepo compatibility package pins the released pairing
 // (packages/kdna); it is a publish snapshot, not a current consumer.


### PR DESCRIPTION
Closes the A2 drift that was never truly fixed after #255 was closed: @aikdna/kdna-web-server@0.3.1 is published on npm and its README was already re-anchored to it (kdna-web-server commit `a4dce0b`), but `ecosystem-manifest.json` still recorded 0.3.0 with the old `source_commit` `5148ef3`, and `publish.yml` + `core-smoke.yml` still pinned `5148ef3`.

- `ecosystem-manifest.json`: web-server version 0.3.0 → 0.3.1, `source_commit` `5148ef3` → `a4dce0b636193d604e39b383cdcf8f5a897b3872`.
- `publish.yml` + `core-smoke.yml`: web-server `ref` → `a4dce0b636193d604e39b383cdcf8f5a897b3872`.

Verified: `npm run validate:ecosystem-manifest` passes (21 components), kdna publish-hardening tests 111/111 green. This is the root cause of the `docs-check` red on #254; once merged, #254 checks will be re-run to confirm it turns green.