### PR TITLE
feat: publish the Python distribution as aikdna on PyPI

### DIFF
--- a/python-sdk/README.md
+++ b/python-sdk/README.md
@@ -29,18 +29,23 @@ and loads identically in Python, a Python-packed container validates and
 loads identically in JS, and both packers produce byte-identical output for
 the same source (same SHA-256).
 
-## Install for local development
+## Install
+
+The Python distribution publishes on PyPI as **`aikdna`** (the import package is
+`kdna`):
+
+```bash
+python -m pip install aikdna
+python -c "import kdna; print(kdna.open_kdna)"
+```
+
+For local development inside this repository:
 
 ```bash
 cd python-sdk
 python -m pip install -e ".[dev]"
 python -m pytest
 ```
-
-This directory is not currently published as an official PyPI distribution.
-Use the npm CLI/Core packages for the published pre-release runtime. The Python Core
-is a source-level integration preview until a separate signed release pipeline
-exists.
 
 The adapter layer supports `@aikdna/kdna-cli >=0.35.0,<0.36.0` and checks the
 CLI version before its first operation. Compatibility with a later pre-1.0 CLI

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=75", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "kdna"
+name = "aikdna"
 version = "0.6.0"
 description = "Python Core and adapter for the KDNA protocol: independent container parsing, validation, LoadPlan, Runtime Capsule, and deterministic pack"
 readme = "README.md"

--- a/python-sdk/scripts/release-signed-build.py
+++ b/python-sdk/scripts/release-signed-build.py
@@ -120,7 +120,7 @@ def main() -> None:
 
     secret_key = load_secret_key()
     try:
-        artifacts = sorted(dist.glob("kdna-*.tar.gz")) + sorted(dist.glob("kdna-*.whl"))
+        artifacts = sorted(dist.glob("*.tar.gz")) + sorted(dist.glob("*.whl"))
         if not artifacts:
             raise SystemExit("no artifacts built")
         for artifact in artifacts:


### PR DESCRIPTION
## Scope
- Rename the Python distribution from `kdna` to `aikdna` in `pyproject.toml` (version stays `0.6.0`; the import package remains `kdna`, per `[tool.setuptools.packages.find] include = ["kdna*"]`).
- Update `python-sdk/README.md` install section to the published PyPI coordinate (`pip install aikdna` → `import kdna`).
- Make `release-signed-build.py` glob distribution-agnostic (`*.tar.gz` / `*.whl`).
## Publication evidence
- `aikdna` 0.6.0 published to PyPI: `https://pypi.org/project/aikdna/0.6.0/`.
- Wheel sha256 `1608bc27f83b5ef9dc1decfc7d15da6be7b0eb897551908dc0388f1532c5325f`, sdist sha256 `1f9fb5d2f591a394178b71af332854efaa046bc56a1edde55c7920ab87abd657` — matching the PyPI simple index.
- Clean venv `pip install aikdna==0.6.0` from PyPI verified: `import kdna` OK, dist version 0.6.0, `pytest` 37 passed.