### PR TITLE
chore: accept app-shared main, pin the consumed coordinate, drop EOL Node 18

### DIFF
--- a/.github/workflows/core-smoke.yml
+++ b/.github/workflows/core-smoke.yml
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-app-shared
-          ref: c942bc932ab087dc6f1ed751cb476c82e2db43a4
+          ref: 017e759efb448bf99b3384ccafa7f25172169ebb
           path: .ecosystem-repos/kdna-app-shared
           fetch-depth: 0
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -255,7 +255,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: aikdna/kdna-app-shared
-          ref: c942bc932ab087dc6f1ed751cb476c82e2db43a4
+          ref: 017e759efb448bf99b3384ccafa7f25172169ebb
           path: .ecosystem-repos/kdna-app-shared
           fetch-depth: 0
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -36,7 +36,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [18, 22, 24]
+        # Node 18 is EOL since 2025-04-30; the ecosystem supports active LTS lines only.
+        node-version: [22, 24]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:

--- a/docs/ecosystem-manifest.md
+++ b/docs/ecosystem-manifest.md
@@ -41,7 +41,15 @@ Artifacts record their repository-relative path, exact version, SHA-256,
 GitHub Release tag and commit, and the Core conformance commit used to verify
 them. The `aikdna/kdna-assets` artifact set must be an exact two-way projection
 of its accepted `index/current.json`; a new asset or Cluster cannot appear on
-only one side. `source_commit` identifies an accepted repository checkout;
+only one side. `source_commit` identifies an accepted repository checkout —
+it is a verified acceptance coordinate, not a live mirror of that repository's
+main branch, so a component may legitimately advance on its own main until the
+next acceptance. The exception is a locked consumer: when another
+manifest-listed component merges a change that consumes the producer at a
+newer coordinate than the manifest records (for example a SwiftPM pin that
+tracks the producer's main), the producer's `source_commit` must be advanced
+to that consumed coordinate in the same acceptance window, so the manifest
+never contradicts what a locked consumer actually resolves.
 `conformance_commit` identifies a separate fixture or contract anchor and must
 not be interpreted as that repository's release commit. A live package-less
 component records `component_version`, `release_tag`, and `release_commit`

--- a/ecosystem-manifest.json
+++ b/ecosystem-manifest.json
@@ -555,7 +555,7 @@
     {
       "repository": "aikdna/kdna-app-shared",
       "local_path": "../kdna-app-shared",
-      "source_commit": "c942bc932ab087dc6f1ed751cb476c82e2db43a4",
+      "source_commit": "017e759efb448bf99b3384ccafa7f25172169ebb",
       "conformance_commit": null,
       "release_tag": "0.5.0",
       "release_commit": "436f7832fbedba9bf55d9459cfa5a2c7f761967e",
@@ -568,7 +568,7 @@
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "Swift package source only; it is not an npm publication",
-        "the 0.5.0 tag predates the current Swift integration; accepted main is recertified against Swift Core 95f638e2f0472a375704fb5fe2f057de0cb4cb07 but remains unpublished source"
+        "the 0.5.0 tag predates the current Swift integration; accepted main is recertified against Swift Core 0.21.0 (tag commit 1e13ef5f1c9283ddf810268218ac406234d25eb7) but remains unpublished source"
       ],
       "recommended_entrypoint": ".package(url: \"https://github.com/aikdna/kdna-app-shared.git\", exact: \"0.5.0\")",
       "legacy_replacement": null
@@ -589,7 +589,7 @@
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "Swift package source only; it is not an npm publication",
-        "the 0.4.0 tag predates the current Swift integration; accepted main is recertified against Swift Core 95f638e2f0472a375704fb5fe2f057de0cb4cb07 and App Shared c942bc932ab087dc6f1ed751cb476c82e2db43a4 but remains unpublished source"
+        "the 0.4.0 tag predates the current Swift integration; accepted main is recertified against Swift Core 0.21.0 (tag commit 1e13ef5f1c9283ddf810268218ac406234d25eb7) and App Shared 017e759efb448bf99b3384ccafa7f25172169ebb but remains unpublished source"
       ],
       "recommended_entrypoint": ".package(url: \"https://github.com/aikdna/kdna-studio-swift.git\", exact: \"0.4.0\")",
       "legacy_replacement": null


### PR DESCRIPTION
## What

Three coordinated follow-ups to the 0.21.0 closeout (#281):

1. **Advance `kdna-app-shared` `source_commit` `c942bc93` → `017e759`** (current main). kdna-studio-swift#18 pins app-shared at main, whose Package.swift requires Core `from: 0.21.0` — the manifest's accepted coordinate must match what the locked consumer actually resolves. The two Swift `known_limitations` notes are refreshed: the accepted chain is now recertified against Swift Core 0.21.0 (tag commit `1e13ef5`), superseding the pre-0.21.0 `95f638e` references. Matching checkout refs in `core-smoke.yml` / `publish.yml` move with it.
2. **Document the `source_commit` policy** this enforces (docs/ecosystem-manifest.md): an accepted acceptance coordinate, not a mirror of main — but when a locked consumer merges a change that consumes the producer at a newer coordinate, the manifest must advance in the same acceptance window.
3. **Drop EOL Node 18** from the `validate.yml` matrix (`[18, 22, 24]` → `[22, 24]`). Node 18 reached EOL 2025-04-30; every other public repo CI already tests 22+ only.

## Evidence

- `kdna-app-shared` main = `017e759efb448bf99b3384ccafa7f25172169ebb` (`Package.swift`: core-swift `from: "0.21.0"`)
- `kdna-core-swift` tag `v0.21.0` = `1e13ef5f1c9283ddf810268218ac406234d25eb7`
- kdna-studio-swift#18 (merged 2026-08-15): pins app-shared at main, resolves Core 0.21.0 at tag `1e13ef5`
- Local gates: `validate-ecosystem-manifest` passed (21 components), `ecosystem-version-lock` 34/34 exact