### PR TITLE
chore: recertify the ecosystem to the published 0.22.0

### DIFF
--- a/.github/workflows/core-smoke.yml
+++ b/.github/workflows/core-smoke.yml
@@ -63,7 +63,7 @@ jobs:
           # Creation candidate-only smoke input. The public release/publish
           # authority remains ecosystem-manifest.json until this PR is accepted.
           repository: aikdna/kdna-core-swift
-          ref: 59a68b760c187d5f7c8909b085b2030d010075de
+          ref: 5a8e2bb5db92d8a9118e1668cf6f1414c4aed5c9
           path: .ecosystem-repos/kdna-core-swift
           fetch-depth: 0
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/ecosystem-manifest.json
+++ b/ecosystem-manifest.json
@@ -15,7 +15,7 @@
       "repository": "aikdna/kdna",
       "local_path": ".",
       "source_commit": "32aa3ff8e633291d4bb9e01de5a70181c8415d93",
-      "conformance_commit": "9430761db45824f3c7a64e1f5c9c30285df8992b",
+      "conformance_commit": "a0edd85970a2b0a559528d40dcca9eff35f8a481",
       "component_version": null,
       "artifacts": [],
       "packages": [
@@ -24,9 +24,9 @@
           "package_name": "@aikdna/kdna-core",
           "npm_package": "@aikdna/kdna-core",
           "version": "0.22.0",
-          "published_version": "0.21.0",
+          "published_version": "0.22.0",
           "lifecycle": "Pre-release",
-          "release_status": "candidate",
+          "release_status": "active",
           "dependency_policy": "current",
           "known_limitations": [],
           "recommended_entrypoint": "npm install @aikdna/kdna-core",
@@ -52,14 +52,14 @@
           "npm_package": "@aikdna/kdna-conformance",
           "version": "0.2.0",
           "lifecycle": "Experimental",
-          "release_status": "candidate",
+          "release_status": "active",
           "dependency_policy": "current",
           "known_limitations": [
             "conformance verdicts are mechanism checks against the pinned reference implementation, not ecosystem authority"
           ],
           "recommended_entrypoint": "npm install @aikdna/kdna-conformance",
           "legacy_replacement": null,
-          "published_version": "0.1.0"
+          "published_version": "0.2.0"
         },
         {
           "package_json": "packages/kdna/package.json",
@@ -121,7 +121,11 @@
       ],
       "lifecycle": "Pre-release",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": ["public", "licensed", "remote"],
+      "supported_access_modes": [
+        "public",
+        "licensed",
+        "remote"
+      ],
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "hosted remote loading and activation are self-hosted reference surfaces, not an AIKDNA-hosted service",
@@ -154,10 +158,15 @@
       ],
       "lifecycle": "Pre-release",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": ["public", "licensed", "remote"],
+      "supported_access_modes": [
+        "public",
+        "licensed",
+        "remote"
+      ],
       "supported_entitlement_profiles": [],
       "known_limitations": [
-        "hosted registry, marketplace, and commercial distribution are not part of the local CLI baseline"
+        "hosted registry, marketplace, and commercial distribution are not part of the local CLI baseline",
+        "bound to Core 0.21.0 while Core 0.22.0 is published; the 0.37.0 re-bind is declared recertification debt for the 0.22.0 wave"
       ],
       "recommended_entrypoint": "kdna plan-load <asset> && kdna load <asset>",
       "legacy_replacement": null
@@ -166,7 +175,7 @@
       "repository": "aikdna/kdna-assets",
       "local_path": "../kdna-assets",
       "source_commit": "4de5bb01f4216624e57ffa7ac901e982dd323d95",
