### PR TITLE
docs: reference SPEC-INDEX from README and add the Implementer Kit

### DIFF
--- a/IMPLEMENTER-KIT.md
+++ b/IMPLEMENTER-KIT.md
@@ -1,0 +1,36 @@
+# KDNA Implementer Kit
+
+A one-page starting point for implementing a KDNA runtime, verifier, or
+consumer. Everything here is reachable in one hop from this file.
+
+## 1. Read the contract
+
+- [SPEC-INDEX.md](./SPEC-INDEX.md) — every normative specification (asset
+  format, runtime loading contract, envelope profile, authorization, fidelity).
+- [RFC index](./rfcs/README.md) — accepted and proposed protocol changes,
+  feature lifecycle, and deprecation policy.
+
+## 2. Validate your implementation
+
+- **Conformance runner**: `@aikdna/kdna-conformance` runs a fixed battery
+  against any KDNA core implementation via `runConformance({ core })`. It
+  checks validate, planLoad, load capsule, and fail-closed behavior on a
+  corrupted container. Install with `npm i @aikdna/kdna-conformance`.
+- **Interactive inspector**: <https://aikdna.github.io/kdna/inspector/> — drag
+  a `.kdna` file to inspect its container, manifest, and load profiles
+  entirely in the browser. Nothing is uploaded.
+
+## 3. Reference fixtures
+
+- `fixtures/` — conformance test fixtures used by the toolchain.
+- `conformance/canonical-conformance.mjs` — the stable container conformance
+  surface (`npm run conformance:canonical`).
+
+## 4. Environment
+
+- A `.kdna` asset is a ZIP container with a stored (uncompressed) `mimetype`,
+  `kdna.json` manifest, and `payload.kdnab` (CBOR), plus `checksums.json`.
+- Container structure proves integrity, not judgment quality. Verifiers must
+  fail closed on any structural or schema deviation.
+- Protocol changes require an RFC and a 12-month deprecation window before
+  removal (see the RFC index).

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Protected, licensed, remote, and native-app loading behavior is specified here:
 - [Runtime projection](./specs/kdna-runtime-projection.md)
 - [Import security](./specs/kdna-import-security.md)
 - [Apple native runtime integration](./docs/apple-native-runtime-integration.md)
+- [SPEC-INDEX: every normative specification](./SPEC-INDEX.md)
 
 Ordinary Core loading remains fail-closed for `access: "remote"`. Self-hosted
 Runtime deployers that control the packaged server-side asset use the explicit


### PR DESCRIPTION
Wave B acceptance + D1.

**B2 acceptance**: `SPEC-INDEX.md` is now referenced from the kdna `README.md` (one hop) so every normative specification is reachable from the entry point.

**B3 acceptance (verified)**: the live inspector at https://aikdna.github.io/kdna/inspector/ was exercised with a real `.kdna` fixture (valid-asset.kdna, kdna:aikdna:laozi-wuwei 0.1.1) — container, manifest, and load profiles parsed correctly in the browser.

**D1**: `IMPLEMENTER-KIT.md` one-page starting point for implementers — contract entry points (SPEC-INDEX, RFC index), the `@aikdna/kdna-conformance` runner, the live inspector, fixtures, and fail-closed principles.