### PR TITLE
fix: install full python-sdk test deps in publish gate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -327,8 +327,8 @@ jobs:
       - name: Verify the isolated npm CLI and extraction boundary
         run: node scripts/core-release-authority.js verify-npm
       - run: node scripts/core-release-authority.js trusted-npm ci --ignore-scripts
-      - name: Install fixed Python test dependency
-        run: python -m pip install --disable-pip-version-check --no-input pytest==9.1.0
+      - name: Install fixed Python test dependencies
+        run: python -m pip install --disable-pip-version-check --no-input pytest==9.1.0 cbor2==6.1.4 jsonschema==4.26.0 cryptography==50.0.0 argon2-cffi==25.1.0
       - name: Fetch protected main for release ancestry verification
         run: git fetch --no-tags origin refs/heads/main:refs/remotes/origin/main
       - name: Verify canonical compatibility release tag


### PR DESCRIPTION
The publish workflow's python-adapter ecosystem-gate stage (scripts/ecosystem-gate.js) runs python-sdk pytest via KDNA_PYTHON. python-sdk/kdna/core imports cbor2 and cryptography at module load; without them, pytest collection fails with ModuleNotFoundError and the gate cannot pass.

publish.yml installed only pytest==9.1.0 for that stage, while core-smoke.yml already installs the full set. This aligns the publish workflow with core-smoke.yml:124.

Verified locally with a clean Python 3.12 venv: with only pytest installed, collection fails on cbor2/cryptography; with the four pinned deps, all 37 python-sdk tests pass.