### PR TITLE
docs: align Node support narrative with the Active-LTS (22/24) policy

### DIFF
--- a/docs/15-minute-agent-guide.md
+++ b/docs/15-minute-agent-guide.md
@@ -7,7 +7,7 @@ Agent-installed Skill.
 
 ## Prerequisites
 
-- Node.js 18 or later
+- Node.js 22 or later
 - `npm install -g @aikdna/kdna-cli`
 - a `.kdna` file that the user selected for this task, session, app, or project
 

--- a/ecosystem-manifest.json
+++ b/ecosystem-manifest.json
@@ -471,7 +471,7 @@
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "published to npm as an experimental integration surface, not a hosted-platform claim",
-        "the verified boundary is Web Client 0.3.0, Web Server 0.3.1, Activation 0.2.1, React 18 or 19, and Node.js 20 or later"
+        "the verified boundary is Web Client 0.3.0, Web Server 0.3.1, Activation 0.2.1, React 18 or 19, and Node.js 22 or later"
       ],
       "recommended_entrypoint": "use endpoint-backed hooks/components",
       "legacy_replacement": null
@@ -503,7 +503,7 @@
       "supported_entitlement_profiles": [],
       "known_limitations": [
         "published to npm as an experimental local scaffolder, not an AIKDNA-hosted application platform",
-        "the verified boundary is Core 0.21.0, Web Server 0.3.1, Web Client 0.3.0, React 0.4.0, Node.js 20 or later, npm, pnpm 11.14.0, and Yarn 1.22.22",
+        "the verified boundary is Core 0.21.0, Web Server 0.3.1, Web Client 0.3.0, React 0.4.0, Node.js 22 or later, npm, pnpm 11.14.0, and Yarn 1.22.22",
         "generated templates cover local public and password-protected inspect/plan-load/load flows; remote-mode web forwarding is not wired"
       ],
       "recommended_entrypoint": "npx create-kdna-web-app@0.5.0 <app>",

--- a/packages/kdna/README.md
+++ b/packages/kdna/README.md
@@ -26,7 +26,7 @@ This package remains available so older installation instructions using
 `@aikdna/kdna` resolve to the current KDNA CLI.
 
 Version 0.14.0 is bound to `@aikdna/kdna-cli@0.36.1` and
-`@aikdna/kdna-core@0.22.0`, requires Node.js 20 or later, and installs one
+`@aikdna/kdna-core@0.22.0`, requires Node.js 22 or later, and installs one
 physical Core package. It is a migration bridge, not the recommended package
 for new applications.
 

--- a/packages/kdna/package.json
+++ b/packages/kdna/package.json
@@ -41,7 +41,7 @@
     "url": "https://github.com/aikdna/kdna/issues"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "dependencies": {
     "@aikdna/kdna-cli": "0.36.1",

--- a/packages/kdna/test/compat.test.js
+++ b/packages/kdna/test/compat.test.js
@@ -109,7 +109,7 @@ test('compatibility manifest pins one released toolchain without claiming the cu
     '@aikdna/kdna-cli': '0.36.1',
     '@aikdna/kdna-core': '0.22.0',
   });
-  assert.deepEqual(pkg.engines, { node: '>=20' });
+  assert.deepEqual(pkg.engines, { node: '>=22' });
   assert.deepEqual(pkg.bin, {
     'kdna-lint': 'bin/kdna-lint.js',
     'kdna-validate': 'bin/kdna-validate.js',


### PR DESCRIPTION
## Summary
Align the public Node support narrative with the Active-LTS (22/24) policy (Owner decision 2026-08-18): residual "Node.js 18/20 or later" / "Node.js 20.9 or newer" statements now state the Node 22 floor that matches `engines` and CI. Published 18/20-compatible releases are marked as the last of their line. Public-surface guards now assert README/engine consistency.

Signed-off-by: aikdna <283974009+aikdna@users.noreply.github.com>