### PR TITLE
docs: add the real-human acceptance preparation kit (C3)

### DIFF
--- a/docs/real-human-acceptance/README.md
+++ b/docs/real-human-acceptance/README.md
@@ -1,0 +1,51 @@
+# Real-Human Acceptance — Boundary Declaration
+
+This directory holds the **prepared materials** for the real-human acceptance
+suite. It contains methodology only: scripts, operation sheets, and verdict
+templates. It contains **no** acceptance results and **no** SIMULATION output.
+
+## Real-human vs SIMULATION isolation
+
+- **Real-human material** = assets and observations produced by a human (the
+  Owner) exercising the product with their own judgment. This is the only
+  material that may count toward real-human acceptance.
+- **SIMULATION material** = assets and observations produced by an agent
+  rehearsing the same steps in isolation. SIMULATION is a mechanism test only.
+  It never counts toward real-human acceptance.
+
+The two are **strictly isolated**:
+
+1. SIMULATION-produced assets never enter this suite and never enter any
+   public asset repository.
+2. Real-human assets produced from these scripts are marked `real-human` and
+   kept separate from any SIMULATION run directory.
+3. A drill or rehearsal that uses generated/judgment-free content is
+   SIMULATION, regardless of who runs it.
+
+## What may and may not be recorded here
+
+May be added after an acceptance run:
+
+- The completed verdict table (dated), with the observed `Actual` column.
+- The real-human asset's coordinates (without credentials or private paths).
+
+Must never be added:
+
+- Agent-authored or generated judgment passed off as real-human.
+- Credential values, key prefixes, or provider error bodies.
+- Local machine paths as release evidence.
+- Internal repo/PR identifiers.
+
+## The five gates
+
+The create script's "five gates" are the validation layers a produced asset
+must pass: container structure, manifest schema, payload schema,
+checksum/digest, and load contract. Passing the gates proves the asset is a
+well-formed KDNA; it does **not** prove the judgment is correct or safe.
+
+## Source of truth
+
+The 0/8 real-human acceptance state is tracked in the workspace acceptance
+ledger, not in this directory. This directory is the public-safe preparation
+surface only. Any claim of real-human acceptance must cite the dated completed
+verdict table, not these templates.

--- a/docs/real-human-acceptance/acceptance-verdict.md
+++ b/docs/real-human-acceptance/acceptance-verdict.md
@@ -1,0 +1,42 @@
+# Real-Human Acceptance — Verdict Table (Item 1)
+
+Purpose: the verdict table for the first real-human acceptance item. The Owner
+walks each row and marks `expected vs actual` in under 30 minutes. A row passes
+only when the observed behavior matches the expected screen.
+
+This table is a **template**; acceptance is not executed from this file. Real
+acceptance runs record their own dated copy.
+
+## How to fill
+
+- **Step**: the step id from the create/consume scripts.
+- **Expected**: the exact screen/behavior the step must show.
+- **Actual**: what the Owner actually observed.
+- **Pass?**: `Y` only if they match. Any mismatch is a fail for that row.
+
+## Item 1 — create a real asset and see the judgment in a real task
+
+| # | Step | Expected | Actual | Pass? |
+|---|------|----------|--------|-------|
+| 1 | Create: answer the 6 questions | Each answer is your real judgment, not a generic assistant answer | | |
+| 2 | Create: fill the draft template | Template contains your highest question, a rule, boundaries, a failure risk | | |
+| 3 | Create: build the source dir | Manifest + payload produced in the source directory, no schema errors | | |
+| 4 | Create: `kdna validate` | Gate 1–4 pass, `overall_valid: true` | | |
+| 5 | Create: `kdna pack` | A `.kdna` container is produced | | |
+| 6 | Consume: `kdna inspect` | Domain/title/version/profiles listed | | |
+| 7 | Consume: `kdna load` | A load plan is shown and approved before load | | |
+| 8 | Consume: judgment in the real task | Output reflects your rule, boundaries, and failure risk | | |
+| 9 | Consume: fail-closed (corrupted copy) | Load rejected with a stable error code | | |
+| 10 | Boundary: material is real-human | The asset is marked real-human, not SIMULATION | | |
+
+## Verdict
+
+- All rows `Y`: **item 1 PASS** — the real-human path works end to end.
+- Any row `N`: **item 1 FAIL** — record which row and the actual behavior;
+  the acceptance is not advanced until the mismatch is resolved.
+- Any row left blank: **item 1 NOT_RUN** — do not count it as pass or fail.
+
+## Timing
+
+Each row is designed to be checked in under 3 minutes; the whole table in under
+30 minutes including the real-task step.