-      "conformance_commit": "9430761db45824f3c7a64e1f5c9c30285df8992b",
+      "conformance_commit": "a0edd85970a2b0a559528d40dcca9eff35f8a481",
       "component_version": null,
       "packages": [],
       "artifacts": [
@@ -176,7 +185,7 @@
           "sha256": "4a90b91fe955ec3a563a7c2b598568f0eedbd04d3393211692490dfde2e09ffc",
           "release_tag": "0.1.1",
           "release_commit": "2dd1e2844fd8b8deff8ea0e2620fd946e5c9544f",
-          "conformance_commit": "9430761db45824f3c7a64e1f5c9c30285df8992b",
+          "conformance_commit": "a0edd85970a2b0a559528d40dcca9eff35f8a481",
           "kind": "kdna-asset",
           "lifecycle": "Experimental",
           "known_limitations": [
@@ -190,7 +199,7 @@
           "sha256": "d8513486bc033523359b8a582ca5d879d5ec01c926601d2fde34813a793c5ccf",
           "release_tag": "0.1.1",
           "release_commit": "2dd1e2844fd8b8deff8ea0e2620fd946e5c9544f",
-          "conformance_commit": "9430761db45824f3c7a64e1f5c9c30285df8992b",
+          "conformance_commit": "a0edd85970a2b0a559528d40dcca9eff35f8a481",
           "kind": "kdna-asset",
           "lifecycle": "Experimental",
           "known_limitations": [
@@ -201,7 +210,9 @@
       ],
       "lifecycle": "Experimental",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": ["public"],
+      "supported_access_modes": [
+        "public"
+      ],
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "reference assets demonstrate technical interoperability and do not establish content correctness, adoption, or outcome claims",
@@ -234,7 +245,9 @@
       ],
       "lifecycle": "Experimental",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": ["public"],
+      "supported_access_modes": [
+        "public"
+      ],
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "MCP is an experimental structured bridge; the loader Skill is Unassessed and neither discovery nor matching creates user authority"
@@ -268,10 +281,14 @@
       ],
       "lifecycle": "Pre-release",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": ["public", "licensed"],
+      "supported_access_modes": [
+        "public",
+        "licensed"
+      ],
       "supported_entitlement_profiles": [],
       "known_limitations": [
-        "Studio export is pre-release and treats review, Human Lock, signatures, and release evidence as optional provenance layers"
+        "Studio export is pre-release and treats review, Human Lock, signatures, and release evidence as optional provenance layers",
+        "bound to Core 0.21.0 while Core 0.22.0 is published; re-binding is declared recertification debt for the 0.22.0 wave"
       ],
       "recommended_entrypoint": "Studio project export followed by Core validate and plan-load",
       "legacy_replacement": null
@@ -302,9 +319,15 @@
       ],
       "lifecycle": "Pre-release",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": ["public", "licensed"],
+      "supported_access_modes": [
+        "public",
+        "licensed"
+      ],
       "supported_entitlement_profiles": [],
-      "known_limitations": ["remote authoring delivery is outside the local Studio CLI baseline"],
+      "known_limitations": [
+        "remote authoring delivery is outside the local Studio CLI baseline",
+        "bound to Core 0.21.0 while Core 0.22.0 is published; re-binding is declared recertification debt for the 0.22.0 wave"
+      ],
       "recommended_entrypoint": "kdna-studio create/add/approve/export",
       "legacy_replacement": null
     },
@@ -331,11 +354,16 @@
       ],
       "lifecycle": "Experimental",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": ["licensed"],
-      "supported_entitlement_profiles": ["license_key"],
+      "supported_access_modes": [
+        "licensed"
+      ],
+      "supported_entitlement_profiles": [
+        "license_key"
+      ],
       "known_limitations": [
         "self-hosted support surface only; not an AIKDNA-hosted activation service",
-        "paid distribution and commercial delivery flows are not part of the public Core baseline"
+        "paid distribution and commercial delivery flows are not part of the public Core baseline",
+        "follows the CLI/Core chain at Core 0.21.0 while Core 0.22.0 is published; re-binding is declared recertification debt for the 0.22.0 wave"
       ],
       "recommended_entrypoint": "self-host only after reviewing specs/kdna-authorization-contract.md",
       "legacy_replacement": null
@@ -363,11 +391,14 @@
       ],
       "lifecycle": "Experimental",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": ["remote"],
