### PR TITLE
revert: back out publish python deps alignment (#270)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -327,8 +327,8 @@ jobs:
       - name: Verify the isolated npm CLI and extraction boundary
         run: node scripts/core-release-authority.js verify-npm
       - run: node scripts/core-release-authority.js trusted-npm ci --ignore-scripts
-      - name: Install fixed Python test dependencies
-        run: python -m pip install --disable-pip-version-check --no-input pytest==9.1.0 cbor2==6.1.4 jsonschema==4.26.0 cryptography==50.0.0 argon2-cffi==25.1.0
+      - name: Install fixed Python test dependency
+        run: python -m pip install --disable-pip-version-check --no-input pytest==9.1.0
       - name: Fetch protected main for release ancestry verification
         run: git fetch --no-tags origin refs/heads/main:refs/remotes/origin/main
       - name: Verify canonical compatibility release tag


### PR DESCRIPTION
Re-landing the publish.yml Python-dependency alignment with a DCO-clean identity. The previous squash merge rewrote the commit author to the account email (9141164@qq.com) while preserving the original Signed-off-by trailer (283974029+...), so the release DCO gate (author must match trailer exactly) rejected the tag commit.

This revert restores the single-dependency install; the follow-up PR re-applies the full dependency set with a matching author+trailer pair.