### PR TITLE
test: add a real kdna-conformance suite and fix the test script

### DIFF
--- a/packages/kdna-conformance/package.json
+++ b/packages/kdna-conformance/package.json
@@ -15,7 +15,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "test": "node --test test/",
+    "test": "node --test test/conformance.test.js",
     "conformance": "node bin/kdna-conformance.js",
     "release:check": "node ../../scripts/check-post-cutover-naming.mjs && node ../../scripts/check-scoped-release-readiness.mjs --package=packages/kdna-conformance --scope=conformance --label=conformance",
     "release:evidence:check": "node ../../scripts/check-scoped-release-readiness.mjs --package=packages/kdna-conformance --scope=conformance --label=conformance --evidence=release-evidence/artifact-manifest.json"

--- a/packages/kdna-conformance/test/conformance.test.js
+++ b/packages/kdna-conformance/test/conformance.test.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { test } = require('node:test');
+
+const { runConformance } = require('../index.js');
+const core = require('@aikdna/kdna-core');
+
+test('conformance suite passes all four checks against the reference core', () => {
+  const report = runConformance({ core });
+  assert.deepEqual(
+    report.results.map((entry) => [entry.name, entry.ok]),
+    [
+      ['container: valid asset passes validation', true],
+      ['loadplan: valid asset can load now', true],
+      ['runtime: load emits a runtime capsule', true],
+      ['hostile: corrupted container fails closed', true],
+    ],
+  );
+  assert.equal(report.failed, 0);
+});
+
+test('runConformance rejects a missing core implementation', () => {
+  assert.throws(() => runConformance({}), /requires a KDNA Core implementation/u);
+});


### PR DESCRIPTION
The `conformance/0.1.0` publish failed at the test gate: `@aikdna/kdna-conformance` had an empty `test/` dir, so `node --test test/` failed ('Cannot find module'). This was never caught because the main `npm test` doesn't run this workspace's test script.

- Adds `test/conformance.test.js`: runs `runConformance` against the reference core and asserts all four checks pass; asserts `runConformance` rejects a missing core.
- Pins the test script to `node --test test/conformance.test.js` (works across node 22/26).

Verified: workspace test 2/2, full `npm test` 196/196.