+      "supported_access_modes": [
+        "remote"
+      ],
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "self-hosted projection server only; there is no AIKDNA-hosted remote loading service",
-        "remote-mode server operation remains an experimental self-hosted reference surface"
+        "remote-mode server operation remains an experimental self-hosted reference surface",
+        "bound to Core 0.21.0 while Core 0.22.0 is published; re-binding is declared recertification debt for the 0.22.0 wave"
       ],
       "recommended_entrypoint": "kdna load <asset> --remote-server <self-hosted-url> --profile=compact --as=prompt",
       "legacy_replacement": null
@@ -395,11 +426,14 @@
       ],
       "lifecycle": "Experimental",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": ["public"],
+      "supported_access_modes": [
+        "public"
+      ],
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "published to npm as an experimental integration surface, not a stable hosted-platform claim",
-        "the verified surface is Node.js-hosted Next.js and Express; server-side Studio export, remote forwarding, and CORS helpers are not implemented"
+        "the verified surface is Node.js-hosted Next.js and Express; server-side Studio export, remote forwarding, and CORS helpers are not implemented",
+        "bound to Core 0.21.0 while Core 0.22.0 is published; re-binding is declared recertification debt for the 0.22.0 wave"
       ],
       "recommended_entrypoint": "mount the server adapter and run the package test/build checks before release",
       "legacy_replacement": null
@@ -427,7 +461,9 @@
       ],
       "lifecycle": "Experimental",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": ["public"],
+      "supported_access_modes": [
+        "public"
+      ],
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "published to npm as an experimental integration surface, not a stable browser runtime",
@@ -459,7 +495,9 @@
       ],
       "lifecycle": "Experimental",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": ["public"],
+      "supported_access_modes": [
+        "public"
+      ],
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "published to npm as an experimental integration surface, not a hosted-platform claim",
@@ -491,7 +529,10 @@
       ],
       "lifecycle": "Experimental",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": ["public", "licensed"],
+      "supported_access_modes": [
+        "public",
+        "licensed"
+      ],
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "published to npm as an experimental local scaffolder, not an AIKDNA-hosted application platform",
@@ -517,14 +558,19 @@
           "lifecycle": "Experimental",
           "release_status": "source-only",
           "dependency_policy": "current",
-          "known_limitations": ["official source reference application; not an npm publication"],
+          "known_limitations": [
+            "official source reference application; not an npm publication"
+          ],
           "recommended_entrypoint": "npm --prefix app ci && npm --prefix app run dev",
           "legacy_replacement": null
         }
       ],
       "lifecycle": "Experimental",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": ["public", "licensed"],
+      "supported_access_modes": [
+        "public",
+        "licensed"
+      ],
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "source-only official reference application; it is not an npm package or an AIKDNA-hosted service",
@@ -545,7 +591,10 @@
       "packages": [],
       "lifecycle": "Pre-release",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": ["public", "licensed"],
+      "supported_access_modes": [
+        "public",
+        "licensed"
+      ],
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "accepted main is recertified against exact public Core candidate commit 76bbc587ce05f7e575c2373832cc5c9eee9df98a; the 0.21.0 tag is the published incumbent"
@@ -565,7 +614,10 @@
       "packages": [],
       "lifecycle": "Pre-release",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": ["public", "licensed"],
+      "supported_access_modes": [
+        "public",
+        "licensed"
+      ],
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "Swift package source only; it is not an npm publication",
@@ -586,7 +638,10 @@
       "packages": [],
       "lifecycle": "Pre-release",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": ["public", "licensed"],
+      "supported_access_modes": [
+        "public",
+        "licensed"
+      ],
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "Swift package source only; it is not an npm publication",
@@ -639,7 +694,9 @@
       "packages": [],
       "lifecycle": "Removed",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": ["public"],
+      "supported_access_modes": [
+        "public"
+      ],
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "Repository deleted. No packaged public replacement is released yet. Future replacement must be a .kdna file with release card and checksum."
@@ -657,7 +714,9 @@
       "packages": [],
       "lifecycle": "Removed",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": ["public"],
