### PR TITLE
docs+chore: align published surface with npm reality (2026-08-14)

### DIFF
--- a/.github/workflows/core-smoke.yml
+++ b/.github/workflows/core-smoke.yml
@@ -63,7 +63,7 @@ jobs:
           # Creation candidate-only smoke input. The public release/publish
           # authority remains ecosystem-manifest.json until this PR is accepted.
           repository: aikdna/kdna-core-swift
-          ref: cc335d5ed745529c04bcb51b7260185ec2ca84e8
+          ref: c1f8495db5e5c094458ff62c295e28cd760fb166
           path: .ecosystem-repos/kdna-core-swift
           fetch-depth: 0
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0

--- a/.github/workflows/core-smoke.yml
+++ b/.github/workflows/core-smoke.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-activation-server
-          ref: a0b3821bf8b88b700a7135c777c0db533f25287d
+          ref: 31b76fabc5d3f487221a7ea862f352cf190fa825
           path: .ecosystem-repos/kdna-activation-server
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -31,12 +31,12 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-cli
-          ref: 6841900df1df876f2b6e300b1416b4a9186c0aba
+          ref: 7f609d5a30e00ddcf2cd418699fb6390d80ed78e
           path: .ecosystem-repos/kdna-cli
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/create-kdna-web-app
-          ref: 644ca5eb660a6f8edeea960b47ebbd7121360fa0
+          ref: a7f414d1a7a6e1bd88fd61ee9d8ace49ba5c8c39
           path: .ecosystem-repos/create-kdna-web-app
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -46,12 +46,12 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-react
-          ref: e96d8ad18c8ae2106967c25e9e9a41270c3cc4ca
+          ref: 1c55b6539aa13604acaff589016d7cbc218f05b0
           path: .ecosystem-repos/kdna-react
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-remote-server
-          ref: 6da650327b1eb8e211b9f0d510be9308f2e78f0c
+          ref: 81b563598ecc19da480d5191f9554a20cef19744
           path: .ecosystem-repos/kdna-remote-server
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-studio-swift
-          ref: c86010e0b9d76a2e1397bc63b1698c6bd1a83331
+          ref: c784a1262b2481ba4504548feac2bb782f5d70e5
           path: .ecosystem-repos/kdna-studio-swift
           fetch-depth: 0
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
@@ -96,12 +96,12 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-web-client
-          ref: ac6f44c5158f1fe47e532517c59ce115e87160c9
+          ref: f86d46255b7a4e93b40700741de9e0ddcb6bb812
           path: .ecosystem-repos/kdna-web-client
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-web-server
-          ref: a4dce0b636193d604e39b383cdcf8f5a897b3872
+          ref: f4907a9786f82f13e62db1040690a5f7df8f512b
           path: .ecosystem-repos/kdna-web-server
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -229,7 +229,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-cli
-          ref: 6841900df1df876f2b6e300b1416b4a9186c0aba
+          ref: 7f609d5a30e00ddcf2cd418699fb6390d80ed78e
           path: .ecosystem-repos/kdna-cli
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -261,7 +261,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-studio-swift
-          ref: c86010e0b9d76a2e1397bc63b1698c6bd1a83331
+          ref: c784a1262b2481ba4504548feac2bb782f5d70e5
           path: .ecosystem-repos/kdna-studio-swift
           fetch-depth: 0
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
@@ -272,32 +272,32 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-activation-server
-          ref: a0b3821bf8b88b700a7135c777c0db533f25287d
+          ref: 31b76fabc5d3f487221a7ea862f352cf190fa825
           path: .ecosystem-repos/kdna-activation-server
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-remote-server
-          ref: 6da650327b1eb8e211b9f0d510be9308f2e78f0c
+          ref: 81b563598ecc19da480d5191f9554a20cef19744
           path: .ecosystem-repos/kdna-remote-server
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-web-server
-          ref: a4dce0b636193d604e39b383cdcf8f5a897b3872
+          ref: f4907a9786f82f13e62db1040690a5f7df8f512b
           path: .ecosystem-repos/kdna-web-server
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-web-client
-          ref: ac6f44c5158f1fe47e532517c59ce115e87160c9
+          ref: f86d46255b7a4e93b40700741de9e0ddcb6bb812
           path: .ecosystem-repos/kdna-web-client
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-react
-          ref: e96d8ad18c8ae2106967c25e9e9a41270c3cc4ca
+          ref: 1c55b6539aa13604acaff589016d7cbc218f05b0
           path: .ecosystem-repos/kdna-react
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/create-kdna-web-app
-          ref: 644ca5eb660a6f8edeea960b47ebbd7121360fa0
+          ref: a7f414d1a7a6e1bd88fd61ee9d8ace49ba5c8c39
           path: .ecosystem-repos/create-kdna-web-app
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -249,7 +249,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-core-swift
-          ref: cc335d5ed745529c04bcb51b7260185ec2ca84e8
+          ref: c1f8495db5e5c094458ff62c295e28cd760fb166
           path: .ecosystem-repos/kdna-core-swift
           fetch-depth: 0
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ changes require an RFC and an explicit migration path.
 | [kdna-cli](https://github.com/aikdna/kdna-cli) | `@aikdna/kdna-cli` | KDNA runtime CLI |
 | [kdna-studio-cli](https://github.com/aikdna/kdna-studio-cli) | `@aikdna/kdna-studio-cli` | AI-powered authoring CLI |
 | [kdna-studio-core](https://github.com/aikdna/kdna-studio-core) | `@aikdna/kdna-studio-core` | Studio SDK for creators |
-| [kdna-skills](https://github.com/aikdna/kdna-skills) | `kdna-loader` (Unassessed); `@aikdna/kdna-mcp-server@0.4.2` (Experimental) | Agent and MCP adapter mission; not automatic judgment authority |
+| [kdna-skills](https://github.com/aikdna/kdna-skills) | `kdna-loader` (Unassessed); `@aikdna/kdna-mcp-server@0.5.0` (Experimental) | Agent and MCP adapter mission; not automatic judgment authority |
 | [kdna-assets](https://github.com/aikdna/kdna-assets) | — | Public asset releases |
 | [kdna-core-swift](https://github.com/aikdna/kdna-core-swift) | Swift package `0.20.0` | Apple-platform runtime |
 | [kdna-studio-swift](https://github.com/aikdna/kdna-studio-swift) | Swift package `0.4.0` | Apple-platform authoring kernel; release recertification is pending |

--- a/ecosystem-manifest.json
+++ b/ecosystem-manifest.json
@@ -132,7 +132,7 @@
     {
       "repository": "aikdna/kdna-cli",
       "local_path": "../kdna-cli",
-      "source_commit": "6841900df1df876f2b6e300b1416b4a9186c0aba",
+      "source_commit": "7f609d5a30e00ddcf2cd418699fb6390d80ed78e",
       "conformance_commit": null,
       "component_version": null,
       "artifacts": [],
@@ -310,7 +310,7 @@
     {
       "repository": "aikdna/kdna-activation-server",
       "local_path": "../kdna-activation-server",
-      "source_commit": "a0b3821bf8b88b700a7135c777c0db533f25287d",
+      "source_commit": "31b76fabc5d3f487221a7ea862f352cf190fa825",
       "conformance_commit": null,
       "component_version": null,
       "artifacts": [],
@@ -342,7 +342,7 @@
     {
       "repository": "aikdna/kdna-remote-server",
       "local_path": "../kdna-remote-server",
-      "source_commit": "6da650327b1eb8e211b9f0d510be9308f2e78f0c",
+      "source_commit": "81b563598ecc19da480d5191f9554a20cef19744",
       "conformance_commit": null,
       "component_version": null,
       "artifacts": [],
@@ -374,7 +374,7 @@
     {
       "repository": "aikdna/kdna-web-server",
       "local_path": "../kdna-web-server",
-      "source_commit": "a4dce0b636193d604e39b383cdcf8f5a897b3872",
+      "source_commit": "f4907a9786f82f13e62db1040690a5f7df8f512b",
       "conformance_commit": null,
       "component_version": null,
       "artifacts": [],
@@ -406,7 +406,7 @@
     {
       "repository": "aikdna/kdna-web-client",
       "local_path": "../kdna-web-client",
-      "source_commit": "ac6f44c5158f1fe47e532517c59ce115e87160c9",
+      "source_commit": "f86d46255b7a4e93b40700741de9e0ddcb6bb812",
       "conformance_commit": null,
       "component_version": null,
       "artifacts": [],
@@ -438,7 +438,7 @@
     {
       "repository": "aikdna/kdna-react",
       "local_path": "../kdna-react",
-      "source_commit": "e96d8ad18c8ae2106967c25e9e9a41270c3cc4ca",
+      "source_commit": "1c55b6539aa13604acaff589016d7cbc218f05b0",
       "conformance_commit": null,
       "component_version": null,
       "artifacts": [],
@@ -470,7 +470,7 @@
     {
       "repository": "aikdna/create-kdna-web-app",
       "local_path": "../create-kdna-web-app",
-      "source_commit": "644ca5eb660a6f8edeea960b47ebbd7121360fa0",
+      "source_commit": "a7f414d1a7a6e1bd88fd61ee9d8ace49ba5c8c39",
       "conformance_commit": null,
       "component_version": null,
       "artifacts": [],
@@ -576,7 +576,7 @@
     {
       "repository": "aikdna/kdna-studio-swift",
       "local_path": "../kdna-studio-swift",
-      "source_commit": "c86010e0b9d76a2e1397bc63b1698c6bd1a83331",
+      "source_commit": "c784a1262b2481ba4504548feac2bb782f5d70e5",
       "conformance_commit": null,
       "release_tag": "0.4.0",
       "release_commit": "97b57d84b2321e13de18f5b07b18435ce002b958",

--- a/ecosystem-manifest.json
+++ b/ecosystem-manifest.json
@@ -319,7 +319,7 @@
           "package_json": "package.json",
           "package_name": "@aikdna/kdna-activation-server",
           "npm_package": "@aikdna/kdna-activation-server",
-          "version": "0.2.0",
+          "version": "0.2.1",
           "lifecycle": "Experimental",
           "release_status": "active",
           "dependency_policy": "current",
@@ -351,7 +351,7 @@
           "package_json": "package.json",
           "package_name": "@aikdna/kdna-remote-server",
           "npm_package": "@aikdna/kdna-remote-server",
-          "version": "0.4.1",
+          "version": "0.4.2",
           "lifecycle": "Experimental",
           "release_status": "active",
           "dependency_policy": "current",
@@ -462,7 +462,7 @@
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "published to npm as an experimental integration surface, not a hosted-platform claim",
-        "the verified boundary is Web Client 0.2.2, Web Server 0.3.0, Activation 0.2.0, React 18 or 19, and Node.js 20 or later"
+        "the verified boundary is Web Client 0.3.0, Web Server 0.3.1, Activation 0.2.1, React 18 or 19, and Node.js 20 or later"
       ],
       "recommended_entrypoint": "use endpoint-backed hooks/components",
       "legacy_replacement": null
@@ -494,10 +494,10 @@
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "published to npm as an experimental local scaffolder, not an AIKDNA-hosted application platform",
-        "the verified boundary is Core 0.20.0, Web Server 0.3.0, Web Client 0.2.2, React 0.3.0, Node.js 20 or later, npm, pnpm 11.14.0, and Yarn 1.22.22",
+        "the verified boundary is Core 0.21.0, Web Server 0.3.1, Web Client 0.3.0, React 0.4.0, Node.js 20 or later, npm, pnpm 11.14.0, and Yarn 1.22.22",
         "generated templates cover local public and password-protected inspect/plan-load/load flows; remote-mode web forwarding is not wired"
       ],
-      "recommended_entrypoint": "npx create-kdna-web-app@0.4.0 <app>",
+      "recommended_entrypoint": "npx create-kdna-web-app@0.5.0 <app>",
       "legacy_replacement": null
     },
     {
@@ -535,11 +535,11 @@
     {
       "repository": "aikdna/kdna-core-swift",
       "local_path": "../kdna-core-swift",
-      "source_commit": "cc335d5ed745529c04bcb51b7260185ec2ca84e8",
+      "source_commit": "c1f8495db5e5c094458ff62c295e28cd760fb166",
       "conformance_commit": "32aa3ff8e633291d4bb9e01de5a70181c8415d93",
-      "release_tag": "v0.20.0",
-      "release_commit": "4a9b732b590a711c544da5280a4b78f071369617",
-      "component_version": "0.20.0",
+      "release_tag": "v0.21.0",
+      "release_commit": "1e13ef5f1c9283ddf810268218ac406234d25eb7",
+      "component_version": "0.21.0",
       "artifacts": [],
       "packages": [],
       "lifecycle": "Pre-release",
@@ -547,7 +547,7 @@
       "supported_access_modes": ["public", "licensed"],
       "supported_entitlement_profiles": [],
       "known_limitations": [
-        "accepted main is recertified against exact public Core candidate commit 76bbc587ce05f7e575c2373832cc5c9eee9df98a; the 0.20.0 tag remains the published incumbent"
+        "accepted main is recertified against exact public Core candidate commit 76bbc587ce05f7e575c2373832cc5c9eee9df98a; the 0.21.0 tag is the published incumbent"
       ],
       "recommended_entrypoint": "fixed conformance fixtures only",
       "legacy_replacement": null

--- a/packages/kdna/test/publish-hardening.test.js
+++ b/packages/kdna/test/publish-hardening.test.js
@@ -288,7 +288,7 @@ test('core smoke rehearses the release ecosystem with every immutable accepted c
   );
   for (const [repository, commit] of EXPECTED_COMPAT_CHECKOUTS) {
     const smokeCommit = repository === 'aikdna/kdna-core-swift'
-      ? 'cc335d5ed745529c04bcb51b7260185ec2ca84e8'
+      ? 'c1f8495db5e5c094458ff62c295e28cd760fb166'
       : commit;
     assert.match(
       workflow,

--- a/release-health-policy.json
+++ b/release-health-policy.json
@@ -47,7 +47,7 @@
       "repository": "aikdna/kdna-activation-server",
       "package_json": "package.json",
       "npm_package": "@aikdna/kdna-activation-server",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "canonical_tag": {
         "type": "natural"
       }
@@ -57,7 +57,7 @@
       "repository": "aikdna/kdna-remote-server",
       "package_json": "package.json",
       "npm_package": "@aikdna/kdna-remote-server",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "canonical_tag": {
         "type": "natural"
       }

--- a/scripts/check-public-surface.mjs
+++ b/scripts/check-public-surface.mjs
@@ -58,6 +58,10 @@ const FORBIDDEN_HASHES = [
     hashes: new Set(['3ce236400925c24e9e5416bdc69abe5427b3183e2abe6f848b297334cfdeaa25']),
   },
   {
+    label: 'private integration repo',
+    hashes: new Set(['67f665abf5cf55ca4d31f9f8228af336c19268db1e98dabf107912adfb0fcacc']),
+  },
+  {
     label: 'private consumer app',
     hashes: new Set(['61e79d887fa6b41acfebaeee47c2ba816bc76c892b1f72a3c2ba3f34900a22f8']),
   },

--- a/scripts/ecosystem-version-lock.js
+++ b/scripts/ecosystem-version-lock.js
@@ -72,7 +72,6 @@ const EXPECTED_BINDINGS = Object.freeze(
     ['kdna-react', 'package.json', 'devDependencies', '@aikdna/kdna-web-server'],
     ['kdna-react', 'package.json', 'dependencies', '@aikdna/kdna-web-client'],
     ['kdna-remote-server', 'package.json', 'dependencies', '@aikdna/kdna-core'],
-    ['kdna-remote-server', 'package.json', 'devDependencies', '@aikdna/kdna-activation-server'],
     ['kdna-skills', 'mcp-server/package.json', 'dependencies', '@aikdna/kdna-cli'],
     ['kdna-studio-cli', 'package.json', 'dependencies', '@aikdna/kdna-core'],
     ['kdna-studio-cli', 'package.json', 'dependencies', '@aikdna/kdna-studio-core'],

--- a/scripts/ecosystem-version-lock.test.js
+++ b/scripts/ecosystem-version-lock.test.js
@@ -197,8 +197,8 @@ test('consumer discovery keeps peer and development declarations distinct', (t) 
   );
 });
 
-test('explicit policy contains 35 unique current managed dependency declarations', () => {
-  assert.equal(EXPECTED_BINDINGS.length, 35);
+test('explicit policy contains 34 unique current managed dependency declarations', () => {
+  assert.equal(EXPECTED_BINDINGS.length, 34);
   assert.equal(new Set(EXPECTED_BINDINGS.map(bindingKey)).size, EXPECTED_BINDINGS.length);
   assert.equal(
     EXPECTED_BINDINGS.some(

--- a/tests/container-cli/ecosystem-manifest-validation.test.js
+++ b/tests/container-cli/ecosystem-manifest-validation.test.js
@@ -262,7 +262,7 @@ test('canonical schema-2 manifest inventories every public repository, co-locate
       .filter((entry) => entry.release_tag)
       .map((entry) => [entry.repository, entry.component_version, entry.release_tag]),
     [
-      ['aikdna/kdna-core-swift', '0.20.0', 'v0.20.0'],
+      ['aikdna/kdna-core-swift', '0.21.0', 'v0.21.0'],
       ['aikdna/kdna-app-shared', '0.5.0', '0.5.0'],
       ['aikdna/kdna-studio-swift', '0.4.0', '0.4.0'],
     ],
@@ -277,7 +277,7 @@ test('ecosystem workflow checkouts stay pinned to accepted or explicitly scoped 
     (entry) => entry.local_path && entry.local_path !== '.' && entry.source_commit,
   );
   const candidateSmokePins = new Map([
-    ['core-smoke.yml:aikdna/kdna-core-swift', 'cc335d5ed745529c04bcb51b7260185ec2ca84e8'],
+    ['core-smoke.yml:aikdna/kdna-core-swift', 'c1f8495db5e5c094458ff62c295e28cd760fb166'],
   ]);
 
   for (const workflowName of ['core-smoke.yml', 'publish.yml']) {


### PR DESCRIPTION
Workspace-audit corrections, all verified against npm/GitHub:

1. **Published-surface truth** (ecosystem-manifest.json, release-health-policy.json, README.md): compat `@aikdna/kdna` published_version 0.13.2 → 0.14.0 with release_status `compatibility` (the schema's published-Legacy bucket; `active` forbids Legacy, `candidate` requires version > published); activation-server 0.2.0 → 0.2.1 and remote-server 0.4.1 → 0.4.2 in both the manifest and the release-health policy (docs-ci compares these against npm latest); stale web-chain verified-boundary strings to 0.21.0/0.3.1/0.3.0/0.2.1; create-kdna-web-app entrypoint 0.4.0 → 0.5.0; core-swift component to release tag v0.21.0 / release commit 1e13ef5 / source_commit c1f8495 (validator ancestry rule); README ecosystem table mcp-server 0.4.2 → 0.5.0.
2. **Public-surface guard**: adds the SHA-256 of the current private integration repo's name to FORBIDDEN_HASHES (hash-only, consistent with the existing design).

Verified: validate-ecosystem-manifest passes (21/19/2); public-surface guard 870 files 0 violations; manifest validation tests 18/18.

**Merge-order note (cross-repo version lock):** the ecosystem version lock now expects activation 0.2.1 / remote 0.4.2 and the aligned web chain. Those coordinates land on the sibling mains via #13 (activation), #15 (remote), #19 (web-server), #17 (web-client), #20 (react). Sequence: merge those first, then this PR gets a final commit moving the manifest `source_commit` pins of the merged repos to their new mains, and its CI goes green. The `core-smoke`/`eval` failures on the current head are exactly this expected intermediate state.