--- a/docs/real-human-acceptance/consume-script.md
+++ b/docs/real-human-acceptance/consume-script.md
@@ -1,0 +1,67 @@
+# Real-Human Acceptance — Consumption Script
+
+Purpose: the real-human consumption path — from getting a `.kdna` asset to
+seeing the judgment take effect in a real task. Each step lists the expected
+screens so the Owner can check "yes, that is what I saw".
+
+This is the **consume** side of the real-human acceptance suite. It consumes
+the asset produced by the create script (or any real-human asset). Read the
+boundary declaration in `README.md` before use.
+
+## 0. Setup
+
+- The KDNA CLI is installed and on `PATH`.
+- You have a real task you are about to do, in which the asset's judgment
+  applies.
+- You have the `.kdna` asset path ready.
+
+## 1. Get the asset
+
+Place the `.kdna` file where your consumer can reach it, or attach it to your
+workspace.
+
+- **Expected screens:** the file is visible in your file manager / workspace
+  file list as a normal file. No server upload happens.
+
+## 2. Inspect before loading
+
+```sh
+kdna inspect your-asset.kdna
+```
+
+- **Expected screens:** domain, title, version, and load profiles are listed.
+  If it shows an error instead, stop — the asset is malformed (fail-closed).
+
+## 3. Authorize the load
+
+Ask the consumer to plan the load and then approve it.
+
+```sh
+kdna plan-load your-asset.kdna
+kdna load your-asset.kdna
+```
+
+- **Expected screens:** `plan-load` returns a load plan (asset identity,
+  profile, budget) that Core authorizes; `load` loads only when Core authorizes
+  it. The plan names the exact asset; nothing is loaded before approval.
+
+## 4. See the judgment take effect in a real task
+
+Now open the real task and ask your assistant / the consumer to apply the
+asset's judgment frame. Describe the situation from your step-1 answer.
+
+- **Expected screens:** the assistant's output reflects your rule — it uses
+  your highest question, respects your boundaries, and flags your failure risk
+  when the rule does not apply. You recognise the reasoning as yours.
+
+## 5. Fail-closed check (optional but recommended)
+
+Try loading a corrupted copy of the asset (flip a byte).
+
+- **Expected screens:** the load is rejected with a stable error code. It is
+  never silently accepted as "valid".
+
+## 6. Done
+
+You saw the judgment take effect in a real task. Record the observed vs
+expected in the acceptance verdict table.