+      "supported_access_modes": [
+        "public"
+      ],
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "Repository deleted. No packaged public replacement is released yet. Future replacement must be a .kdna file with release card and checksum."
@@ -675,7 +734,9 @@
       "packages": [],
       "lifecycle": "Removed",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": ["public"],
+      "supported_access_modes": [
+        "public"
+      ],
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "Repository deleted. No packaged public replacement is released yet. Future replacement must be a .kdna file with release card and checksum."
@@ -695,7 +756,9 @@
       "supported_kdna_version": null,
       "supported_access_modes": [],
       "supported_entitlement_profiles": [],
-      "known_limitations": ["not part of the current stable public runtime baseline"],
+      "known_limitations": [
+        "not part of the current stable public runtime baseline"
+      ],
       "recommended_entrypoint": "local public .kdna assets through Core/CLI",
       "legacy_replacement": "local public asset workflow"
     }

--- a/ecosystem-manifest.json
+++ b/ecosystem-manifest.json
@@ -121,11 +121,7 @@
       ],
       "lifecycle": "Pre-release",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": [
-        "public",
-        "licensed",
-        "remote"
-      ],
+      "supported_access_modes": ["public", "licensed", "remote"],
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "hosted remote loading and activation are self-hosted reference surfaces, not an AIKDNA-hosted service",
@@ -158,11 +154,7 @@
       ],
       "lifecycle": "Pre-release",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": [
-        "public",
-        "licensed",
-        "remote"
-      ],
+      "supported_access_modes": ["public", "licensed", "remote"],
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "hosted registry, marketplace, and commercial distribution are not part of the local CLI baseline",
@@ -210,9 +202,7 @@
       ],
       "lifecycle": "Experimental",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": [
-        "public"
-      ],
+      "supported_access_modes": ["public"],
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "reference assets demonstrate technical interoperability and do not establish content correctness, adoption, or outcome claims",
@@ -245,9 +235,7 @@
       ],
       "lifecycle": "Experimental",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": [
-        "public"
-      ],
+      "supported_access_modes": ["public"],
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "MCP is an experimental structured bridge; the loader Skill is Unassessed and neither discovery nor matching creates user authority"
@@ -281,10 +269,7 @@
       ],
       "lifecycle": "Pre-release",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": [
-        "public",
-        "licensed"
-      ],
+      "supported_access_modes": ["public", "licensed"],
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "Studio export is pre-release and treats review, Human Lock, signatures, and release evidence as optional provenance layers",
@@ -319,10 +304,7 @@
       ],
       "lifecycle": "Pre-release",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": [
-        "public",
-        "licensed"
-      ],
+      "supported_access_modes": ["public", "licensed"],
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "remote authoring delivery is outside the local Studio CLI baseline",
@@ -354,12 +336,8 @@
       ],
       "lifecycle": "Experimental",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": [
-        "licensed"
-      ],
-      "supported_entitlement_profiles": [
-        "license_key"
-      ],
+      "supported_access_modes": ["licensed"],
+      "supported_entitlement_profiles": ["license_key"],
       "known_limitations": [
         "self-hosted support surface only; not an AIKDNA-hosted activation service",
         "paid distribution and commercial delivery flows are not part of the public Core baseline",
@@ -391,9 +369,7 @@
       ],
       "lifecycle": "Experimental",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": [
-        "remote"
-      ],
+      "supported_access_modes": ["remote"],
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "self-hosted projection server only; there is no AIKDNA-hosted remote loading service",
@@ -426,9 +402,7 @@
       ],
       "lifecycle": "Experimental",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": [
-        "public"
-      ],
+      "supported_access_modes": ["public"],
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "published to npm as an experimental integration surface, not a stable hosted-platform claim",
@@ -461,9 +435,7 @@
       ],
       "lifecycle": "Experimental",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": [
-        "public"
-      ],
+      "supported_access_modes": ["public"],
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "published to npm as an experimental integration surface, not a stable browser runtime",
@@ -495,9 +467,7 @@
       ],
       "lifecycle": "Experimental",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": [
