### PR TITLE
docs: warn against the PyPI kdna squat in READMEs and audit script

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ kdna plan-load ./judgment.kdna --json
 kdna load ./judgment.kdna --profile=compact --as=json
 ```
 
+> **Python/PyPI note:** the `kdna` project name on PyPI is an unrelated
+> third-party placeholder, not ours. Our official Python distribution on PyPI
+> is **`aikdna`** (the import package name remains `kdna`). Install only
+> `aikdna` from PyPI — never `pip install kdna`.
+
 The AIKDNA asset repository currently displays two current-format technical
 reference assets and zero Clusters. Listing is not an endorsement, and the
 local demonstration above remains the recommended first-run path.

--- a/README.zh.md
+++ b/README.zh.md
@@ -53,6 +53,10 @@ kdna plan-load ./judgment.kdna --json
 kdna load ./judgment.kdna --profile=compact --as=json
 ```
 
+> **Python/PyPI 提示：** PyPI 上的 `kdna` 项目名是与本项目无关的第三方空占，
+> 并非我方。我方在 PyPI 的官方发行名是 **`aikdna`**（import 包名仍为
+> `kdna`）。只安装 PyPI 的 `aikdna`——绝不要 `pip install kdna`。
+
 这条路径证明容器能够被当前工具链验证、规划和投影，不证明模型已经采用资产，
 也不证明资产内容正确或结果更好。
 

--- a/scripts/audit-security.sh
+++ b/scripts/audit-security.sh
@@ -64,3 +64,23 @@ else
 fi
 
 echo "No token-like strings found."
+
+echo
+
+echo "== PyPI kdna name-squat release monitor =="
+# The PyPI `kdna` project name is an unrelated third-party placeholder, not
+# ours. Our official Python distribution on PyPI is `aikdna` (import package
+# `kdna`). If anyone uploads a release file to the `kdna` project, alert so a
+# reader cannot mistake it for our package.
+if ! command -v curl >/dev/null 2>&1; then
+  echo "SKIP: curl not available; PyPI kdna squat monitor not run."
+else
+  body="$(curl -fsS -A 'Mozilla/5.0 (AIKDNA typosquat watch)' --max-time 30 https://pypi.org/simple/kdna/ 2>/dev/null || true)"
+  count="$(printf '%s' "$body" | grep -cE 'href="[^"]*\.(whl|tar\.gz)#sha256=' || true)"
+  if (( count > 0 )); then
+    echo "ALERT: PyPI project \"kdna\" now hosts $count release file(s) (name squat)."
+    printf '%s\n' "$body" | grep -oE 'href="[^"]*"' || true
+    exit 1
+  fi
+  echo "OK: PyPI \"kdna\" has no release files (name-squat monitor clear)."
+fi


### PR DESCRIPTION
PyPI 上的 `kdna` 项目名是第三方空占、非我方。官方 Python 发行名为 `aikdna`（import 包名仍为 `kdna`）。

改动：
- 根 README.md / README.zh.md 安装节后加 PyPI 警示（绝不要 pip install kdna）
- scripts/audit-security.sh 新增 PyPI kdna 占名发布监控：检出 pypi.org/simple/kdna 出现 release 文件即 ALERT + exit 1（离线安全，curl 失败不误报）

对抗审查 F7 处置项。python-sdk/README.md 的警示已由 #276 含在基线。