--- a/docs/real-human-acceptance/create-script.md
+++ b/docs/real-human-acceptance/create-script.md
@@ -1,0 +1,90 @@
+# Real-Human Acceptance — Creation Script
+
+Purpose: turn a human's real judgment material into a `.kdna` asset that passes
+the five gates. This is the **creation** side of the real-human acceptance
+suite. The Owner speaks or fills in the template below; the script shapes the
+result into a valid asset.
+
+Read the boundary declaration (`README.md` in this directory) before using:
+assets produced here are **real-human material** and must stay isolated from
+any SIMULATION output.
+
+## 0. What you need
+
+- A real judgment you actually use: a recurring decision where you have a
+  private standard that a generic assistant would get wrong.
+- A plain text editor (or just your voice if you fill the template by hand).
+- The KDNA toolchain installed (`kdna validate`, `kdna pack`, `kdna inspect`).
+
+## 1. Pre-generated question sequence (answer each out loud or in writing)
+
+Answer these in order. Do not skip; each answer feeds one part of the asset.
+
+1. **The situation.** What is the recurring situation where you must decide?
+   (One sentence. Example: "whether to escalate a conflict at work or absorb it".)
+2. **The highest question.** What single question are you really answering in
+   that situation?
+3. **Your default rule.** When you act, what is your default rule of thumb?
+4. **The exception list.** In what cases does your rule NOT apply? (List as
+   many as you can. This is your boundary set.)
+5. **The failure risk.** When your rule is applied wrongly, what is the most
+   likely harm? (One sentence.)
+6. **The tell.** What signal tells you the rule is being misapplied in real
+   time?
+
+## 2. Draft template
+
+Fill this in with your answers from section 1.
+
+```text
+highest_question: <answer 2>
+axioms:
+  - one_sentence: <answer 3>
+    applies_when: [<situation keywords from answer 1>]
+    does_not_apply_when: [<answer 4 items>]
+    failure_risk: <answer 5>
+boundaries:
+  - type: scope
+    text: <answer 4, first boundary>
+self_checks:
+  - <answer 6>
+```
+
+## 3. Produce the asset
+
+The creation path is asset-first: build a source directory holding the
+manifest (`kdna.json`) and judgment payload, validate it, then pack it into a
+`.kdna` container.
+
+1. Create a source directory named after your domain.
+2. Write `kdna.json` (the manifest) with your domain, title, version, and
+   `payload` pointing at your judgment file.
+3. Write the judgment payload (from section 2) into the payload file.
+4. Validate the source directory, then pack it:
+
+```sh
+kdna validate asset-source/          # must report overall_valid: true
+kdna pack asset-source/ -o your-asset.kdna
+```
+
+You can also confirm the packaged asset with `kdna inspect your-asset.kdna`.
+
+## 4. The five gates
+
+A produced asset is only accepted when all five gates pass:
+
+1. **Container** — valid ZIP with `mimetype` stored first, plus `kdna.json`,
+   `payload.kdnab`, `checksums.json`.
+2. **Manifest schema** — `kdna.json` conforms to the manifest schema.
+3. **Payload schema** — the judgment payload conforms to the payload schema.
+4. **Checksum/digest** — `checksums.json` digests match the container bytes.
+5. **Load contract** — the asset plans to load now and loads into a runtime
+   capsule.
+
+`kdna validate` reports gate 1–4; gate 5 is verified by a load call (see the
+consume script).
+
+## 5. Done
+
+You have a real-human `.kdna` produced from your actual judgment. Proceed to
+the consume script for the load-and-see path.


### PR DESCRIPTION
C3 preparation materials for the first real-human acceptance item. **Methodology only; no acceptance is executed from this directory** — the 0/8 real-human state stays tracked in the workspace acceptance ledger, not here.

- **create-script.md** — guided creation: 6-question elicitation sequence + draft template + the five gates (container / manifest schema / payload schema / checksum / load contract), using the allowlisted CLI surface (`kdna validate` / `kdna pack` / `kdna inspect`).
- **consume-script.md** — real-human consumption path: inspect → plan-load → load → see the judgment in a real task → fail-closed check, each step with expected screens.
- **acceptance-verdict.md** — item-1 verdict table (10 rows, expected vs actual, PASS/FAIL/NOT_RUN), runnable in under 30 minutes.
- **README.md** — index + real-human vs SIMULATION boundary declaration (strict isolation; SIMULATION never counts toward acceptance).

Public-safe: no internal paths, no credentials, no internal PR/repo identifiers. Every CLI command referenced is in the published command allowlist (verified). All five gates cross-check against the conformance runner and core validate.