-        "public"
-      ],
+      "supported_access_modes": ["public"],
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "published to npm as an experimental integration surface, not a hosted-platform claim",
@@ -529,10 +499,7 @@
       ],
       "lifecycle": "Experimental",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": [
-        "public",
-        "licensed"
-      ],
+      "supported_access_modes": ["public", "licensed"],
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "published to npm as an experimental local scaffolder, not an AIKDNA-hosted application platform",
@@ -558,19 +525,14 @@
           "lifecycle": "Experimental",
           "release_status": "source-only",
           "dependency_policy": "current",
-          "known_limitations": [
-            "official source reference application; not an npm publication"
-          ],
+          "known_limitations": ["official source reference application; not an npm publication"],
           "recommended_entrypoint": "npm --prefix app ci && npm --prefix app run dev",
           "legacy_replacement": null
         }
       ],
       "lifecycle": "Experimental",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": [
-        "public",
-        "licensed"
-      ],
+      "supported_access_modes": ["public", "licensed"],
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "source-only official reference application; it is not an npm package or an AIKDNA-hosted service",
@@ -591,10 +553,7 @@
       "packages": [],
       "lifecycle": "Pre-release",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": [
-        "public",
-        "licensed"
-      ],
+      "supported_access_modes": ["public", "licensed"],
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "accepted main is recertified against exact public Core candidate commit 76bbc587ce05f7e575c2373832cc5c9eee9df98a; the 0.21.0 tag is the published incumbent"
@@ -614,10 +573,7 @@
       "packages": [],
       "lifecycle": "Pre-release",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": [
-        "public",
-        "licensed"
-      ],
+      "supported_access_modes": ["public", "licensed"],
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "Swift package source only; it is not an npm publication",
@@ -638,10 +594,7 @@
       "packages": [],
       "lifecycle": "Pre-release",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": [
-        "public",
-        "licensed"
-      ],
+      "supported_access_modes": ["public", "licensed"],
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "Swift package source only; it is not an npm publication",
@@ -694,9 +647,7 @@
       "packages": [],
       "lifecycle": "Removed",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": [
-        "public"
-      ],
+      "supported_access_modes": ["public"],
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "Repository deleted. No packaged public replacement is released yet. Future replacement must be a .kdna file with release card and checksum."
@@ -714,9 +665,7 @@
       "packages": [],
       "lifecycle": "Removed",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": [
-        "public"
-      ],
+      "supported_access_modes": ["public"],
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "Repository deleted. No packaged public replacement is released yet. Future replacement must be a .kdna file with release card and checksum."
@@ -734,9 +683,7 @@
       "packages": [],
       "lifecycle": "Removed",
       "supported_kdna_version": "1.0",
-      "supported_access_modes": [
-        "public"
-      ],
+      "supported_access_modes": ["public"],
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "Repository deleted. No packaged public replacement is released yet. Future replacement must be a .kdna file with release card and checksum."
@@ -756,9 +703,7 @@
       "supported_kdna_version": null,
       "supported_access_modes": [],
       "supported_entitlement_profiles": [],
-      "known_limitations": [
-        "not part of the current stable public runtime baseline"
-      ],
+      "known_limitations": ["not part of the current stable public runtime baseline"],
       "recommended_entrypoint": "local public .kdna assets through Core/CLI",
       "legacy_replacement": "local public asset workflow"
     }

