### PR TITLE
docs: align RFC-0014 status with file and list RFC-0014/RFC-0019 in RFC index

### DIFF
--- a/docs/rfc-status.md
+++ b/docs/rfc-status.md
@@ -10,7 +10,7 @@ KDNA Core surface.
 | RFC-0011 | Product Runtime | Accepted proposal | It does not change the canonical `.kdna` container. |
 | RFC-0012 | Artifact Envelope | Draft | Not a current Core requirement. |
 | RFC-0013 | Judgment Asset Lifecycle | Withdrawn | Archived; no Core fields or behavior were adopted. |
-| RFC-0014 | KDNA Card extension | Withdrawn | Archived; no proposed Card extension fields were adopted. |
+| RFC-0014 | KDNA Asset Authorization, Entitlement, and LoadPlan | Proposed | Proposed authorization/entitlement/LoadPlan contract; not yet accepted as a binding compatibility promise. |
 | RFC-0015 | Runtime Trace extension | Withdrawn | Archived; use the maintained trace schema and documentation. |
 
 The canonical protocol is [SPEC.md](../SPEC.md). Runtime behavior is described

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -18,7 +18,9 @@ Current initial RFC set:
 - [RFC-0010: KDNA Fidelity Protocol](../specs/fidelity-protocol.md)
 - [RFC-0011: KDNA Product Runtime](../docs/product-runtime.md)
 - [RFC-0012: KDNA Artifact Contract](../specs/RFC-0012-artifact-contract.md)
+- [RFC-0014: KDNA Asset Authorization, Entitlement, and LoadPlan](./RFC-0014-asset-authorization-and-loadplan.md)
 - [RFC-0018: KDNA Canonical Envelope Profile — `kdna.envelope.aead`](./RFC-0018-envelope-aead.md) — draft pre-release candidate for the first public envelope wire contract. Three known-answer test vectors live at `conformance/envelope-aead/`. The unversioned `scrypt-sha256` KDF is mandatory, `argon2id` is optional, and `profile_version: 0.1.0` carries the wire coordinate. The profile non-collapse invariant forbids silent cross-KDF or cross-AEAD migration.
+- [RFC-0019: Account/device external key grants](./RFC-0019-account-device-external-key-grant.md) — draft envelope profile `kdna.envelope.external-grant` for revocable per-account/per-device authorization of `licensed` assets; derives from RFC-0018 key-slot wrapping and forbids fallback to password or license-key profiles.
 - [RFC-0021: KDNA Signature Track](./RFC-0021-signature-track.md) — draft placeholder that reserves and scopes the signature track turning RFC-0006's long-term signing model into an independently verifiable wire contract. Names six milestones (payload canonicalization, identity, bundle format, rotation/revocation, offline verification, 1.0 compatibility) and the fail-closed / non-collapse / provenance-is-not-correctness / offline invariants. No implementation is bound to it yet.
 
 ## RFC States


### PR DESCRIPTION
## Summary

Fixes two documentation drift defects in the RFC status surface:

1. `docs/rfc-status.md` listed RFC-0014 as "KDNA Card extension / Withdrawn",
   but the actual file `rfcs/RFC-0014-asset-authorization-and-loadplan.md` is
   titled "KDNA Asset Authorization, Entitlement, and LoadPlan" with
   `Status: Proposed`. The stale row is corrected to match the file.
2. `rfcs/README.md` "Current initial RFC set" omitted two RFCs whose files are
   present in the repo: RFC-0014 (asset authorization / LoadPlan) and RFC-0019
   (account/device external key grants). Both are added in numeric order.

## Diff

- `docs/rfc-status.md`: RFC-0014 row — title "KDNA Card extension" → "KDNA Asset
  Authorization, Entitlement, and LoadPlan", status "Withdrawn" → "Proposed",
  guidance updated.
- `rfcs/README.md`: add RFC-0014 and RFC-0019 index entries.

## Verification

- `ls rfcs/` confirms RFC-0014-asset-authorization-and-loadplan.md and
  RFC-0019-account-device-external-key-grant.md both exist.
- RFC-0018 and RFC-0021 were already listed (checked per the inventory request).
