### PR TITLE
feat: add @aikdna/kdna-conformance publish infrastructure

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -148,6 +148,61 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+  publish-conformance:
+    if: >-
+      github.repository == 'aikdna/kdna' &&
+      github.event_name == 'release' &&
+      github.event.action == 'published' &&
+      github.event.release.draft == false &&
+      github.event.release.prerelease == false &&
+      startsWith(github.event.release.tag_name, 'conformance/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      RELEASE_EVENT_ACTION: ${{ github.event.action }}
+      RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+      RELEASE_IS_DRAFT: ${{ github.event.release.draft }}
+      RELEASE_IS_PRERELEASE: ${{ github.event.release.prerelease }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          ref: ${{ github.event.release.tag_name }}
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - name: Verify exact conformance tag and source commit
+        run: npm --workspace @aikdna/kdna-conformance run release:check
+      - run: npm --workspace @aikdna/kdna-conformance test
+      - run: npm --workspace @aikdna/kdna-conformance run conformance
+      - name: Build and retain the exact Conformance package artifact
+        run: npm run release:evidence -- --package=conformance
+      - name: Verify conformance release evidence
+        run: npm --workspace @aikdna/kdna-conformance run release:evidence:check
+      - name: Select the verified Conformance artifact
+        run: |
+          ARTIFACT_PATH=$(node -p "require('./release-evidence/artifact-manifest.json').artifacts[0].artifact_path")
+          echo "CONFORMANCE_RELEASE_ARTIFACT=$ARTIFACT_PATH" >> "$GITHUB_ENV"
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: kdna-conformance-release-evidence
+          path: release-evidence/
+      - name: Publish @aikdna/kdna-conformance
+        run: |
+          VERSION=$(node -p "require('./packages/kdna-conformance/package.json').version")
+          if npm view "@aikdna/kdna-conformance@$VERSION" version >/dev/null 2>&1; then
+            echo "@aikdna/kdna-conformance@$VERSION is already published; skipping."
+            exit 0
+          fi
+          npm publish "./$CONFORMANCE_RELEASE_ARTIFACT" --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   publish-compat:
     if: >-
       github.repository == 'aikdna/kdna' &&

--- a/ecosystem-manifest.json
+++ b/ecosystem-manifest.json
@@ -47,6 +47,20 @@
           "legacy_replacement": null
         },
         {
+          "package_json": "packages/kdna-conformance/package.json",
+          "package_name": "@aikdna/kdna-conformance",
+          "npm_package": "@aikdna/kdna-conformance",
+          "version": "0.1.0",
+          "lifecycle": "Experimental",
+          "release_status": "active",
+          "dependency_policy": "current",
+          "known_limitations": [
+            "conformance verdicts are mechanism checks against the pinned reference implementation, not ecosystem authority"
+          ],
+          "recommended_entrypoint": "npm install @aikdna/kdna-conformance",
+          "legacy_replacement": null
+        },
+        {
           "package_json": "packages/kdna/package.json",
           "package_name": "@aikdna/kdna",
           "npm_package": "@aikdna/kdna",

--- a/packages/kdna-conformance/package.json
+++ b/packages/kdna-conformance/package.json
@@ -16,7 +16,9 @@
   ],
   "scripts": {
     "test": "node --test test/",
-    "conformance": "node bin/kdna-conformance.js"
+    "conformance": "node bin/kdna-conformance.js",
+    "release:check": "node ../../scripts/check-post-cutover-naming.mjs && node ../../scripts/check-scoped-release-readiness.mjs --package=packages/kdna-conformance --scope=conformance --label=conformance",
+    "release:evidence:check": "node ../../scripts/check-scoped-release-readiness.mjs --package=packages/kdna-conformance --scope=conformance --label=conformance --evidence=release-evidence/artifact-manifest.json"
   },
   "dependencies": {
     "@aikdna/kdna-core": "0.21.0",

--- a/release-health-policy.json
+++ b/release-health-policy.json
@@ -73,6 +73,17 @@
       }
     },
     {
+      "label": "KDNA Conformance",
+      "repository": "aikdna/kdna",
+      "package_json": "packages/kdna-conformance/package.json",
+      "npm_package": "@aikdna/kdna-conformance",
+      "version": "0.1.0",
+      "canonical_tag": {
+        "type": "prefix",
+        "value": "conformance/"
+      }
+    },
+    {
       "label": "KDNA Web Client",
       "repository": "aikdna/kdna-web-client",
       "package_json": "package.json",

--- a/scripts/generate-release-evidence.js
+++ b/scripts/generate-release-evidence.js
@@ -25,6 +25,10 @@ const knownPackages = {
     label: 'eval',
     path: path.join(repoRoot, 'packages', 'kdna-eval'),
   },
+  conformance: {
+    label: 'conformance',
+    path: path.join(repoRoot, 'packages', 'kdna-conformance'),
+  },
 };
 
 function validateKnownPackages(

--- a/scripts/test-publish-health.mjs
+++ b/scripts/test-publish-health.mjs
@@ -26,7 +26,7 @@ const ecosystemManifest = JSON.parse(
 
 test('release-health policy is complete, unique, and structurally valid', () => {
   assert.equal(validatePolicy(policy), policy);
-  assert.equal(policy.packages.length, 13);
+  assert.equal(policy.packages.length, 14);
   assert.deepEqual(
     new Set(policy.packages.map((entry) => entry.npm_package)),
     new Set([
@@ -42,6 +42,7 @@ test('release-health policy is complete, unique, and structurally valid', () => 
       'create-kdna-web-app',
       '@aikdna/kdna-core',
       '@aikdna/kdna-eval',
+      '@aikdna/kdna-conformance',
       '@aikdna/kdna',
     ]),
   );

--- a/tests/container-cli/ecosystem-manifest-validation.test.js
+++ b/tests/container-cli/ecosystem-manifest-validation.test.js
@@ -207,6 +207,7 @@ test('canonical schema-2 manifest inventories every public repository, co-locate
     new Set([
       '@aikdna/kdna-core',
       '@aikdna/kdna-eval',
+      '@aikdna/kdna-conformance',
       '@aikdna/kdna',
       '@aikdna/agent',
       '@aikdna/kdna-artifact-engine',


### PR DESCRIPTION
B1 completion — makes the recorded 'publish now' decision executable.

- **ecosystem-manifest.json**: add the `@aikdna/kdna-conformance` package record (active, 0.1.0) to the `aikdna/kdna` component.
- **release-health-policy.json**: add KDNA Conformance with a `conformance/` prefix canonical tag; policy projection test updated 13 → 14.
- **scripts/generate-release-evidence.js**: register the conformance known-package label so `release:evidence --package=conformance` works.
- **ecosystem-manifest-validation.test.js**: include `@aikdna/kdna-conformance` in the `aikdna/kdna` package inventory.
- **packages/kdna-conformance**: add `release:check` and `release:evidence:check` gates (scoped-release-readiness, scope/label `conformance`).
- **publish.yml**: add `publish-conformance` job (trigger `conformance/` tag; version guard + gates + provenance publish), modeled on `publish-eval`.

Verified: `validate:ecosystem-manifest`, `test:release-health`, `test:ecosystem-lock`, and full `npm test` (196/196) all green.

After merge: `gh release create conformance/0.1.0` triggers the publish; verify with `npm view @aikdna/kdna-conformance`.