--- a/packages/kdna/test/publish-hardening.test.js
+++ b/packages/kdna/test/publish-hardening.test.js
@@ -288,7 +288,7 @@ test('core smoke rehearses the release ecosystem with every immutable accepted c
   );
   for (const [repository, commit] of EXPECTED_COMPAT_CHECKOUTS) {
     const smokeCommit = repository === 'aikdna/kdna-core-swift'
-      ? '59a68b760c187d5f7c8909b085b2030d010075de'
+      ? '5a8e2bb5db92d8a9118e1668cf6f1414c4aed5c9'
       : commit;
     assert.match(
       workflow,

--- a/release-health-policy.json
+++ b/release-health-policy.json
@@ -77,12 +77,11 @@
       "repository": "aikdna/kdna",
       "package_json": "packages/kdna-conformance/package.json",
       "npm_package": "@aikdna/kdna-conformance",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "canonical_tag": {
         "type": "prefix",
         "value": "conformance/"
-      },
-      "candidate_version": "0.2.0"
+      }
     },
     {
       "label": "KDNA Web Client",
@@ -119,11 +118,10 @@
       "repository": "aikdna/kdna",
       "package_json": "packages/kdna-core/package.json",
       "npm_package": "@aikdna/kdna-core",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "canonical_tag": {
         "type": "natural"
-      },
-      "candidate_version": "0.22.0"
+      }
     },
     {
       "label": "KDNA Eval",

--- a/scripts/ecosystem-version-lock.js
+++ b/scripts/ecosystem-version-lock.js
@@ -322,6 +322,15 @@ const LAGGING_CONSUMERS = new Set([
   'create-kdna-web-app',
   'kdna-demo-web-viewer',
   'kdna-web-client',
+  // 0.22.0 wave recertification debt: these consumers re-bind to Core 0.22.0
+  // through the CLI 0.37.0 release chain. All are disclosed in the manifest
+  // and tracked in the execution control table.
+  'kdna-cli',
+  'kdna-activation-server',
+  'kdna-remote-server',
+  'kdna-studio-cli',
+  'kdna-studio-core',
+  'kdna-web-server',
 ]);
 // The monorepo compatibility package pins the released pairing
 // (packages/kdna); it is a publish snapshot, not a current consumer.

--- a/tests/container-cli/ecosystem-manifest-validation.test.js
+++ b/tests/container-cli/ecosystem-manifest-validation.test.js
@@ -277,7 +277,7 @@ test('ecosystem workflow checkouts stay pinned to accepted or explicitly scoped 
     (entry) => entry.local_path && entry.local_path !== '.' && entry.source_commit,
   );
   const candidateSmokePins = new Map([
-    ['core-smoke.yml:aikdna/kdna-core-swift', '59a68b760c187d5f7c8909b085b2030d010075de'],
+    ['core-smoke.yml:aikdna/kdna-core-swift', '5a8e2bb5db92d8a9118e1668cf6f1414c4aed5c9'],
   ]);
 
   for (const workflowName of ['core-smoke.yml', 'publish.yml']) {
@@ -340,7 +340,7 @@ test('candidate Core conformance anchor carries the declared candidate package v
   fs.writeFileSync(manifestPath, JSON.stringify(canonical));
   const result = runValidator(manifestPath);
   assert.equal(result.status, 1);
-  assert.match(result.stderr, /conformance_commit package version mismatch/u);
+  assert.match(result.stderr, /conformance_commit must equal release tag 0.22.0/u);
 });
 
 test('asset inventory is an exact two-way projection of index/current.json', (t) => {


### PR DESCRIPTION
## Summary
Core 0.22.0 + kdna-conformance 0.2.0 are published on npm (tags `0.22.0`, `conformance/0.2.0` at `a0edd85`; verified via `npm view`). Recertification per the 0.21.0 pattern:
- manifest: core + conformance packages to active with published_version = version; shared conformance anchor (kdna + kdna-assets + artifacts) binds the tag commit a0edd85.
- release-health policy: candidate_version fields dropped, versions 0.22.0/0.2.0.
- core-smoke Swift pin → kdna-core-swift#45 (5a8e2bb, recertified to a0edd85).
- Consumer re-bind chain (kdna-cli 0.37.0 onward, activation/remote/studio/web servers) declared as 0.22.0-wave recertification debt in the manifest known_limitations + the version-lock lagging list.

Verified locally: root npm test green, container-cli suites 196/196, manifest validator passed, version-lock --strict 34/34 exact, claims-lint passed, release-health 8/8.

Signed-off-by: aikdna <283974009+aikdna@users.noreply.github.com>