### PR TITLE
fix: install full python-sdk test deps in publish gate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -327,8 +327,8 @@ jobs:
       - name: Verify the isolated npm CLI and extraction boundary
         run: node scripts/core-release-authority.js verify-npm
       - run: node scripts/core-release-authority.js trusted-npm ci --ignore-scripts
-      - name: Install fixed Python test dependency
-        run: python -m pip install --disable-pip-version-check --no-input pytest==9.1.0
+      - name: Install fixed Python test dependencies
+        run: python -m pip install --disable-pip-version-check --no-input pytest==9.1.0 cbor2==6.1.4 jsonschema==4.26.0 cryptography==50.0.0 argon2-cffi==25.1.0
       - name: Fetch protected main for release ancestry verification
         run: git fetch --no-tags origin refs/heads/main:refs/remotes/origin/main
       - name: Verify canonical compatibility release tag


### PR DESCRIPTION
Aligns the publish workflow's python-adapter stage dependency install with core-smoke.yml:124. python-sdk/kdna/core imports cbor2 and cryptography at module load; without them pytest collection fails and the ecosystem gate cannot pass.

Re-applies the earlier change with a DCO-clean author+trailer pair so the compatibility release tag passes the author-signoff gate.