### PR TITLE
docs: warn that the PyPI kdna project is unrelated

### DIFF
--- a/python-sdk/README.md
+++ b/python-sdk/README.md
@@ -39,6 +39,9 @@ python -m pip install aikdna
 python -c "import kdna; print(kdna.open_kdna)"
 ```
 
+> **Security note:** the `kdna` project on PyPI is unrelated to this project.
+> Install only the official `aikdna` distribution from this repository.
+
 For local development inside this repository:
 
 ```bash


### PR DESCRIPTION
## Scope
Add a security note to the python-sdk README install section: the `kdna` project on PyPI is unrelated to this project; install only the official `aikdna` distribution.
## Rationale
Our official PyPI distribution is `aikdna` (import package `kdna`). The unrelated `kdna` name on PyPI must not be mistaken for this package.